### PR TITLE
Fix peer delta state being wiped on every export

### DIFF
--- a/addons/Nebula/Core/Serialization/Serializers/InterestResyncSerializer.cs
+++ b/addons/Nebula/Core/Serialization/Serializers/InterestResyncSerializer.cs
@@ -11,9 +11,9 @@ namespace Nebula.Serialization.Serializers
     public partial class InterestResyncSerializer : RefCounted, IStateSerializer
     {
         private const int SYNC_INTERVAL = 3; // ~10hz at 30 TPS
-        
+
         private NetworkController network;
-        
+
         // Client-side: tracks current interest state
         private bool clientHasInterest = false;
 
@@ -34,14 +34,14 @@ namespace Nebula.Serialization.Serializers
             {
                 return;
             }
-            
+
             // Stagger by node ID so not all nodes sync on same tick
             int tickOffset = (int)(network.NetId.Value % SYNC_INTERVAL);
             if ((currentWorld.CurrentTick + tickOffset) % SYNC_INTERVAL != 0)
             {
                 return;
             }
-            
+
             bool isInterested = network.IsPeerInterested(peer);
             NetWriter.WriteByte(buffer, isInterested ? (byte)1 : (byte)0);
         }
@@ -50,10 +50,10 @@ namespace Nebula.Serialization.Serializers
         {
             nodeOut = network;
             if (network == null) return;
-            
+
             byte interestByte = NetReader.ReadByte(buffer);
             bool hasInterest = interestByte == 1;
-            
+
             // Only fire event if state actually changed
             if (hasInterest != clientHasInterest)
             {

--- a/addons/Nebula/Core/Serialization/Serializers/NetPropertiesSerializer.cs
+++ b/addons/Nebula/Core/Serialization/Serializers/NetPropertiesSerializer.cs
@@ -1394,8 +1394,15 @@ namespace Nebula.Serialization.Serializers
             }
 
             // Zero-alloc dictionary access via ref for delta state
-            ref var state = ref CollectionsMarshal.GetValueRefOrAddDefault(_peerStates, peerId, out bool isNew);
-            if (isNew || !state.IsInitialized)
+            // NOTE: GetValueRefOrAddDefault's out parameter is `exists` - true when the key was
+            // ALREADY in the dictionary - not `isNew`. Reading it the other way round meant this
+            // block recreated the peer's state on every export after the first, wiping AckedMask,
+            // PendingDirtyMask, SentHistory and LatestAckedTick every single tick. Consequences:
+            // delta encoding could never engage (no baseline ever survived to be used), acks could
+            // never commit (SentHistory was blank by the time the ack arrived), and every export
+            // allocated a fresh set of state arrays.
+            ref var state = ref CollectionsMarshal.GetValueRefOrAddDefault(_peerStates, peerId, out bool exists);
+            if (!exists || !state.IsInitialized)
             {
                 state = CreateOrGetPooledState();
             }


### PR DESCRIPTION
CollectionsMarshal.GetValueRefOrAddDefault's out parameter is `exists` - true when the key was already present - but it was being read as `isNew`. The condition was therefore inverted: every export after the first saw the existing peer state as brand new and replaced it.

That reset AckedMask, PendingDirtyMask, SentHistory and LatestAckedTick every tick, which quietly disabled the whole snapshot-delta path. No baseline ever survived long enough to be used, so every property went out absolute; and SentHistory was always blank by the time an ack arrived, so acks could never commit. It also allocated a fresh set of per-peer arrays on every single export.

Also strips trailing whitespace in InterestResyncSerializer.