### PR TITLE
Added WorldId to OnPlayerJoined and OnPlayerCleanup events

### DIFF
--- a/addons/Nebula/Core/NetworkController.cs
+++ b/addons/Nebula/Core/NetworkController.cs
@@ -1380,7 +1380,7 @@ namespace Nebula
 			return null;
 		}
 
-		public void _OnPeerConnected(UUID peerId)
+		public void _OnPeerConnected(UUID worldId, UUID peerId)
 		{
 			var peer = NetRunner.Instance.Peers[peerId];
 			SetPeerInterest(peerId, NetNode.InitializeInterest(peer), recurse: false);

--- a/addons/Nebula/Core/WorldRunner.cs
+++ b/addons/Nebula/Core/WorldRunner.cs
@@ -968,8 +968,8 @@ namespace Nebula
         /// <summary>
         /// Invoked when a player joins the world (sync status becomes IN_WORLD).
         /// </summary>
-        public event Action<UUID> OnPlayerJoined;
-        public event Action<UUID> OnPlayerCleanup;
+        public event Action<UUID, UUID> OnPlayerJoined;
+        public event Action<UUID, UUID> OnPlayerCleanup;
 
 
         /// <summary>
@@ -1062,7 +1062,7 @@ namespace Nebula
             NetRunner.Instance.WorldPeerMap.Remove(peerId);
             NetRunner.Instance.PeerWorldMap.Remove(peerId);
             NetRunner.Instance.PeerIds.Remove(peer.ID);
-            OnPlayerCleanup?.Invoke(peerId);
+            OnPlayerCleanup?.Invoke(WorldId, peerId);
         }
 
         private int _frameCounter = 0;
@@ -1757,7 +1757,7 @@ namespace Nebula
 
             foreach (var peerId in _pendingPlayerJoined)
             {
-                OnPlayerJoined?.Invoke(peerId);
+                OnPlayerJoined?.Invoke(WorldId, peerId);
             }
 
             _pendingPlayerJoined.Clear();

--- a/addons/Nebula/Core/WorldRunner.cs
+++ b/addons/Nebula/Core/WorldRunner.cs
@@ -968,8 +968,8 @@ namespace Nebula
         /// <summary>
         /// Invoked when a player joins the world (sync status becomes IN_WORLD).
         /// </summary>
-        public event Action<UUID> OnPlayerJoined;
-        public event Action<UUID> OnPlayerCleanup;
+        public event Action<UUID, UUID> OnPlayerJoined;
+        public event Action<UUID, UUID> OnPlayerCleanup;
 
 
         /// <summary>
@@ -1102,7 +1102,7 @@ namespace Nebula
                 NetRunner.Instance.Peers.Remove(peerId);
                 NetRunner.Instance.PeerIds.Remove(peer.ID);
             }
-            OnPlayerCleanup?.Invoke(peerId);
+            OnPlayerCleanup?.Invoke(WorldId, peerId);
         }
 
         private int _frameCounter = 0;
@@ -1883,7 +1883,7 @@ namespace Nebula
 
             foreach (var peerId in _pendingPlayerJoined)
             {
-                OnPlayerJoined?.Invoke(peerId);
+                OnPlayerJoined?.Invoke(WorldId, peerId);
             }
 
             _pendingPlayerJoined.Clear();


### PR DESCRIPTION
I've been using a WorldManager node that's not part of any world to keep track of players moving between worlds and other worldly things.  I found it useful to have these callbacks give the world Id and the player Id.