### PR TITLE
v1.2.2: Add peer-scoped interest restriction and misc fixes

### DIFF
--- a/addons/Nebula/Core/NetworkController.cs
+++ b/addons/Nebula/Core/NetworkController.cs
@@ -293,6 +293,26 @@ namespace Nebula
 		/// If set to true, the node will be automatically despawned on the same tick the server identifies that there are no more peers interested in the node.
 		/// </summary>
 		public bool DespawnOnNoInterestPeers = false;
+
+		/// <summary>
+		/// Gates the <see cref="InterestPeers"/> pre-filter.
+		/// When false (default), <see cref="InterestPeers"/> is ignored entirely and the node is
+		/// visible to all peers (subject to the normal InterestLayers / [NetInterest] filter).
+		/// When true, ONLY peers contained in <see cref="InterestPeers"/> are eligible to see the
+		/// node; an empty set means the node is visible to nobody. Peers removed from the set while
+		/// this is true are hard-despawned on their client (and re-spawned cleanly if re-added).
+		/// Use this for peer-scoped nodes (item drops, personal quest items) without burning an
+		/// interest layer.
+		/// </summary>
+		public bool RestrictToInterestPeers = false;
+
+		/// <summary>
+		/// Server-side latch, set true the first time any peer passes <see cref="IsPeerInterested(UUID)"/>.
+		/// Used by <see cref="DespawnOnNoInterestPeers"/> to avoid despawning a freshly-spawned node
+		/// before the granting code has had a chance to add interested peers.
+		/// </summary>
+		internal bool HadInterestedPeer = false;
+
 		public NetworkController[] StaticNetworkChildren = [];
 
 		/// <summary>
@@ -409,10 +429,89 @@ namespace Nebula
 			SetPeerInterest(peerId, currentInterest & ~interestLayers, recurse);
 		}
 
+		/// <summary>
+		/// Adds a peer to the <see cref="InterestPeers"/> set. Only has an effect on visibility when
+		/// <see cref="RestrictToInterestPeers"/> is true. Recurses to nested children so a scene's
+		/// members match the parent, mirroring <see cref="SetPeerInterest"/>.
+		/// </summary>
+		public void AddInterestPeer(NetPeer peer, bool recurse = true)
+		{
+			AddInterestPeer(NetRunner.Instance.GetPeerId(peer), recurse);
+		}
+
+		public void AddInterestPeer(UUID peerId, bool recurse = true)
+		{
+			InterestPeers.Add(peerId);
+			if (recurse && IsNetScene())
+			{
+				foreach (var child in StaticNetworkChildren)
+					child?.AddInterestPeer(peerId, recurse);
+				foreach (var child in DynamicNetworkChildren)
+					child.AddInterestPeer(peerId, recurse);
+			}
+		}
+
+		/// <summary>
+		/// Removes a peer from the <see cref="InterestPeers"/> set. When
+		/// <see cref="RestrictToInterestPeers"/> is true this hard-despawns the node on that peer's client.
+		/// </summary>
+		public void RemoveInterestPeer(NetPeer peer, bool recurse = true)
+		{
+			RemoveInterestPeer(NetRunner.Instance.GetPeerId(peer), recurse);
+		}
+
+		public void RemoveInterestPeer(UUID peerId, bool recurse = true)
+		{
+			InterestPeers.Remove(peerId);
+			if (recurse && IsNetScene())
+			{
+				foreach (var child in StaticNetworkChildren)
+					child?.RemoveInterestPeer(peerId, recurse);
+				foreach (var child in DynamicNetworkChildren)
+					child.RemoveInterestPeer(peerId, recurse);
+			}
+		}
+
+		/// <summary>
+		/// Replaces the entire <see cref="InterestPeers"/> set with the given peers.
+		/// </summary>
+		public void SetInterestPeers(IEnumerable<UUID> peerIds, bool recurse = true)
+		{
+			InterestPeers.Clear();
+			foreach (var peerId in peerIds)
+				InterestPeers.Add(peerId);
+			if (recurse && IsNetScene())
+			{
+				foreach (var child in StaticNetworkChildren)
+					child?.SetInterestPeers(InterestPeers, recurse);
+				foreach (var child in DynamicNetworkChildren)
+					child.SetInterestPeers(InterestPeers, recurse);
+			}
+		}
+
+		/// <summary>
+		/// Clears the <see cref="InterestPeers"/> set. When <see cref="RestrictToInterestPeers"/> is
+		/// true this makes the node visible to nobody (all peers hard-despawn).
+		/// </summary>
+		public void ClearInterestPeers(bool recurse = true)
+		{
+			InterestPeers.Clear();
+			if (recurse && IsNetScene())
+			{
+				foreach (var child in StaticNetworkChildren)
+					child?.ClearInterestPeers(recurse);
+				foreach (var child in DynamicNetworkChildren)
+					child.ClearInterestPeers(recurse);
+			}
+		}
+
 		public bool IsPeerInterested(UUID peerId)
 		{
 			// Root scene is always visible
 			if (CurrentWorld.RootScene == this) return true;
+
+			// Peer-set pre-filter: when enabled, only members are eligible (empty set => nobody).
+			if (RestrictToInterestPeers && !InterestPeers.Contains(peerId)) return false;
 
 			var peerLayers = InterestLayers.GetValueOrDefault(peerId, 0);
 			if (peerLayers == 0) return false;
@@ -454,6 +553,7 @@ namespace Nebula
 			spawnReady.Remove(peerId);
 			preparingSpawn.Remove(peerId);
 			InterestLayers.Remove(peerId);
+			InterestPeers.Remove(peerId);
 
 			// Clear per-peer property data for this peer
 			if (PerPeerValues != null && _propIsPerPeer != null)

--- a/addons/Nebula/Core/Serialization/Serializers/SpawnSerializer.cs
+++ b/addons/Nebula/Core/Serialization/Serializers/SpawnSerializer.cs
@@ -75,9 +75,36 @@ namespace Nebula.Serialization.Serializers
                 return;
             }
 
+            // Per-peer HARD despawn: peer-filter enabled and this peer isn't a member.
+            // Unlike interest-layer loss (soft), removing a peer from a restricted InterestPeers
+            // set fully despawns the node on that client, while keeping it alive server-side.
+            bool inPeerSet = !netController.RestrictToInterestPeers
+                             || netController.InterestPeers.Contains(peerId);
+            if (!inPeerSet)
+            {
+                // Only despawn if the peer actually has (or is receiving) the node.
+                // NotSpawned/Despawned: nothing to do, leave state so a future re-add spawns cleanly.
+                if (spawnState is WorldRunner.ClientSpawnState.Spawning
+                    or WorldRunner.ClientSpawnState.Spawned
+                    or WorldRunner.ClientSpawnState.Despawning)
+                {
+                    ExportDespawn(currentWorld, peer, peerId, spawnState, buffer);
+                }
+                return;
+            }
+
+            // Soft path (unchanged): fails interest LAYERS / [NetInterest].
             if (!netController.IsPeerInterested(peer))
             {
                 return;
+            }
+
+            // Interested and in the peer set. If this peer was previously hard-despawned due to
+            // peer-set exclusion, reset so we send a fresh spawn (new local node id + full resync).
+            if (spawnState == WorldRunner.ClientSpawnState.Despawned)
+            {
+                currentWorld.SetClientSpawnState(netController.NetId, peer, WorldRunner.ClientSpawnState.NotSpawned);
+                spawnState = WorldRunner.ClientSpawnState.NotSpawned;
             }
 
             // Check if spawn data has already been sent (Spawning or Spawned state)
@@ -345,8 +372,11 @@ namespace Nebula.Serialization.Serializers
                     // Free the local NetId for this peer so it can be reused
                     currentWorld.DeregisterPeerNode(netController, peer);
 
-                    // Check if all peers have acknowledged despawn
-                    if (currentWorld.AreAllPeersDespawned(netController.NetId))
+                    // Check if all peers have acknowledged despawn.
+                    // Only delete the node globally for a genuine global despawn (IsQueuedForDespawn).
+                    // Interest-driven per-peer despawns must keep the node alive server-side so it
+                    // can re-spawn when the peer regains interest.
+                    if (netController.IsQueuedForDespawn && currentWorld.AreAllPeersDespawned(netController.NetId))
                     {
                         // All peers have despawned, add to pending deletion
                         currentWorld._pendingDeletion.Add(netController);

--- a/addons/Nebula/Core/WorldRunner.cs
+++ b/addons/Nebula/Core/WorldRunner.cs
@@ -1124,6 +1124,32 @@ namespace Nebula
                 {
                     continue;
                 }
+
+                // Auto-despawn nodes that no connected peer is interested in anymore.
+                // Guarded by HadInterestedPeer so a freshly-spawned node isn't despawned before
+                // the granting code (e.g. AddInterestPeer on zone-enter) has had a chance to run.
+                if (netController.DespawnOnNoInterestPeers && !netController.IsQueuedForDespawn)
+                {
+                    bool anyInterested = false;
+                    foreach (var peerState in PeerStates.Values)
+                    {
+                        if (peerState.Status == PeerSyncStatus.DISCONNECTED) continue;
+                        if (netController.IsPeerInterested(peerState.Peer))
+                        {
+                            anyInterested = true;
+                            break;
+                        }
+                    }
+                    if (anyInterested)
+                    {
+                        netController.HadInterestedPeer = true;
+                    }
+                    else if (netController.HadInterestedPeer)
+                    {
+                        QueueDespawn(netController);
+                    }
+                }
+
                 // Phase 1: Apply all buffered inputs (root first, then children — must match simulation order)
                 if (netController.HasInputSupport)
                 {

--- a/addons/Nebula/Generator/ProtocolBuilder/TscnParser.cs
+++ b/addons/Nebula/Generator/ProtocolBuilder/TscnParser.cs
@@ -51,7 +51,13 @@ namespace Nebula.Generators
         }
 
         private static readonly Regex ExtResourceRegex = new(@"ExtResource\(""([^""]+)""\)", RegexOptions.Compiled);
-        private static readonly Regex IdRegex = new(@"id=""?([^""\]]+)""?", RegexOptions.Compiled);
+        /// <summary>
+        /// Matches key="quoted value" or key=unquotedToken on a .tscn header line.
+        /// Quoted values may contain spaces (e.g. path="res://NPC/Big Fooder/X.cs").
+        /// </summary>
+        private static readonly Regex AttributeRegex = new(
+            @"(\w+)=(""[^""]*""|[^\s\]]+)",
+            RegexOptions.Compiled);
 
         public ParsedTscn Parse(string fileText)
         {
@@ -139,119 +145,87 @@ namespace Nebula.Generators
         private static GdScene ParseGdScene(string line)
         {
             var scene = new GdScene();
-            var parts = line.Split(' ');
-            
-            foreach (var part in parts)
+            foreach (var (key, value) in ExtractAttributes(line))
             {
-                if (part.StartsWith("load_steps="))
-                {
-                    if (int.TryParse(ExtractValue(part), out var steps))
-                        scene.LoadSteps = steps;
-                }
-                else if (part.StartsWith("format="))
-                {
-                    if (int.TryParse(ExtractValue(part), out var format))
-                        scene.Format = format;
-                }
-                else if (part.StartsWith("uid="))
-                {
-                    scene.Uid = ExtractValue(part);
-                }
+                if (key == "load_steps" && int.TryParse(value, out var steps))
+                    scene.LoadSteps = steps;
+                else if (key == "format" && int.TryParse(value, out var format))
+                    scene.Format = format;
+                else if (key == "uid")
+                    scene.Uid = value;
             }
-            
             return scene;
         }
 
         private static ExtResource ParseExtResource(string line)
         {
             var resource = new ExtResource();
-            var parts = line.Split(' ');
-            
-            foreach (var part in parts)
+            foreach (var (key, value) in ExtractAttributes(line))
             {
-                if (part.StartsWith("type="))
-                {
-                    resource.Type = ExtractValue(part);
-                }
-                else if (part.StartsWith("path="))
-                {
-                    resource.Path = ExtractValue(part);
-                }
-                else if (part.StartsWith("id="))
-                {
-                    var match = IdRegex.Match(part);
-                    if (match.Success)
-                    {
-                        resource.Id = match.Groups[1].Value;
-                    }
-                }
+                if (key == "type")
+                    resource.Type = value;
+                else if (key == "path")
+                    resource.Path = value;
+                else if (key == "id")
+                    resource.Id = value;
             }
-            
             return resource;
         }
 
         private static SubResource ParseSubResource(string line)
         {
             var resource = new SubResource();
-            var parts = line.Split(' ');
-            
-            foreach (var part in parts)
+            foreach (var (key, value) in ExtractAttributes(line))
             {
-                if (part.StartsWith("type="))
-                {
-                    resource.Type = ExtractValue(part);
-                }
-                else if (part.StartsWith("id="))
-                {
-                    resource.Id = ExtractValue(part);
-                }
+                if (key == "type")
+                    resource.Type = value;
+                else if (key == "id")
+                    resource.Id = value;
             }
-            
             return resource;
         }
 
         private TscnNode ParseNode(string line)
         {
             var node = new TscnNode();
-            var parts = line.Split(' ');
-            
-            foreach (var part in parts)
+            foreach (var (key, value) in ExtractAttributes(line))
             {
-                if (part.StartsWith("name="))
+                if (key == "name")
+                    node.Name = value;
+                else if (key == "type")
+                    node.Type = value;
+                else if (key == "parent")
+                    node.Parent = value;
+                else if (key == "instance")
                 {
-                    node.Name = ExtractValue(part);
-                }
-                else if (part.StartsWith("type="))
-                {
-                    node.Type = ExtractValue(part);
-                }
-                else if (part.StartsWith("parent="))
-                {
-                    node.Parent = ExtractValue(part);
-                }
-                else if (part.StartsWith("instance="))
-                {
-                    var instValue = part.Substring("instance=".Length).Trim('"', ']');
-                    var match = ExtResourceRegex.Match(instValue);
+                    var match = ExtResourceRegex.Match(value);
                     if (match.Success)
                     {
                         var resourceId = match.Groups[1].Value;
                         if (_resourceToPathMap.TryGetValue(resourceId, out var path) && path.EndsWith(".tscn"))
-                        {
                             node.Instance = path;
-                        }
                     }
                 }
             }
-            
             return node;
         }
 
-        private static string ExtractValue(string part)
+        /// <summary>
+        /// Yields (key, unquotedValue) pairs from a .tscn header line such as
+        /// [ext_resource type="Script" path="res://foo bar/x.cs" id="1_abc"].
+        /// Does not split inside double-quoted values, so paths with spaces parse correctly.
+        /// </summary>
+        private static IEnumerable<(string Key, string Value)> ExtractAttributes(string line)
         {
-            var eqIndex = part.IndexOf('=');
-            if (eqIndex < 0) return "";
-            return part.Substring(eqIndex + 1).Trim('"', ']', ' ');
+            foreach (Match match in AttributeRegex.Matches(line))
+            {
+                var key = match.Groups[1].Value;
+                var raw = match.Groups[2].Value;
+                var value = raw.Length >= 2 && raw[0] == '"' && raw[raw.Length - 1] == '"'
+                    ? raw.Substring(1, raw.Length - 2)
+                    : raw.TrimEnd(']');
+                yield return (key, value);
+            }
         }
     }
 }

--- a/addons/Nebula/Utils/Env/Env.cs
+++ b/addons/Nebula/Utils/Env/Env.cs
@@ -60,7 +60,23 @@ namespace Nebula.Utility.Tools
                 }
             }
 
-            InitialWorldScene = StartArgs.GetValueOrDefault("initialWorldScene", ProjectSettings.GetSetting(ProjectSettingKeys[ProjectSettingId.WORLD_DEFAULT_SCENE]).AsString());
+            // Priority: cmdline --initialWorldScene → .env INITIAL_WORLD_SCENE → project default.
+            if (StartArgs.TryGetValue("initialWorldScene", out var argScene) && !string.IsNullOrEmpty(argScene))
+            {
+                InitialWorldScene = argScene;
+            }
+            else
+            {
+                var fromEnv = GetValue("INITIAL_WORLD_SCENE");
+                if (!string.IsNullOrEmpty(fromEnv))
+                {
+                    InitialWorldScene = fromEnv;
+                }
+                else
+                {
+                    InitialWorldScene = ProjectSettings.GetSetting(ProjectSettingKeys[ProjectSettingId.WORLD_DEFAULT_SCENE]).AsString();
+                }
+            }
 
             // Check for worldId with case-insensitive key lookup
             var worldIdKey = StartArgs.Keys.FirstOrDefault(k => k.Equals("worldId", StringComparison.OrdinalIgnoreCase));

--- a/addons/Nebula/plugin.cfg
+++ b/addons/Nebula/plugin.cfg
@@ -3,5 +3,5 @@
 name="Nebula"
 description="Netcode Framework for Online Multiplayer Games"
 author="Heavenlode"
-version="1.2.1"
+version="1.2.2"
 script="Tools/Main.cs"


### PR DESCRIPTION
- Add RestrictToInterestPeers to gate node visibility to an explicit InterestPeers set, with hard despawn/respawn on peers leaving/rejoining
- Add DespawnOnNoInterestPeers auto-despawn loop in WorldRunner, guarded by HadInterestedPeer so freshly-spawned nodes survive the initial grant window
- Fix TscnParser attribute parsing to handle quoted values containing spaces (e.g. resource paths)
- Add INITIAL_WORLD_SCENE .env fallback between cmdline args and project default