### PR TITLE
Add NebulaPack tick payload compression

### DIFF
--- a/addons/Nebula/Core/NetNode3D.cs
+++ b/addons/Nebula/Core/NetNode3D.cs
@@ -52,7 +52,11 @@ namespace Nebula
             var spawnSerializer = new SpawnSerializer(Network);
             var propertySerializer = new NetPropertiesSerializer(Network);
             var interestResyncSerializer = new InterestResyncSerializer(Network);
-            Serializers = [spawnSerializer, propertySerializer, interestResyncSerializer];
+            Serializers = [
+                spawnSerializer,
+                propertySerializer,
+                interestResyncSerializer
+            ];
         }
 
         public virtual void _WorldReady() { }

--- a/addons/Nebula/Core/NetRunner.cs
+++ b/addons/Nebula/Core/NetRunner.cs
@@ -349,6 +349,28 @@ namespace Nebula
         public static bool LogTickPayloads =>
             _logTickPayloads ??= ProjectSettings.GetSetting("Nebula/config/log_tick_payloads", false).AsBool();
 
+        private static bool? _packEnabled;
+        /// <summary>
+        /// When enabled via <c>Nebula/config/pack_enabled</c>, the server delta-compresses tick
+        /// payloads against a baseline the peer has acknowledged (see NebulaPack).
+        ///
+        /// This is a server-side, per-packet decision — every packet says whether it is a delta or
+        /// raw — so clients decode both regardless of their own setting and no handshake is needed.
+        /// Cached on first read; toggling takes effect on the next run.
+        /// </summary>
+        public static bool PackEnabled =>
+            _packEnabled ??= ProjectSettings.GetSetting("Nebula/config/pack_enabled", false).AsBool();
+
+        private static bool? _packValidate;
+        /// <summary>
+        /// When enabled via <c>Nebula/config/pack_validate</c>, the server appends a checksum of the
+        /// raw payload and the client verifies it after decoding. Costs 2 bytes per packet and
+        /// catches any window divergence immediately instead of letting it corrupt state silently.
+        /// Recommended on in development.
+        /// </summary>
+        public static bool PackValidate =>
+            _packValidate ??= ProjectSettings.GetSetting("Nebula/config/pack_validate", false).AsBool();
+
         private void _debugService()
         {
             if (debugEnet == null) return;

--- a/addons/Nebula/Core/Serialization/NebulaPack.cs
+++ b/addons/Nebula/Core/Serialization/NebulaPack.cs
@@ -1,0 +1,579 @@
+using System;
+
+namespace Nebula.Serialization
+{
+    // ============================================================================================
+    //  NebulaPack — tick payload compression
+    // ============================================================================================
+    //
+    //  THE PROBLEM
+    //
+    //  Most of a tick's payload prefix is byte-for-byte identical to the previous one. Node
+    //  bitmasks, serializer masks, property masks and encoding-flag bytes almost never change. In a
+    //  real capture, 42 of 69 bytes were the same in every single packet.
+    //
+    //
+    //  THE IDEA
+    //
+    //  Don't send the payload. Send only the bytes that differ from a payload the client already
+    //  has, walking both byte-by-byte at the same position.
+    //
+    //      client already has:   A B C D E F G H
+    //      we want to send:      A B C X Y F G H
+    //
+    //      what we actually send:   skip 3, then 2 literal bytes (X Y), then skip 3
+    //
+    //  That is three small numbers and two bytes, instead of eight bytes. We call each
+    //  "skip N, then M literal bytes" pair a run, and a payload is just a list of runs.
+    //
+    //  This is NOT a general compressor. It only compares position 0 to position 0, 1 to 1, and so
+    //  on. That sounds too simple to work, but tick payloads are naturally aligned, and on real
+    //  data it beat deflate-with-a-shared-dictionary while being far cheaper and far less code.
+    //
+    //
+    //  WHICH PREVIOUS PAYLOAD?
+    //
+    //  We can only delta against a payload the client definitely has. The client acks every tick it
+    //  applies, so the server keeps the last few payloads it sent each peer and marks each one as
+    //  the ack for it arrives. Only a marked payload can be used.
+    //
+    //  Note this is per-tick, not "everything up to tick N". Acks travel over the same lossy channel
+    //  as the ticks, so an ack for tick 15 tells us nothing about whether tick 13 arrived. Assuming
+    //  it did would mean deltaing against bytes the client never received.
+    //
+    //  The packet says which one, as an age: "this is a delta against the payload from 2 ticks
+    //  ago". The client keeps the same last-few-payloads ring, so it looks up tick-minus-2 and
+    //  decodes against that.
+    //
+    //  The server tries every acknowledged payload in range and picks whichever produces the
+    //  smallest result. Usually that is the immediately previous tick, but not always: when a node
+    //  spawns or despawns the payload shifts and everything misaligns, and a payload from a few
+    //  ticks earlier can match far better. Trying them all is cheap because measuring is just the
+    //  same byte walk without writing anything.
+    //
+    //
+    //  WHAT IF A PACKET IS LOST?
+    //
+    //  Nothing breaks. A lost tick simply never gets acked, so it never becomes a baseline
+    //  candidate. Losing packets means the server has fewer baselines to choose from — never a
+    //  wrong one.
+    //
+    //  If the client somehow can't decode a packet, it refuses it: doesn't apply it, doesn't ack
+    //  it. That tick never becomes a baseline either, and once every acked payload has aged out of
+    //  range the server goes back to sending raw by itself. No renegotiation, no reset message.
+    //  It just heals.
+    //
+    //  Sending raw is always allowed and always safe. Every packet says which it is.
+    //
+    //
+    //  WIRE FORMAT
+    //
+    //      [flags: 1 byte]
+    //      [baselineAge: 1 byte]   only when the delta flag is set; always >= 1
+    //      [body]                  the runs, or the raw payload
+    //      [checksum: 2 bytes]     only when the checksum flag is set
+    //
+    //      flags bit 0 (0x01)  body is a delta
+    //      flags bit 1 (0x02)  a checksum follows the body
+    //
+    //  The body of a delta is:
+    //
+    //      [rawLen varint][skip varint][literalCount varint][literal bytes]  [skip][count][bytes] ...
+    //
+    //  rawLen comes first so the decoder knows how big the result is before writing anything, and
+    //  can reject a packet claiming more than fits.
+    //
+    //  The checksum is of the RAW payload, so it verifies that the client decoded to exactly what
+    //  the server started with. It catches the two windows disagreeing, which is the one failure
+    //  that would otherwise be silent.
+    //
+    //
+    //  WHERE THINGS LIVE
+    //
+    //      WritePacket   server side. Picks a baseline, writes the whole packet body.
+    //      ReadPacket    client side. Validates, decodes, checksums.
+    //      NebulaPackWindow   the ring of recent payloads, one per peer on the server,
+    //                         one on the client.
+    //
+    //  The server calls WritePacket, then records the payload it sent. The client calls ReadPacket,
+    //  and records the payload only if it applied AND acked it — so the client's ring is never
+    //  missing something the server thinks it has.
+    //
+    // ============================================================================================
+
+    /// <summary>Why <see cref="NebulaPack.ReadPacket"/> rejected a packet.</summary>
+    public enum PackResult
+    {
+        Ok,
+        /// <summary>Packet was empty or ended before the header was complete.</summary>
+        Truncated,
+        /// <summary>Flag bits set that this build doesn't understand.</summary>
+        UnknownFlags,
+        /// <summary>Delta named a baseline tick the client no longer has.</summary>
+        BaselineMissing,
+        /// <summary>The run list was malformed.</summary>
+        MalformedDelta,
+        /// <summary>Decoded payload wouldn't fit the destination buffer.</summary>
+        TooLarge,
+        /// <summary>Decoded cleanly but to different bytes than the server encoded.</summary>
+        ChecksumMismatch,
+    }
+
+    public static class NebulaPack
+    {
+        /// <summary>Body is a delta, not a raw payload.</summary>
+        public const byte FlagDelta = 0x01;
+
+        /// <summary>A 2-byte checksum of the raw payload follows the body.</summary>
+        public const byte FlagChecksum = 0x02;
+
+        /// <summary>Flags this build understands. Anything else is rejected.</summary>
+        public const byte FlagMask = FlagDelta | FlagChecksum;
+
+        // ---------------------------------------------------------------- server
+
+        /// <summary>
+        /// Writes a complete tick body into <paramref name="destination"/>: flags, then either a
+        /// delta or the raw payload, then an optional checksum.
+        ///
+        /// Falls back to raw when compression is off, when no acknowledged baseline is in range, or
+        /// when no baseline actually beats sending raw.
+        /// </summary>
+        /// <param name="window">The payloads previously sent to this peer.</param>
+        /// <param name="currentTick">The tick being sent.</param>
+        /// <returns>The baseline age used, or 0 if the payload was sent raw.</returns>
+        public static int WritePacket(
+            NetBuffer destination,
+            ReadOnlySpan<byte> payload,
+            NebulaPackWindow window,
+            Tick currentTick,
+            bool allowDelta,
+            bool addChecksum)
+        {
+            int age = allowDelta
+                ? PickBaseline(payload, window, currentTick, out int deltaSize)
+                : 0;
+
+            byte flags = 0;
+            if (age > 0) flags |= FlagDelta;
+            if (addChecksum) flags |= FlagChecksum;
+
+            int rewindTo = destination.WritePosition;
+            NetWriter.WriteByte(destination, flags);
+
+            bool wroteDelta = false;
+            if (age > 0 && window.TryGetAcked(currentTick - age, out var baseline))
+            {
+                NetWriter.WriteByte(destination, (byte)age);
+                int written = EncodeDelta(payload, baseline, destination.GetWriteSpan(payload.Length));
+                if (written > 0)
+                {
+                    destination.AdvanceWrite(written);
+                    wroteDelta = true;
+                }
+                else
+                {
+                    // Didn't fit after all. Start the body over as a raw payload.
+                    destination.WritePosition = rewindTo;
+                    NetWriter.WriteByte(destination, (byte)(flags & ~FlagDelta));
+                }
+            }
+
+            if (!wroteDelta)
+            {
+                age = 0;
+                NetWriter.WriteBytes(destination, payload);
+            }
+
+            if (addChecksum) NetWriter.WriteUInt16(destination, Checksum(payload));
+
+            return age;
+        }
+
+        /// <summary>
+        /// Finds the acknowledged baseline that compresses <paramref name="payload"/> smallest.
+        /// Returns its age in ticks, or 0 if none beats sending raw.
+        ///
+        /// Measuring doesn't write anything, so trying every candidate costs only a few byte
+        /// comparisons each.
+        /// </summary>
+        private static int PickBaseline(
+            ReadOnlySpan<byte> payload,
+            NebulaPackWindow window,
+            Tick currentTick,
+            out int bestSize)
+        {
+            bestSize = -1;
+            int bestAge = 0;
+            if (window == null) return 0;
+
+            for (int age = 1; age <= NebulaPackWindow.MaxPackAge; age++)
+            {
+                Tick candidate = currentTick - age;
+                if (candidate < 0) break;
+                // TryGetAcked, not TryGet: only a tick this peer specifically acknowledged.
+                if (!window.TryGetAcked(candidate, out var baseline)) continue;
+
+                int size = MeasureDelta(payload, baseline);
+                if (size < payload.Length && (bestSize < 0 || size < bestSize))
+                {
+                    bestSize = size;
+                    bestAge = age;
+                }
+            }
+
+            return bestAge;
+        }
+
+        // ---------------------------------------------------------------- client
+
+        /// <summary>
+        /// Reads a tick body written by <see cref="WritePacket"/> and leaves the raw payload in
+        /// <paramref name="destination"/>, ready to import.
+        ///
+        /// Everything here runs on untrusted bytes, so every length is checked before use and this
+        /// never throws. On any failure the caller must not apply or acknowledge the tick — that's
+        /// what makes the server fall back to raw on its own.
+        /// </summary>
+        /// <param name="window">Payloads this client has already applied and acked.</param>
+        /// <param name="tick">The tick this packet is for.</param>
+        public static PackResult ReadPacket(
+            ReadOnlySpan<byte> wire,
+            Tick tick,
+            NebulaPackWindow window,
+            NetBuffer destination)
+        {
+            if (wire.Length < 1) return PackResult.Truncated;
+
+            byte flags = wire[0];
+            if ((flags & ~FlagMask) != 0) return PackResult.UnknownFlags;
+
+            bool isDelta = (flags & FlagDelta) != 0;
+            bool hasChecksum = (flags & FlagChecksum) != 0;
+
+            int offset = 1;
+            int age = 0;
+            if (isDelta)
+            {
+                if (wire.Length < offset + 1) return PackResult.Truncated;
+                age = wire[offset++];
+                if (age < 1) return PackResult.MalformedDelta;    // 0 would mean "delta against myself"
+            }
+
+            int bodyEnd = wire.Length - (hasChecksum ? 2 : 0);
+            if (bodyEnd < offset) return PackResult.Truncated;
+            var body = wire.Slice(offset, bodyEnd - offset);
+
+            destination.Reset();
+            var output = destination.GetWriteSpan(destination.Capacity);
+
+            int produced;
+            if (isDelta)
+            {
+                if (window == null || !window.TryGet(tick - age, out var baseline))
+                    return PackResult.BaselineMissing;
+
+                produced = DecodeDelta(body, baseline, output);
+                if (produced < 0) return PackResult.MalformedDelta;
+            }
+            else
+            {
+                if (body.Length > output.Length) return PackResult.TooLarge;
+                body.CopyTo(output);
+                produced = body.Length;
+            }
+
+            if (hasChecksum)
+            {
+                ushort expected = (ushort)(wire[bodyEnd] | (wire[bodyEnd + 1] << 8));
+                if (expected != Checksum(output.Slice(0, produced)))
+                    return PackResult.ChecksumMismatch;
+            }
+
+            destination.AdvanceWrite(produced);
+            destination.ResetRead();
+            return PackResult.Ok;
+        }
+
+        // ---------------------------------------------------------------- codec
+
+        /// <summary>
+        /// How many bytes <see cref="EncodeDelta"/> would produce, without producing them.
+        /// </summary>
+        public static int MeasureDelta(ReadOnlySpan<byte> input, ReadOnlySpan<byte> window)
+            => Encode(input, window, default, measureOnly: true);
+
+        /// <summary>
+        /// Writes the run list. Returns bytes written, or -1 if <paramref name="output"/> is too
+        /// small. Note a delta can legitimately be larger than the input when nothing matches —
+        /// deciding whether it is worth sending is the caller's job.
+        /// </summary>
+        public static int EncodeDelta(ReadOnlySpan<byte> input, ReadOnlySpan<byte> window, Span<byte> output)
+            => Encode(input, window, output, measureOnly: false);
+
+        /// <summary>
+        /// Rebuilds the payload from a run list. Returns bytes written, or -1 if the input is
+        /// malformed in any way. Never throws, never reads or writes out of bounds.
+        /// </summary>
+        public static int DecodeDelta(ReadOnlySpan<byte> input, ReadOnlySpan<byte> window, Span<byte> output)
+        {
+            int readPos = 0;
+            if (!TryReadVarint(input, ref readPos, out uint rawLen)) return -1;
+            if (rawLen > (uint)output.Length) return -1;
+
+            int writePos = 0;
+            while (writePos < (int)rawLen)
+            {
+                if (!TryReadVarint(input, ref readPos, out uint skip)) return -1;
+                if (!TryReadVarint(input, ref readPos, out uint literals)) return -1;
+
+                // A run has to consume something, or a malformed packet would loop forever.
+                if (skip == 0 && literals == 0) return -1;
+
+                uint remaining = rawLen - (uint)writePos;
+
+                if (skip > 0)
+                {
+                    // Skipped bytes are copied from the same position in the baseline.
+                    if (skip > remaining) return -1;
+                    if ((uint)writePos + skip > (uint)window.Length) return -1;
+                    window.Slice(writePos, (int)skip).CopyTo(output.Slice(writePos, (int)skip));
+                    writePos += (int)skip;
+                    remaining -= skip;
+                }
+
+                if (literals > 0)
+                {
+                    if (literals > remaining) return -1;
+                    if ((uint)readPos + literals > (uint)input.Length) return -1;
+                    input.Slice(readPos, (int)literals).CopyTo(output.Slice(writePos, (int)literals));
+                    readPos += (int)literals;
+                    writePos += (int)literals;
+                }
+            }
+
+            return (int)rawLen;
+        }
+
+        /// <summary>FNV-1a 64 folded down to 16 bits.</summary>
+        public static ushort Checksum(ReadOnlySpan<byte> data)
+        {
+            ulong h = 1469598103934665603UL;   // FNV offset basis
+            for (int i = 0; i < data.Length; i++)
+            {
+                h ^= data[i];
+                h *= 1099511628211UL;          // FNV prime
+            }
+            h ^= h >> 32;
+            h ^= h >> 16;
+            return (ushort)h;
+        }
+
+        /// <summary>
+        /// The byte walk, shared by measuring and encoding so the two can never disagree.
+        ///
+        /// Each loop consumes at least one input byte: if the skip run is empty then the bytes
+        /// differ, which means the literal run that follows is not empty. So it always terminates.
+        /// </summary>
+        private static int Encode(ReadOnlySpan<byte> input, ReadOnlySpan<byte> window, Span<byte> output, bool measureOnly)
+        {
+            int inputLen = input.Length;
+            int windowLen = window.Length;
+
+            int size = VarintSize((uint)inputLen);
+            int pos = 0;
+            if (!measureOnly && !TryWriteVarint(output, ref pos, (uint)inputLen)) return -1;
+
+            int i = 0;
+            while (i < inputLen)
+            {
+                // How many bytes match the baseline from here? CommonPrefixLength is SIMD-accelerated.
+                int skipStart = i;
+                if (i < windowLen)
+                {
+                    int compareLen = Math.Min(inputLen - i, windowLen - i);
+                    i += input.Slice(i, compareLen).CommonPrefixLength(window.Slice(i, compareLen));
+                }
+                int skip = i - skipStart;
+
+                // How many differ before they line up again? Anything past the end of the baseline
+                // counts as differing, so a payload longer than its baseline needs no special case.
+                int literalStart = i;
+                while (i < inputLen && (i >= windowLen || input[i] != window[i])) i++;
+                int literals = i - literalStart;
+
+                size += VarintSize((uint)skip) + VarintSize((uint)literals) + literals;
+
+                if (!measureOnly)
+                {
+                    if (!TryWriteVarint(output, ref pos, (uint)skip)) return -1;
+                    if (!TryWriteVarint(output, ref pos, (uint)literals)) return -1;
+                    if (pos + literals > output.Length) return -1;
+                    input.Slice(literalStart, literals).CopyTo(output.Slice(pos, literals));
+                    pos += literals;
+                }
+            }
+
+            return measureOnly ? size : pos;
+        }
+
+        // ---------------------------------------------------------------- varints
+
+        private static int VarintSize(uint v)
+            => v < 0x80u ? 1 : v < 0x4000u ? 2 : v < 0x200000u ? 3 : v < 0x10000000u ? 4 : 5;
+
+        private static bool TryWriteVarint(Span<byte> dst, ref int pos, uint value)
+        {
+            while (true)
+            {
+                byte b = (byte)(value & 0x7F);
+                value >>= 7;
+                if (value != 0) b |= 0x80;
+                if ((uint)pos >= (uint)dst.Length) return false;
+                dst[pos++] = b;
+                if (value == 0) return true;
+            }
+        }
+
+        private static bool TryReadVarint(ReadOnlySpan<byte> src, ref int pos, out uint value)
+        {
+            value = 0;
+            int shift = 0;
+            // A uint32 varint is never more than 5 bytes; refusing longer keeps garbage bounded.
+            for (int k = 0; k < 5; k++)
+            {
+                if ((uint)pos >= (uint)src.Length) { value = 0; return false; }
+                byte b = src[pos++];
+                value |= (uint)(b & 0x7F) << shift;
+                if ((b & 0x80) == 0) return true;
+                shift += 7;
+            }
+            value = 0;
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// The last few tick payloads, kept so they can be used as delta baselines. The server keeps
+    /// one of these per peer (what it sent); the client keeps one (what it applied and acked).
+    ///
+    /// Slots are indexed by <c>tick % RingSize</c> and each remembers its own tick, so an old slot
+    /// that hasn't been overwritten yet is never mistaken for a current one.
+    /// </summary>
+    public sealed class NebulaPackWindow
+    {
+        /// <summary>How many payloads are kept. Must be larger than <see cref="MaxPackAge"/>.</summary>
+        public const int RingSize = 32;
+
+        /// <summary>
+        /// Oldest baseline that may be used, in ticks. Anything older may already have been
+        /// overwritten, which is why this has to stay below <see cref="RingSize"/>.
+        ///
+        /// This is what decides which players get compression at all. A baseline can only be used
+        /// once the peer has acked it, so the server is always at least one round trip behind — if
+        /// that round trip is longer than MaxPackAge ticks, nothing is ever in range and every
+        /// packet goes out raw.
+        ///
+        /// At 30 TPS a tick is ~33ms, so 30 covers about a second of round trip. Sized off real
+        /// latency rather than loopback: at MaxPackAge = 6 compression switched off entirely above
+        /// ~200ms ping, silently, which is an ordinary connection for a remote player.
+        ///
+        /// Cost is RingSize payloads per peer per side — roughly 3 KB each at current payload sizes.
+        /// </summary>
+        public const int MaxPackAge = 30;
+
+        static NebulaPackWindow()
+        {
+            if (MaxPackAge >= RingSize)
+            {
+                throw new InvalidOperationException(
+                    $"NebulaPackWindow.MaxPackAge ({MaxPackAge}) must be less than RingSize ({RingSize}), " +
+                    "otherwise a usable baseline can be overwritten before it is used.");
+            }
+        }
+
+        private readonly byte[][] _slots = new byte[RingSize][];
+        private readonly int[] _lengths = new int[RingSize];
+        private readonly Tick[] _ticks = new Tick[RingSize];
+        private readonly bool[] _acked = new bool[RingSize];
+
+        public NebulaPackWindow() => Reset();
+
+        /// <summary>
+        /// Stores a copy of the payload. It has to be a copy — the caller's buffer is pooled and
+        /// reused next tick.
+        /// </summary>
+        public void Record(Tick tick, ReadOnlySpan<byte> payload)
+        {
+            if (tick < 0) return;   // the client uses -1 while switching worlds
+
+            int idx = tick % RingSize;
+            var slot = _slots[idx];
+            if (slot == null || slot.Length < payload.Length)
+            {
+                _slots[idx] = slot = new byte[Math.Max(payload.Length, 128)];
+            }
+            payload.CopyTo(slot);
+            _lengths[idx] = payload.Length;
+            _ticks[idx] = tick;
+            _acked[idx] = false;
+        }
+
+        /// <summary>
+        /// Server side. Marks one specific tick as confirmed received by the peer.
+        ///
+        /// This has to be per-tick. "Everything up to tick N" would be wrong: the client acks each
+        /// tick it applies, and those acks travel over the same lossy channel as everything else, so
+        /// a newer ack arriving says nothing about whether older ticks got through. Deltaing against
+        /// a tick the client never received produces a packet it can only throw away.
+        /// </summary>
+        public void MarkAcked(Tick tick)
+        {
+            if (tick < 0) return;
+            int idx = tick % RingSize;
+            if (_ticks[idx] == tick) _acked[idx] = true;
+        }
+
+        /// <summary>
+        /// Server side. Like <see cref="TryGet"/>, but only returns payloads the peer has actually
+        /// acknowledged — the only ones that are legal to use as a delta baseline.
+        /// </summary>
+        public bool TryGetAcked(Tick tick, out ReadOnlySpan<byte> payload)
+        {
+            payload = default;
+            if (tick < 0) return false;
+            if (!_acked[tick % RingSize]) return false;
+            return TryGet(tick, out payload);
+        }
+
+        /// <summary>Gets the payload for a tick, if that exact tick still occupies its slot.</summary>
+        public bool TryGet(Tick tick, out ReadOnlySpan<byte> payload)
+        {
+            payload = default;
+            if (tick < 0) return false;
+
+            int idx = tick % RingSize;
+            if (_ticks[idx] != tick) return false;
+
+            var slot = _slots[idx];
+            if (slot == null) return false;
+
+            payload = slot.AsSpan(0, _lengths[idx]);
+            return true;
+        }
+
+        /// <summary>
+        /// Forgets everything. Required when a client switches worlds: node ids are per-world, so an
+        /// old payload would decode into completely the wrong nodes.
+        /// </summary>
+        public void Reset()
+        {
+            for (int i = 0; i < RingSize; i++)
+            {
+                _ticks[i] = -1;
+                _lengths[i] = 0;
+                _acked[i] = false;
+            }
+        }
+    }
+}

--- a/addons/Nebula/Core/Serialization/NebulaPack.cs.uid
+++ b/addons/Nebula/Core/Serialization/NebulaPack.cs.uid
@@ -1,0 +1,1 @@
+uid://0kpu0q2hmytj

--- a/addons/Nebula/Core/WorldRunner.cs
+++ b/addons/Nebula/Core/WorldRunner.cs
@@ -1135,6 +1135,8 @@ namespace Nebula
 
             PeerStates.Remove(peerId);
             _peerLastAckTick.Remove(peerId);
+            ResetPackState(peerId);
+            _peerPackWindows.Remove(peerId);
             _peerPendingAcks.Remove(peerId); // Fix #5: Clean up pending acks tracking
             _peerNetBufferPool.Remove(peerId); // Clean up pooled export buffer
             _peerListDirty = true; // Fix #1: Mark peer list as dirty
@@ -1356,16 +1358,29 @@ namespace Nebula
                             continue;
                         }
 
+                        var packPayload = peerStateBuffer.WrittenSpan;
+
                         using var buffer = new NetBuffer();
                         NetWriter.WriteInt32(buffer, CurrentTick);
-                        NetWriter.WriteBytes(buffer, peerStateBuffer.WrittenSpan);
-                        var size = buffer.Length;
-                        if (size > NetRunner.MTU)
+                        _peerPackWindows.TryGetValue(peerId, out var packWindow);
+                        NebulaPack.WritePacket(
+                            buffer, packPayload, packWindow, CurrentTick,
+                            NetRunner.PackEnabled, NetRunner.PackValidate);
+
+                        // Check the UNCOMPRESSED size against the MTU. Checking the compressed size
+                        // would let compression mask a genuinely oversized world, and the payload
+                        // still has to fit whenever no baseline is available.
+                        var rawSize = sizeof(int) + 1 + packPayload.Length;
+                        if (rawSize > NetRunner.MTU)
                         {
-                            Log(Debugger.DebugLevel.ERROR, $"[MTU EXCEEDED] Peer {peer.ID} tick {CurrentTick}: Data size {size} exceeds MTU {NetRunner.MTU} - PACKET MAY BE CORRUPTED!");
+                            Log(Debugger.DebugLevel.ERROR, $"[MTU EXCEEDED] Peer {peer.ID} tick {CurrentTick}: Uncompressed size {rawSize} exceeds MTU {NetRunner.MTU} (on wire {buffer.Length}) - PACKET MAY BE CORRUPTED!");
                         }
 
                         NetRunner.SendUnreliableSequenced(peer, (byte)NetRunner.ENetChannelId.Tick, buffer);
+
+                        // Remember what we sent; it becomes a delta baseline once this peer acks it.
+                        RecordPackPayload(peerId, peerStateBuffer.WrittenSpan);
+
                         if (DebugTcpListener != null && DebugTcpClients.Count > 0)
                         {
                             using var debugBuffer = new NetBuffer();
@@ -1790,6 +1805,11 @@ namespace Nebula
             CurrentTick = -1;
             _predictionInitialized = false;
             _clientPredictedTick = -1;
+
+            // Node ids are per-peer-per-world, so a payload captured in the old world would decode
+            // into entirely the wrong nodes. The destination world also restarts near tick 0, which
+            // would otherwise collide with retained ring slots.
+            _clientPackWindow.Reset();
             TimeSinceLastTick = 0f;
             _ownedEntities.Clear();
             _ownedEntitiesDirty = true;
@@ -1816,6 +1836,49 @@ namespace Nebula
         /// Tracks the last tick each peer acknowledged. Used for timeout detection.
         /// </summary>
         private Dictionary<UUID, Tick> _peerLastAckTick = new();
+
+        /// <summary>
+        /// NebulaPack, server side: the recent payloads sent to each peer. Each entry is marked
+        /// acked as that peer's ack for it arrives, and only marked entries may be used as a delta
+        /// baseline.
+        ///
+        /// Don't try to drive this off <see cref="_peerLastAckTick"/> above. That tracks only the
+        /// newest ack, which is fine for timeout detection but says nothing about whether any
+        /// particular older tick arrived.
+        /// </summary>
+        private Dictionary<UUID, NebulaPackWindow> _peerPackWindows = new();
+
+        /// <summary>
+        /// NebulaPack, client side: the payloads this client has applied and acked, which is exactly
+        /// the set the server is allowed to delta against.
+        /// </summary>
+        private readonly NebulaPackWindow _clientPackWindow = new();
+        private NetBuffer _clientPackBuffer;
+
+        /// <summary>
+        /// Remembers the payload just sent to a peer, so it can be used as a delta baseline once
+        /// that peer acknowledges the tick.
+        /// </summary>
+        private void RecordPackPayload(UUID peerId, ReadOnlySpan<byte> payload)
+        {
+            if (!_peerPackWindows.TryGetValue(peerId, out var window))
+            {
+                window = new NebulaPackWindow();
+                _peerPackWindows[peerId] = window;
+            }
+            window.Record(CurrentTick, payload);
+        }
+
+
+        /// <summary>
+        /// Drops NebulaPack state for a peer. Called on disconnect, and on world migration where
+        /// node ids are reassigned — a payload from the previous world would decode into the wrong
+        /// nodes entirely.
+        /// </summary>
+        private void ResetPackState(UUID peerId)
+        {
+            if (_peerPackWindows.TryGetValue(peerId, out var window)) window.Reset();
+        }
 
         /// <summary>
         /// Server-side: the last tick this peer acknowledged receiving, or -1 if none yet.
@@ -2484,6 +2547,11 @@ namespace Nebula
             // Update last ack tick for timeout tracking
             _peerLastAckTick[peerId] = tick;
 
+            // Mark this exact tick as received, so NebulaPack may use it as a delta baseline.
+            // Per-tick on purpose: acks are lossy too, so "everything below the newest ack" is not
+            // a safe assumption (see NebulaPackWindow.MarkAcked).
+            if (_peerPackWindows.TryGetValue(peerId, out var packWindow)) packWindow.MarkAcked(tick);
+
             var isFirstAck = peerState.Status == PeerSyncStatus.INITIAL;
             if (isFirstAck)
             {
@@ -2531,6 +2599,28 @@ namespace Nebula
             }
         }
 
+        /// <summary>
+        /// Client-side. Turns a received tick body back into the raw payload ImportState expects.
+        /// Returns false if the packet can't be trusted, in which case the caller must neither
+        /// apply nor acknowledge the tick — that is what makes the server fall back to raw.
+        /// </summary>
+        private bool TryUnpackTickPayload(Tick tick, byte[] wire, out NetBuffer payload)
+        {
+            _clientPackBuffer ??= new NetBuffer(NetRunner.MTU + 64, usePool: true);
+
+            var result = NebulaPack.ReadPacket(wire, tick, _clientPackWindow, _clientPackBuffer);
+            if (result != PackResult.Ok)
+            {
+                payload = null;
+                Log(Debugger.DebugLevel.ERROR, $"[Nebula][Pack] tick {tick} rejected: {result}");
+                return false;
+            }
+
+            payload = _clientPackBuffer;
+            return true;
+        }
+
+
         public void ClientProcessTick(int incomingTick, byte[] stateBytes)
         {
             // Skip old/duplicate ticks
@@ -2551,8 +2641,17 @@ namespace Nebula
             try
             {
                 // Log(Debugger.DebugLevel.VERBOSE, $"Importing state bytes of size {stateBytes.Length}");
-                using var stateBuffer = new NetBuffer(stateBytes);
-                importSucceeded = ImportState(stateBuffer);
+                if (TryUnpackTickPayload(incomingTick, stateBytes, out var stateBuffer))
+                {
+                    importSucceeded = ImportState(stateBuffer);
+
+                    // Only an applied-and-acked payload may serve as a future baseline, so this is
+                    // gated on exactly the same condition as the ack below.
+                    if (importSucceeded)
+                    {
+                        _clientPackWindow.Record(incomingTick, stateBuffer.WrittenSpan);
+                    }
+                }
             }
             catch (Exception ex)
             {

--- a/addons/Nebula/Testing/Unit/NebulaPackTests.cs
+++ b/addons/Nebula/Testing/Unit/NebulaPackTests.cs
@@ -1,0 +1,523 @@
+using System;
+using Nebula.Serialization;
+using Xunit;
+
+namespace Nebula.Testing.Unit;
+
+/// <summary>
+/// Round-trip, ratio and hardening tests for the NebulaPack lockstep byte-delta codec.
+///
+/// The codec is pure and stateless, so unlike the NetArray sync tests these need no peer state or
+/// tick plumbing - they drive the public statics directly. Two properties matter most and are
+/// asserted throughout:
+///   1. MeasureDelta must return exactly what EncodeDelta writes, because baseline selection picks
+///      the cheapest candidate using Measure and then encodes once. A mismatch would silently pick
+///      the wrong baseline or overflow the destination.
+///   2. DecodeDelta runs on untrusted bytes and must never throw for any input at all.
+/// </summary>
+[NebulaUnitTest]
+public class NebulaPackTests
+{
+    /// <summary>Encodes, decodes and asserts the result is byte-identical to the input.</summary>
+    private static int AssertRoundTrip(byte[] input, byte[] window)
+    {
+        int measured = NebulaPack.MeasureDelta(input, window);
+        Assert.True(measured > 0, "MeasureDelta must return a positive size");
+
+        var encoded = new byte[measured];
+        int written = NebulaPack.EncodeDelta(input, window, encoded);
+        Assert.Equal(measured, written);
+
+        var decoded = new byte[input.Length];
+        int produced = NebulaPack.DecodeDelta(encoded, window, decoded);
+        Assert.Equal(input.Length, produced);
+        Assert.Equal(input, decoded);
+
+        return measured;
+    }
+
+    // ---------------------------------------------------------------- round trips
+
+    [NebulaUnitTest]
+    public void RoundTrip_RandomPairs()
+    {
+        var rng = new Random(20260726);
+        for (int trial = 0; trial < 2000; trial++)
+        {
+            int inLen = rng.Next(0, 200);
+            int winLen = rng.Next(0, 200);
+            var input = new byte[inLen];
+            var window = new byte[winLen];
+            rng.NextBytes(input);
+            rng.NextBytes(window);
+
+            // Make them share structure some of the time, so both the "mostly matching" and
+            // "mostly differing" paths get exercised.
+            if (trial % 2 == 0)
+            {
+                int shared = Math.Min(inLen, winLen);
+                for (int i = 0; i < shared; i++)
+                {
+                    if (rng.Next(4) != 0) input[i] = window[i];
+                }
+            }
+
+            AssertRoundTrip(input, window);
+        }
+    }
+
+    [NebulaUnitTest]
+    public void RoundTrip_EmptyInput()
+    {
+        AssertRoundTrip(Array.Empty<byte>(), new byte[] { 1, 2, 3 });
+    }
+
+    [NebulaUnitTest]
+    public void RoundTrip_EmptyWindow()
+    {
+        AssertRoundTrip(new byte[] { 1, 2, 3, 4 }, Array.Empty<byte>());
+    }
+
+    [NebulaUnitTest]
+    public void RoundTrip_BothEmpty()
+    {
+        AssertRoundTrip(Array.Empty<byte>(), Array.Empty<byte>());
+    }
+
+    [NebulaUnitTest]
+    public void RoundTrip_SingleByte()
+    {
+        AssertRoundTrip(new byte[] { 0x42 }, new byte[] { 0x42 });
+        AssertRoundTrip(new byte[] { 0x42 }, new byte[] { 0x43 });
+        AssertRoundTrip(new byte[] { 0x42 }, Array.Empty<byte>());
+    }
+
+    [NebulaUnitTest]
+    public void RoundTrip_IdenticalToWindow_CostsAlmostNothing()
+    {
+        var payload = new byte[69];
+        new Random(1).NextBytes(payload);
+
+        int size = AssertRoundTrip(payload, (byte[])payload.Clone());
+
+        // rawLen varint + a single (skip=69, diff=0) run.
+        Assert.True(size <= 5, $"identical payload should encode to a few bytes, got {size}");
+    }
+
+    [NebulaUnitTest]
+    public void RoundTrip_NothingInCommon()
+    {
+        var input = new byte[100];
+        var window = new byte[100];
+        for (int i = 0; i < 100; i++) { input[i] = 0xFF; window[i] = 0x00; }
+
+        int size = AssertRoundTrip(input, window);
+
+        // No match anywhere, so the delta cannot beat raw - the caller is expected to notice this
+        // via MeasureDelta and send the payload raw instead.
+        Assert.True(size > input.Length, "an incompressible delta should measure larger than raw");
+    }
+
+    [NebulaUnitTest]
+    public void RoundTrip_EndsOnSkipRun()
+    {
+        // Differs only at the very front, so the encoding ends with a long trailing skip.
+        var window = new byte[80];
+        new Random(2).NextBytes(window);
+        var input = (byte[])window.Clone();
+        input[0] ^= 0xFF;
+
+        int size = AssertRoundTrip(input, window);
+        Assert.True(size < 12, $"single leading change should stay tiny, got {size}");
+    }
+
+    [NebulaUnitTest]
+    public void RoundTrip_InputLongerAndShorterThanWindow()
+    {
+        var window = new byte[50];
+        new Random(3).NextBytes(window);
+
+        var longer = new byte[80];
+        window.CopyTo(longer, 0);
+        for (int i = 50; i < 80; i++) longer[i] = 0xAB;
+        AssertRoundTrip(longer, window);
+
+        var shorter = new byte[20];
+        Array.Copy(window, shorter, 20);
+        AssertRoundTrip(shorter, window);
+    }
+
+    [NebulaUnitTest]
+    public void RoundTrip_MtuSized()
+    {
+        var window = new byte[1400];
+        new Random(4).NextBytes(window);
+        var input = (byte[])window.Clone();
+        for (int i = 0; i < 1400; i += 97) input[i] ^= 0x5A;
+
+        AssertRoundTrip(input, window);
+    }
+
+    // ---------------------------------------------------------------- ratio
+
+    [NebulaUnitTest]
+    public void Ratio_MatchesRealPayloadShape()
+    {
+        // Mirrors the structure decoded from a real capture: a long constant prefix (framing,
+        // masks, flag bytes), then two Vector3s whose low mantissa bytes churn in a 3-vary/1-same
+        // pattern, then a constant tail.
+        var window = new byte[69];
+        new Random(5).NextBytes(window);
+        var input = (byte[])window.Clone();
+        foreach (int start in new[] { 42, 46, 50, 55, 59, 63 })
+        {
+            for (int k = 0; k < 3; k++) input[start + k] ^= 0x37;
+        }
+
+        int size = AssertRoundTrip(input, window);
+        Assert.True(size < 40, $"expected well under half of 69 bytes, got {size}");
+    }
+
+    // ---------------------------------------------------------------- encode limits
+
+    [NebulaUnitTest]
+    public void Encode_ReturnsMinusOneWhenDestinationTooSmall()
+    {
+        var input = new byte[64];
+        new Random(6).NextBytes(input);
+        var window = new byte[64];
+
+        int needed = NebulaPack.MeasureDelta(input, window);
+        Assert.True(needed > 1);
+
+        Assert.Equal(-1, NebulaPack.EncodeDelta(input, window, new byte[needed - 1]));
+        Assert.Equal(-1, NebulaPack.EncodeDelta(input, window, Array.Empty<byte>()));
+        Assert.Equal(needed, NebulaPack.EncodeDelta(input, window, new byte[needed]));
+    }
+
+    // ---------------------------------------------------------------- hardening
+
+    [NebulaUnitTest]
+    public void Decode_RejectsEmptyAndTruncatedBodies()
+    {
+        var window = new byte[40];
+        var input = new byte[40];
+        new Random(7).NextBytes(input);
+
+        var encoded = new byte[NebulaPack.MeasureDelta(input, window)];
+        NebulaPack.EncodeDelta(input, window, encoded);
+
+        Assert.Equal(-1, NebulaPack.DecodeDelta(Array.Empty<byte>(), window, new byte[64]));
+
+        for (int cut = 1; cut < encoded.Length; cut++)
+        {
+            var truncated = encoded.AsSpan(0, cut).ToArray();
+            Assert.Equal(-1, NebulaPack.DecodeDelta(truncated, window, new byte[64]));
+        }
+    }
+
+    [NebulaUnitTest]
+    public void Decode_RejectsRawLenLargerThanOutput()
+    {
+        var window = new byte[100];
+        var input = new byte[100];
+        new Random(8).NextBytes(input);
+
+        var encoded = new byte[NebulaPack.MeasureDelta(input, window)];
+        NebulaPack.EncodeDelta(input, window, encoded);
+
+        Assert.Equal(-1, NebulaPack.DecodeDelta(encoded, window, new byte[99]));
+        Assert.Equal(100, NebulaPack.DecodeDelta(encoded, window, new byte[100]));
+    }
+
+    [NebulaUnitTest]
+    public void Decode_RejectsSkipRunLongerThanWindow()
+    {
+        // rawLen = 10, then a single (skip = 10, diff = 0) run, but the window holds only 4 bytes.
+        var body = new byte[] { 10, 10, 0 };
+        Assert.Equal(-1, NebulaPack.DecodeDelta(body, new byte[4], new byte[10]));
+        // Same body against a large enough window is fine.
+        Assert.Equal(10, NebulaPack.DecodeDelta(body, new byte[10], new byte[10]));
+    }
+
+    [NebulaUnitTest]
+    public void Decode_RejectsNonProgressingRun()
+    {
+        // rawLen = 5 then (skip = 0, diff = 0) would spin forever if it were not rejected.
+        var body = new byte[] { 5, 0, 0 };
+        Assert.Equal(-1, NebulaPack.DecodeDelta(body, new byte[16], new byte[16]));
+    }
+
+    [NebulaUnitTest]
+    public void Decode_RejectsOverlongVarint()
+    {
+        // Six continuation bytes - a uint32 varint is never more than five.
+        var body = new byte[] { 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x01 };
+        Assert.Equal(-1, NebulaPack.DecodeDelta(body, new byte[16], new byte[16]));
+    }
+
+    [NebulaUnitTest]
+    public void Decode_NeverThrowsOnArbitraryGarbage()
+    {
+        var rng = new Random(9);
+        var window = new byte[64];
+        rng.NextBytes(window);
+
+        for (int trial = 0; trial < 5000; trial++)
+        {
+            var garbage = new byte[rng.Next(0, 40)];
+            rng.NextBytes(garbage);
+            var output = new byte[rng.Next(0, 128)];
+
+            int result = NebulaPack.DecodeDelta(garbage, window, output);
+
+            // Either a clean rejection, or a self-consistent decode of a byte string that happened
+            // to be well-formed. Never an exception, never a length outside the destination.
+            Assert.True(result == -1 || (result >= 0 && result <= output.Length));
+        }
+    }
+
+    // ---------------------------------------------------------------- window ring
+
+    [NebulaUnitTest]
+    public void Window_RecordsAndRetrievesByTick()
+    {
+        var win = new NebulaPackWindow();
+        var payload = new byte[] { 1, 2, 3, 4, 5 };
+
+        win.Record(5, payload);
+
+        Assert.True(win.TryGet(5, out var got));
+        Assert.Equal(payload, got.ToArray());
+        Assert.False(win.TryGet(6, out _));
+    }
+
+    [NebulaUnitTest]
+    public void Window_CopiesRatherThanAliasing()
+    {
+        var win = new NebulaPackWindow();
+        var payload = new byte[] { 1, 2, 3 };
+        win.Record(1, payload);
+
+        // The caller's buffer is pooled and reused next tick; the ring must not observe that.
+        payload[0] = 0xFF;
+
+        Assert.True(win.TryGet(1, out var got));
+        Assert.Equal(new byte[] { 1, 2, 3 }, got.ToArray());
+    }
+
+    [NebulaUnitTest]
+    public void Window_StaleSlotIsNotMistakenForLive()
+    {
+        var win = new NebulaPackWindow();
+        win.Record(3, new byte[] { 9, 9 });
+
+        // Wraps onto the same slot, which must invalidate the old tick rather than return its bytes.
+        win.Record(3 + NebulaPackWindow.RingSize, new byte[] { 7 });
+
+        Assert.False(win.TryGet(3, out _));
+        Assert.True(win.TryGet(3 + NebulaPackWindow.RingSize, out var got));
+        Assert.Equal(new byte[] { 7 }, got.ToArray());
+    }
+
+    [NebulaUnitTest]
+    public void Window_IgnoresNegativeTicks()
+    {
+        // The client sets CurrentTick to -1 on world reset; tick % RingSize would index negatively.
+        var win = new NebulaPackWindow();
+        win.Record(-1, new byte[] { 1, 2 });
+        Assert.False(win.TryGet(-1, out _));
+    }
+
+    [NebulaUnitTest]
+    public void Window_ResetClearsEverything()
+    {
+        var win = new NebulaPackWindow();
+        for (int t = 0; t < NebulaPackWindow.RingSize; t++) win.Record(t, new byte[] { (byte)t });
+
+        win.Reset();
+
+        for (int t = 0; t < NebulaPackWindow.RingSize; t++) Assert.False(win.TryGet(t, out _));
+    }
+
+    [NebulaUnitTest]
+    public void Window_MaxPackAgeFitsInRing()
+    {
+        // The invariant the whole scheme rests on: any baseline the sender may name must still be
+        // resolvable, i.e. not yet overwritten.
+        Assert.True(NebulaPackWindow.MaxPackAge < NebulaPackWindow.RingSize);
+    }
+
+    // ---------------------------------------------------------------- protocol under loss
+
+    /// <summary>
+    /// Simulates the real server/client loop - ack-gated baseline selection, best-of-N, a lossy
+    /// tick channel and a lossy ack channel - and asserts the client always reconstructs exactly
+    /// what the server intended, or refuses the packet outright. Never silent corruption.
+    ///
+    /// This is the claim the whole design rests on: because the server only ever names a baseline
+    /// the peer has acknowledged, dropped and delayed packets can shrink the compression ratio but
+    /// can never desync the window.
+    /// </summary>
+    [NebulaUnitTest]
+    public void Protocol_SurvivesPacketAndAckLoss()
+    {
+        var rng = new Random(11);
+        var serverWindow = new NebulaPackWindow();
+        var clientWindow = new NebulaPackWindow();
+
+        var inFlightAcks = new System.Collections.Generic.List<(Tick tick, int deliverAt)>();
+
+        var payload = new byte[91];
+        rng.NextBytes(payload);
+
+        int applied = 0, rawSent = 0, deltaSent = 0;
+
+        for (Tick tick = 0; tick < 400; tick++)
+        {
+            // The world evolves a little each tick, like a moving entity.
+            for (int k = 0; k < 6; k++) payload[40 + k] = (byte)rng.Next(256);
+
+            // ---- server: pick the cheapest acked baseline in range, exactly as WorldRunner does
+            int bestAge = -1, bestSize = -1;
+            for (int age = 1; age <= NebulaPackWindow.MaxPackAge; age++)
+            {
+                Tick candidate = tick - age;
+                if (candidate < 0) break;
+                // Per-tick, not "<= newest ack": acks are lossy, so a newer ack proves nothing
+                // about an older tick. Getting this wrong means deltaing against bytes the client
+                // never received, which is precisely what this test exists to catch.
+                if (!serverWindow.TryGetAcked(candidate, out var baseline)) continue;
+
+                int size = NebulaPack.MeasureDelta(payload, baseline);
+                if (size < payload.Length && (bestSize < 0 || size < bestSize))
+                {
+                    bestSize = size;
+                    bestAge = age;
+                }
+            }
+
+            byte[] body;
+            if (bestAge > 0)
+            {
+                serverWindow.TryGetAcked(tick - bestAge, out var baseline);
+                body = new byte[bestSize];
+                Assert.Equal(bestSize, NebulaPack.EncodeDelta(payload, baseline, body));
+                deltaSent++;
+            }
+            else
+            {
+                body = (byte[])payload.Clone();
+                rawSent++;
+            }
+
+            var sentPayload = (byte[])payload.Clone();
+            serverWindow.Record(tick, sentPayload);
+
+            // ---- lossy tick channel
+            bool tickDelivered = rng.Next(100) >= 15;
+
+            if (tickDelivered)
+            {
+                byte[] reconstructed;
+                if (bestAge > 0)
+                {
+                    // The server named an acked baseline, so the client must be able to resolve it.
+                    Assert.True(clientWindow.TryGet(tick - bestAge, out var baseline),
+                        $"tick {tick}: client is missing baseline {tick - bestAge} the server named as acked");
+
+                    reconstructed = new byte[sentPayload.Length];
+                    int produced = NebulaPack.DecodeDelta(body, baseline, reconstructed);
+                    Assert.Equal(sentPayload.Length, produced);
+                }
+                else
+                {
+                    reconstructed = body;
+                }
+
+                Assert.Equal(sentPayload, reconstructed);
+                Assert.Equal(NebulaPack.Checksum(sentPayload), NebulaPack.Checksum(reconstructed));
+
+                clientWindow.Record(tick, reconstructed);
+                applied++;
+
+                // Ack travels back over its own lossy path with variable delay.
+                if (rng.Next(100) >= 10)
+                {
+                    inFlightAcks.Add((tick, (int)tick + rng.Next(1, 3)));
+                }
+            }
+
+            // ---- ack delivery: marks that ONE tick, exactly as PeerAcknowledge does
+            for (int i = inFlightAcks.Count - 1; i >= 0; i--)
+            {
+                if (inFlightAcks[i].deliverAt <= tick)
+                {
+                    serverWindow.MarkAcked(inFlightAcks[i].tick);
+                    inFlightAcks.RemoveAt(i);
+                }
+            }
+        }
+
+        Assert.True(applied > 250, $"expected most ticks to be applied, got {applied}");
+        Assert.True(deltaSent > 200, $"expected compression to engage on most ticks, got {deltaSent} (raw {rawSent})");
+    }
+
+    /// <summary>
+    /// When the client stops acking, every candidate baseline ages out of range and the server has
+    /// no choice but raw. This is the self-healing path that recovers from a decode failure without
+    /// any explicit renegotiation.
+    /// </summary>
+    [NebulaUnitTest]
+    public void Protocol_BaselineAgesOutWhenAcksStop()
+    {
+        var window = new NebulaPackWindow();
+        var payload = new byte[64];
+        new Random(12).NextBytes(payload);
+
+        const Tick lastAcked = 10;
+        for (Tick t = 0; t <= lastAcked; t++) window.Record(t, payload);
+
+        // One tick past the last ack a baseline is still available...
+        Assert.True(HasCandidate(window, lastAcked + 1, lastAcked));
+        // ...but once the gap exceeds MaxPackAge nothing is nameable any more.
+        Assert.False(HasCandidate(window, lastAcked + NebulaPackWindow.MaxPackAge + 1, lastAcked));
+
+        static bool HasCandidate(NebulaPackWindow window, Tick now, Tick acked)
+        {
+            for (int age = 1; age <= NebulaPackWindow.MaxPackAge; age++)
+            {
+                Tick candidate = now - age;
+                if (candidate < 0) break;
+                if (candidate > acked) continue;
+                if (window.TryGet(candidate, out _)) return true;
+            }
+            return false;
+        }
+    }
+
+    [NebulaUnitTest]
+    public void Window_RoundTripsThroughCodecAtMaxAge()
+    {
+        var win = new NebulaPackWindow();
+        var rng = new Random(10);
+
+        var baseline = new byte[69];
+        rng.NextBytes(baseline);
+        const Tick baseTick = 100;
+        win.Record(baseTick, baseline);
+
+        var current = (byte[])baseline.Clone();
+        current[10] ^= 0xFF;
+
+        Tick nowTick = baseTick + NebulaPackWindow.MaxPackAge;
+        Assert.True(win.TryGet(nowTick - NebulaPackWindow.MaxPackAge, out var resolved));
+
+        var encoded = new byte[NebulaPack.MeasureDelta(current, resolved)];
+        Assert.Equal(encoded.Length, NebulaPack.EncodeDelta(current, resolved, encoded));
+
+        var decoded = new byte[current.Length];
+        Assert.Equal(current.Length, NebulaPack.DecodeDelta(encoded, resolved, decoded));
+        Assert.Equal(current, decoded);
+    }
+}

--- a/addons/Nebula/Testing/Unit/NebulaPackTests.cs.uid
+++ b/addons/Nebula/Testing/Unit/NebulaPackTests.cs.uid
@@ -1,0 +1,1 @@
+uid://bstqx4483re8r


### PR DESCRIPTION
Most of a tick payload is byte-for-byte identical to the previous one - node bitmasks, serializer masks, property masks and encoding-flag bytes rarely change. In a real capture, 42 of 69 bytes repeated in every packet.

NebulaPack sends only the bytes that differ from a payload the peer already has, as a list of "skip N, then M literal bytes" runs compared position-for-position. It is not a general compressor, but tick payloads are naturally aligned, and on real data it beat deflate with a shared dictionary at a fraction of the cost and code.

Baseline selection is ack-driven. Each side keeps a 32-slot ring of recent payloads; the server marks a slot usable only when that specific tick's ack arrives, and picks whichever acked baseline in range encodes smallest
- measuring is the same byte walk with no writes, so trying them all is cheap. Marking is per-tick rather than "everything below the newest ack", since acks share the same lossy channel as the ticks.

Loss is self-healing. A dropped tick is never acked, so it never becomes a candidate; a packet the client can't decode is neither applied nor acked, so it doesn't either. Once every acked payload ages out, the server sends raw again on its own. Every packet declares whether it is a delta, so no handshake or reset message is involved and clients decode both regardless of their own setting.

MaxPackAge is 30 ticks (~1s at 30 TPS), sized off real latency rather than loopback: at 6, compression silently switched off above ~200ms ping.

Decoding runs on untrusted bytes, so every length is bounds-checked and DecodeDelta returns -1 rather than throwing on anything malformed. An optional 2-byte FNV-1a checksum of the raw payload catches the two windows diverging, which is the one failure that would otherwise be silent.

Both off by default behind Nebula/config/pack_enabled and Nebula/config/pack_validate.

Other notes:
- The MTU check now measures the uncompressed size, so compression can't mask a genuinely oversized world.
- Pack state is dropped on disconnect and on world migration, since node ids are per-peer-per-world and the destination world restarts near tick 0.
- Tests cover codec round trips, malformed-input hardening, ring-slot staleness, and a simulated lossy channel including ack loss.