### PR TITLE
Add TargetPeer parameter to NetFunctions

### DIFF
--- a/addons/Nebula/Core/NetFunction.cs
+++ b/addons/Nebula/Core/NetFunction.cs
@@ -4,6 +4,7 @@ using Godot;
 using Nebula.Serialization;
 using MethodBoundaryAspect.Fody.Attributes;
 using Nebula.Utility.Tools;
+using System.ComponentModel;
 
 namespace Nebula
 {
@@ -24,6 +25,13 @@ namespace Nebula
         // TODO: Ensure this is used in WorldRunner to correctly filter out invalid calls
         public NetworkSources Source { get; set; } = NetworkSources.All;
         public bool ExecuteOnCaller { get; set; } = true;
+
+        /// <summary>
+        /// Specify this NetFunction to be targetable and sent to a specific peer.  The first parameter must be a UUID that specifies which peer to target.
+        /// Using an empty UUID will allow for default server source behavior and send to all peers. Only useable when network source is server.
+        /// </summary>
+        public bool TargetPeer { get; set; } = false;
+        
         public override void OnEntry(MethodExecutionArgs args)
         {
             // Debugger.Instance.Log(Debugger.DebugLevel.VERBOSE, $"NetFunction: {args.Method.Name} called on {args.Instance.GetType().Name}");
@@ -47,6 +55,16 @@ namespace Nebula
                 if (NetRunner.Instance.IsClient && (Source & NetworkSources.Client) == 0)
                 {
                     return;
+                }
+
+                if (TargetPeer && Source == NetworkSources.Client)
+                {
+                    throw new Exception("NetFunction with TargetPeer=true is only supported for server sources");
+                }
+
+                if (TargetPeer && (args.Arguments.Length == 0 || args.Arguments[0] is not string))  //TODO: change to UUID when netfunction serialization updated
+                {
+                    throw new Exception("NetFunction with TargetPeer=true must have UUID as first parameter");
                 }
 
                 // Use cached NetSceneFilePath to avoid Godot StringName allocations

--- a/addons/Nebula/Core/WorldRunner.cs
+++ b/addons/Nebula/Core/WorldRunner.cs
@@ -2578,22 +2578,43 @@ namespace Nebula
             if (NetRunner.Instance.IsServer)
             {
                 var node = GetNodeFromNetId(netId);
-                // TODO: Apply interest layers for network function, like network property
-                foreach (var peer in node.InterestLayers.Keys)
+                var targetPeer = UUID.Empty;
+
+                if (functionInfo.TargetPeer)
+                    targetPeer = new UUID((string)args[0]); //TODO: change to UUID when netfunction serialization updated
+                    
+                //server send to all peers, not targetpeer function or targetpeer with empty uuid
+                if (!functionInfo.TargetPeer || (functionInfo.TargetPeer && targetPeer == UUID.Empty))
+                {
+                    // TODO: Apply interest layers for network function, like network property
+                    foreach (var peer in node.InterestLayers.Keys)
+                    {
+                        using var buffer = new NetBuffer();
+                        NetId.NetworkSerialize(this, NetRunner.Instance.Peers[peer], netId, buffer);
+                        NetWriter.WriteByte(buffer, functionInfo.Index);
+                        for (int i = 0; i < args.Length; i++)
+                        {
+                            // Use protocol metadata directly, no Variant conversion
+                            NetWriter.WriteByType(buffer, functionInfo.Arguments[i].VariantType, args[i]);
+                        }
+                        NetRunner.SendReliable(NetRunner.Instance.Peers[peer], (byte)NetRunner.ENetChannelId.Function, buffer);
+                    }
+                }
+                else //server send to target peer
                 {
                     using var buffer = new NetBuffer();
-                    NetId.NetworkSerialize(this, NetRunner.Instance.Peers[peer], netId, buffer);
+                    NetId.NetworkSerialize(this, NetRunner.Instance.Peers[targetPeer], netId, buffer);
                     NetWriter.WriteByte(buffer, functionInfo.Index);
                     for (int i = 0; i < args.Length; i++)
                     {
                         // Use protocol metadata directly, no Variant conversion
                         NetWriter.WriteByType(buffer, functionInfo.Arguments[i].VariantType, args[i]);
                     }
-                    NetRunner.SendReliable(NetRunner.Instance.Peers[peer], (byte)NetRunner.ENetChannelId.Function, buffer);
+                    NetRunner.SendReliable(NetRunner.Instance.Peers[targetPeer], (byte)NetRunner.ENetChannelId.Function, buffer);
                 }
             }
             else
-            {
+            {                
                 using var buffer = new NetBuffer();
                 NetId.NetworkSerialize(this, NetRunner.Instance.ServerPeer, netId, buffer);
                 NetWriter.WriteByte(buffer, functionInfo.Index);

--- a/addons/Nebula/Generator/ProtocolBuilder/CodeEmitter.cs
+++ b/addons/Nebula/Generator/ProtocolBuilder/CodeEmitter.cs
@@ -382,7 +382,8 @@ namespace Nebula.Generators
             sb.AppendLine($"{indent}    \"{Escape(func.Name)}\",");
             sb.AppendLine($"{indent}    {func.Index},");
             EmitArgumentsArray(sb, func.Arguments, indent + "    ");
-            sb.AppendLine($"{indent}    (NetworkSources){func.Sources}),");
+            sb.AppendLine($"{indent}    (NetworkSources){func.Sources},");
+            sb.AppendLine($"{indent}    {func.TargetPeer.ToString().ToLowerInvariant()}),");
         }
 
         private static void EmitFunctionWithIntKey(StringBuilder sb, int key, FunctionData func, string indent)
@@ -392,7 +393,8 @@ namespace Nebula.Generators
             sb.AppendLine($"{indent}    \"{Escape(func.Name)}\",");
             sb.AppendLine($"{indent}    {func.Index},");
             EmitArgumentsArray(sb, func.Arguments, indent + "    ");
-            sb.AppendLine($"{indent}    (NetworkSources){func.Sources}),");
+            sb.AppendLine($"{indent}    (NetworkSources){func.Sources},");
+            sb.AppendLine($"{indent}    {func.TargetPeer.ToString().ToLowerInvariant()}),");
         }
 
         private static void EmitArgumentsArray(StringBuilder sb, List<ArgumentData> args, string indent)

--- a/addons/Nebula/Generator/ProtocolBuilder/Models.cs
+++ b/addons/Nebula/Generator/ProtocolBuilder/Models.cs
@@ -70,6 +70,7 @@ namespace Nebula.Generators
         public byte Index { get; set; }
         public List<ArgumentData> Arguments { get; } = new();
         public int Sources { get; set; } = 3;
+        public bool TargetPeer { get; set; } = false;
     }
 
     internal sealed class ArgumentData

--- a/addons/Nebula/Generator/ProtocolBuilder/ProtocolGenerator.cs
+++ b/addons/Nebula/Generator/ProtocolBuilder/ProtocolGenerator.cs
@@ -332,7 +332,8 @@ namespace Nebula.Generators
                                 NodePath = $"{nodePath}/{func.Value.NodePath}",
                                 Name = func.Value.Name,
                                 Index = (byte)functionCount++,
-                                Sources = func.Value.Sources
+                                Sources = func.Value.Sources,
+                                TargetPeer = func.Value.TargetPeer
                             };
                             newFunc.Arguments.AddRange(func.Value.Arguments);
                             result.Functions[newNodePath][func.Key] = newFunc;
@@ -425,7 +426,8 @@ namespace Nebula.Generators
                             NodePath = nodePath,
                             Name = func.Name,
                             Index = (byte)functionCount++,
-                            Sources = func.Sources
+                            Sources = func.Sources,
+                            TargetPeer = func.TargetPeer
                         };
 
                         foreach (var param in func.Parameters)

--- a/addons/Nebula/Generator/ProtocolBuilder/TypeAnalyzer.cs
+++ b/addons/Nebula/Generator/ProtocolBuilder/TypeAnalyzer.cs
@@ -49,6 +49,7 @@ namespace Nebula.Generators
             public string Name { get; init; } = "";
             public List<ParameterInfo> Parameters { get; init; } = new();
             public int Sources { get; init; } = 3; // All by default
+            public bool TargetPeer { get; init; } = false;
         }
 
         public sealed class ParameterInfo
@@ -390,13 +391,14 @@ namespace Nebula.Generators
                     {
                         Name = method.Name,
                         Parameters = method.Parameters
-                            .Select(p => {
+                            .Select(p =>
+                            {
                                 var isEnum = p.Type.TypeKind == TypeKind.Enum;
                                 string? enumUnderlying = null;
                                 if (isEnum && p.Type is INamedTypeSymbol enumType)
                                     enumUnderlying = enumType.EnumUnderlyingType?.ToDisplayString();
-                                return new ParameterInfo 
-                                { 
+                                return new ParameterInfo
+                                {
                                     TypeFullName = GetFullTypeName(p.Type),
                                     IsEnum = isEnum,
                                     EnumUnderlyingTypeName = enumUnderlying
@@ -404,6 +406,7 @@ namespace Nebula.Generators
                             })
                             .ToList(),
                         Sources = GetNamedArgument(netFuncAttr, "Source", 3), // Default All = 3
+                        TargetPeer = GetNamedArgument(netFuncAttr, "TargetPeer", false)
                     };
                 }
 

--- a/addons/Nebula/Generator/Shared/ProtocolTypes.cs
+++ b/addons/Nebula/Generator/Shared/ProtocolTypes.cs
@@ -189,19 +189,22 @@ namespace Nebula.Serialization
         public readonly byte Index;
         public readonly NetFunctionArgument[] Arguments;
         public readonly NetworkSources Sources;
+        public readonly bool TargetPeer = false;
 
         public ProtocolNetFunction(
             string nodePath,
             string name,
             byte index,
             NetFunctionArgument[] arguments,
-            NetworkSources sources)
+            NetworkSources sources,
+            bool targetPeer)
         {
             NodePath = nodePath;
             Name = name;
             Index = index;
             Arguments = arguments;
             Sources = sources;
+            TargetPeer = targetPeer;
         }
     }
 


### PR DESCRIPTION
Added TargetPeer parameter to NetFunctions so can be marked for server sources to send to a specific peer instead of all interested peers.  Takes a UUID as first argument specifying peer or using an empty UUID defaults back to the normal all interested peer behavior.  Using string for now instead of UUID due to not serializing through NetFunctions.