### PR TITLE
Ship per-peer NetProperty state end to end (1.7.0)

### DIFF
--- a/addons/Nebula/Core/NetProperty.cs
+++ b/addons/Nebula/Core/NetProperty.cs
@@ -53,8 +53,34 @@ namespace Nebula
         public int ChunkBudget = 256;
 
         /// <summary>
-        /// When true, this property will have different values for each peer.
-        /// This is useful for properties where each peer sees a unique value, such as quest state.
+        /// When true, this property holds a distinct value per peer. Useful when each peer sees
+        /// a unique value, such as quest state or per-player interactability.
+        ///
+        /// The property MUST be declared <c>partial</c> (NEBULA006) — the generator implements
+        /// per-peer-aware accessors. Because partial property definitions cannot carry
+        /// initializers, move any non-default initial value into the constructor.
+        ///
+        /// Semantics:
+        /// <list type="bullet">
+        /// <item>Server, inside <c>using (Network.ForPeer(peerId))</c>: gets and sets target that
+        /// peer's value. Gets fall back to the base value when the peer has no override. Sets
+        /// always deliver — there is deliberately no equality short-circuit, so writing a value
+        /// one peer already holds still reaches the peer in scope. The scope is lexical and
+        /// process-wide: ANY per-peer property on ANY node accessed inside it targets that peer.</item>
+        /// <item>Server, outside any scope: accessors target the base value. A base write
+        /// broadcasts to exactly the peers WITHOUT an override; peers with overrides keep theirs.
+        /// A joining peer with no override receives no wire value and uses the constructor
+        /// default — keep constructor defaults identical on server and client.</item>
+        /// <item>Client: behaves as a plain property, written by import. NotifyOnChange and
+        /// NetChangeListener fire as usual.</item>
+        /// </list>
+        ///
+        /// Restrictions: primitive value types only (int, bool, long, float, enums, Vector*,
+        /// UUID, NetId, ...) — reference types, string, INetSerializable and NetArray are
+        /// rejected (NEBULA007), as is combining with Predicted or Interpolate (NEBULA008).
+        /// Per-peer values are always sent absolute (never delta-encoded). Per-peer state is
+        /// cleaned up on disconnect; a peer that merely leaves a world keeps its entries on
+        /// that world's nodes until the world is torn down.
         /// </summary>
         public bool PerPeerState = false;
     }

--- a/addons/Nebula/Core/NetRunner.cs
+++ b/addons/Nebula/Core/NetRunner.cs
@@ -354,12 +354,47 @@ namespace Nebula
         }
 
         /// <summary>
-        /// This determines how fast the network sends data. When physics runs at 60 ticks per second, then at 2 PhysicsTicksPerNetworkTick, the network runs at 30hz.
+        /// How many physics ticks elapse per network tick. Derived from the
+        /// <c>Nebula/config/network/ticks_per_second</c> project setting (default 30): the
+        /// network tick fires on whole physics frames, so the divisor is the physics rate
+        /// over the requested rate, rounded to the nearest whole frame count. When the
+        /// requested rate does not divide the physics rate evenly, the nearest achievable
+        /// rate is used and a warning names it.
+        ///
+        /// Server and client must agree; both read the same project.godot, so this holds as
+        /// long as builds ship the same settings. Cached on first read - checked every
+        /// physics frame in WorldRunner, so it must not hit ProjectSettings per frame -
+        /// meaning changes take effect on the next run.
         /// </summary>
-        public const int PhysicsTicksPerNetworkTick = 2;
+        private static int? _physicsTicksPerNetworkTick;
+        public static int PhysicsTicksPerNetworkTick
+        {
+            get
+            {
+                if (_physicsTicksPerNetworkTick == null)
+                {
+                    int physicsRate = Engine.PhysicsTicksPerSecond;
+                    int requested = Math.Max(1,
+                        ProjectSettings.GetSetting("Nebula/config/network/ticks_per_second", 30).AsInt32());
+                    int divisor = Math.Max(1, (int)Math.Round(physicsRate / (double)requested));
+                    int actual = physicsRate / divisor;
+                    if (actual != requested)
+                    {
+                        Debugger.Instance?.Log(
+                            $"Nebula/config/network/ticks_per_second={requested} does not divide the physics rate ({physicsRate}); running at {actual} TPS (one network tick every {divisor} physics ticks).",
+                            Debugger.DebugLevel.WARN);
+                    }
+                    _physicsTicksPerNetworkTick = divisor;
+                }
+                return _physicsTicksPerNetworkTick.Value;
+            }
+        }
 
         /// <summary>
-        /// Ticks Per Second. The number of Ticks which are expected to elapse every second.
+        /// Ticks Per Second: the ACHIEVED network tick rate - engine physics rate divided by
+        /// <see cref="PhysicsTicksPerNetworkTick"/>. Equals the configured
+        /// <c>Nebula/config/network/ticks_per_second</c> whenever that divides the physics
+        /// rate evenly.
         /// </summary>
         private static int? _tps;
         public static int TPS
@@ -396,6 +431,21 @@ namespace Nebula
 
         public static bool LogTickPayloads =>
             _logTickPayloads ??= ProjectSettings.GetSetting("Nebula/config/debug/log_tick_payloads", false).AsBool();
+
+        private static int? _simulateIncomingTickLoss;
+        /// <summary>
+        /// Debug: percentage (0-100) of received tick packets the CLIENT drops before
+        /// processing, via <c>Nebula/config/debug/simulate_incoming_tick_loss</c>. Simulates
+        /// an unreliable link on a lossless LAN so loss-recovery paths (spawn resend-until-
+        /// acked, delta baseline fallback) can be exercised deterministically. Client-side
+        /// only; 0 (default) is a no-op. Cached on first read.
+        /// </summary>
+        public static int SimulateIncomingTickLoss =>
+            _simulateIncomingTickLoss ??= Math.Clamp(
+                ProjectSettings.GetSetting("Nebula/config/debug/simulate_incoming_tick_loss", 0).AsInt32(), 0, 100);
+
+        /// <summary>RNG for <see cref="SimulateIncomingTickLoss"/>. Debug-only, client-local.</summary>
+        private static readonly RandomNumberGenerator _tickLossRng = new();
 
         private static bool? _packEnabled;
         /// <summary>
@@ -580,6 +630,15 @@ namespace Nebula
                                     {
                                         Debugger.Instance.Log(Debugger.DebugLevel.INFO,
                                             $"[Nebula][TickPayload] tick={tick} ({bytes.Length} bytes) {Convert.ToHexString(bytes)}");
+                                    }
+                                    // Debug: simulate packet loss by dropping received ticks before
+                                    // processing. Client-side only, never touches the shared sim -
+                                    // exists to exercise loss-recovery paths (spawn resend, delta
+                                    // baseline fallback) deterministically on a LAN with no real loss.
+                                    if (SimulateIncomingTickLoss > 0
+                                        && _tickLossRng.RandiRange(1, 100) <= SimulateIncomingTickLoss)
+                                    {
+                                        break;
                                     }
                                     WorldRunner.CurrentWorld.ClientProcessTick(tick, bytes);
                                 }

--- a/addons/Nebula/Core/NetworkController.cs
+++ b/addons/Nebula/Core/NetworkController.cs
@@ -16,24 +16,37 @@ namespace Nebula
 	*/
 	public partial class NetworkController : RefCounted
 	{
+		/// <summary>
+		/// Scopes a peer context for per-peer property access. The context is lexical and
+		/// process-wide (thread-static): while a scope is open, reads and writes of ANY
+		/// per-peer property on ANY node target that peer. Scopes nest; disposing restores
+		/// the outer scope's peer.
+		/// </summary>
 		public ref struct PeerScope
 		{
-			private readonly NetworkController _network;
+			private readonly UUID _saved;
 
-			internal PeerScope(NetworkController network, UUID peerId)
+			internal PeerScope(UUID peerId)
 			{
-				_network = network;
-				_network._currentContextPeer = peerId;
+				_saved = _contextPeer;
+				_contextPeer = peerId;
 			}
 
 			public void Dispose()
 			{
-				_network._currentContextPeer = default;
+				_contextPeer = _saved;
 			}
 		}
 
-		public PeerScope ForPeer(UUID peerId) => new PeerScope(this, peerId);
-		private UUID _currentContextPeer = default;
+		public PeerScope ForPeer(UUID peerId) => new PeerScope(peerId);
+
+		[ThreadStatic]
+		private static UUID _contextPeer;
+
+		/// <summary>
+		/// The peer targeted by the innermost open <see cref="ForPeer"/> scope, or default when none.
+		/// </summary>
+		internal static UUID CurrentContextPeer => _contextPeer;
 
 		#region Snapshot Interpolation
 
@@ -230,9 +243,17 @@ namespace Nebula
 				if (_attachedNetNodeSceneFilePath == null)
 				{
 					var rawPath = RawNode.SceneFilePath;
-					_attachedNetNodeSceneFilePath = string.IsNullOrEmpty(rawPath)
+					var resolved = string.IsNullOrEmpty(rawPath)
 						? NetParent?.RawNode?.SceneFilePath ?? ""
 						: rawPath;
+					// Same pre-instantiation guard as IsNetScene(): an empty result means the
+					// node (and its parent) aren't resolvable yet - return it but don't cache,
+					// or the real path could never be observed later.
+					if (string.IsNullOrEmpty(resolved))
+					{
+						return resolved;
+					}
+					_attachedNetNodeSceneFilePath = resolved;
 				}
 				return _attachedNetNodeSceneFilePath;
 			}
@@ -262,11 +283,32 @@ namespace Nebula
 		}
 
 		bool? _isNetScene = null;
+
+		/// <summary>Test seam: exposes the IsNetScene cache state (null = not yet cached).</summary>
+		internal bool? IsNetSceneCacheForTests => _isNetScene;
+
 		public bool IsNetScene()
 		{
 			if (_isNetScene == null)
 			{
-				_isNetScene = Protocol.IsNetScene(RawNode.SceneFilePath);
+				// Don't cache before instantiation completes: constructor-time property writes
+				// (e.g. per-peer ctor defaults routed through MarkDirty) land here while
+				// SceneFilePath is still empty, and caching false would permanently demote a
+				// real NetScene - no serializers, no property sync for the whole scene.
+				// An empty path only becomes trustworthy (a genuine static child) once the
+				// node is in the tree; caching then keeps MarkDirty's hot path free of the
+				// allocating SceneFilePath interop fetch.
+				var scenePath = RawNode.SceneFilePath;
+				if (string.IsNullOrEmpty(scenePath))
+				{
+					if (!RawNode.IsInsideTree())
+					{
+						return false;
+					}
+					_isNetScene = false;
+					return false;
+				}
+				_isNetScene = Protocol.IsNetScene(scenePath);
 			}
 			return _isNetScene.Value;
 		}
@@ -360,6 +402,19 @@ namespace Nebula
 		/// </summary>
 		private bool[] _propIsPerPeer;
 		private int _perPeerPropertyCount;
+
+		/// <summary>
+		/// Cached wire type per property index, used by the per-peer write path
+		/// (which bypasses MarkDirty and so cannot rely on its protocol lookup).
+		/// Allocated only when the scene has per-peer properties.
+		/// </summary>
+		private SerialVariantType[] _propVariantTypes;
+
+		/// <summary>
+		/// Compact list of per-peer property indices, for serializer iteration without
+		/// scanning all 64 slots. Allocated only when the scene has per-peer properties.
+		/// </summary>
+		internal int[] PerPeerPropIndices;
 
 		public HashSet<NetworkController> DynamicNetworkChildren = [];
 
@@ -649,14 +704,165 @@ namespace Nebula
 			// Allocate per-peer storage
 			PerPeerValues = new Dictionary<UUID, PropertyCache>[propCount];
 			PerPeerDirtyMask = new Dictionary<UUID, long>();
+			_propVariantTypes = new SerialVariantType[propCount];
+			PerPeerPropIndices = new int[_perPeerPropertyCount];
 
+			var perPeerSlot = 0;
 			for (int i = 0; i < propCount; i++)
 			{
+				_propVariantTypes[i] = Protocol.UnpackProperty(NetSceneFilePath, i).VariantType;
 				if (_propIsPerPeer[i])
 				{
 					PerPeerValues[i] = new Dictionary<UUID, PropertyCache>();
+					PerPeerPropIndices[perPeerSlot++] = i;
 				}
 			}
+		}
+
+		/// <summary>
+		/// Test seam: initializes per-peer storage directly from the given metadata, bypassing
+		/// protocol registration, and marks this controller as a NetScene root so root
+		/// resolution terminates here. Never call outside tests.
+		/// </summary>
+		internal void InitializePerPeerStorageForTests(bool[] isPerPeer, SerialVariantType[] variantTypes)
+		{
+			_isNetScene = true;
+			_propIsPerPeer = isPerPeer;
+			_propVariantTypes = variantTypes;
+			_perPeerPropertyCount = 0;
+			for (int i = 0; i < isPerPeer.Length; i++)
+			{
+				if (isPerPeer[i]) _perPeerPropertyCount++;
+			}
+
+			PerPeerValues = new Dictionary<UUID, PropertyCache>[isPerPeer.Length];
+			PerPeerDirtyMask = new Dictionary<UUID, long>();
+			PerPeerPropIndices = new int[_perPeerPropertyCount];
+
+			var perPeerSlot = 0;
+			for (int i = 0; i < isPerPeer.Length; i++)
+			{
+				if (isPerPeer[i])
+				{
+					PerPeerValues[i] = new Dictionary<UUID, PropertyCache>();
+					PerPeerPropIndices[perPeerSlot++] = i;
+				}
+			}
+		}
+
+		/// <summary>
+		/// Walks up to the NetScene root that owns per-peer storage. Null when the node
+		/// is not yet registered in a world (NetParent needs CurrentWorld).
+		/// </summary>
+		private NetworkController ResolvePerPeerRoot()
+		{
+			var node = this;
+			while (node != null && !node.IsNetScene())
+			{
+				node = node.NetParent;
+			}
+			return node;
+		}
+
+		/// <summary>
+		/// Reads the current context peer's value for a per-peer property. Called by generated
+		/// property getters. Returns false (caller falls back to the base field) when: not the
+		/// server, no <see cref="ForPeer"/> scope is open, the owning NetScene root cannot be
+		/// resolved yet, storage is absent, or the peer has no override.
+		/// Alloc-free; <paramref name="cachedIndex"/> and <paramref name="cachedRoot"/> are
+		/// resolved once and reused across calls.
+		/// </summary>
+		/// <summary>
+		/// Test seam: lets unit tests exercise the per-peer paths without a live NetRunner.
+		/// Never set outside tests.
+		/// </summary>
+		internal static bool ForcePerPeerServerContextForTests = false;
+
+		/// <summary>
+		/// Null-safe server check for the per-peer accessors. Only evaluated while a ForPeer
+		/// scope is open, but a scope can be opened before/without a NetRunner (tests, tools).
+		/// </summary>
+		private static bool PerPeerServerContext =>
+			ForcePerPeerServerContextForTests || (NetRunner.Instance?.IsServer ?? false);
+
+		public bool TryReadPerPeer(INetNodeBase sourceNode, string propertyName, ref int cachedIndex, ref NetworkController cachedRoot, out PropertyCache value)
+		{
+			value = default;
+			var peerId = _contextPeer;
+			if (peerId == default || !PerPeerServerContext)
+			{
+				return false;
+			}
+
+			var root = cachedRoot ?? ResolvePerPeerRoot();
+			if (root == null || root.PerPeerValues == null)
+			{
+				return false;
+			}
+			cachedRoot = root;
+
+			if (cachedIndex < 0)
+			{
+				var staticChildId = sourceNode.Network.StaticChildId;
+				if (!Protocol.LookupPropertyByStaticChildId(root.NetSceneFilePath, staticChildId, propertyName, out var prop))
+				{
+					return false;
+				}
+				cachedIndex = prop.Index;
+			}
+
+			var peerValues = root.PerPeerValues[cachedIndex];
+			return peerValues != null && peerValues.TryGetValue(peerId, out value);
+		}
+
+		/// <summary>
+		/// Writes the current context peer's value for a per-peer property and marks it dirty
+		/// for that peer only. Called by generated property setters — deliberately without any
+		/// equality short-circuit, so writing a value one peer already holds still delivers it
+		/// to the peer in scope. Returns false (caller falls back to the broadcast path) under
+		/// the same conditions as <see cref="TryReadPerPeer"/>.
+		/// </summary>
+		public bool TryWritePerPeer<T>(INetNodeBase sourceNode, string propertyName, T value, ref int cachedIndex, ref NetworkController cachedRoot) where T : struct
+		{
+			var peerId = _contextPeer;
+			if (peerId == default || !PerPeerServerContext)
+			{
+				return false;
+			}
+
+			var root = cachedRoot ?? ResolvePerPeerRoot();
+			if (root == null || root.PerPeerValues == null)
+			{
+				return false;
+			}
+			cachedRoot = root;
+
+			if (cachedIndex < 0)
+			{
+				var staticChildId = sourceNode.Network.StaticChildId;
+				if (!Protocol.LookupPropertyByStaticChildId(root.NetSceneFilePath, staticChildId, propertyName, out var prop))
+				{
+					return false;
+				}
+				cachedIndex = prop.Index;
+			}
+
+			var peerValues = root.PerPeerValues[cachedIndex];
+			if (peerValues == null)
+			{
+				return false;
+			}
+
+			var cache = new PropertyCache();
+			SetCachedValueToCache(root._propVariantTypes[cachedIndex], value, ref cache);
+			peerValues[peerId] = cache;
+
+			if (!root.PerPeerDirtyMask.TryGetValue(peerId, out var mask))
+			{
+				mask = 0;
+			}
+			root.PerPeerDirtyMask[peerId] = mask | (1L << cachedIndex);
+			return true;
 		}
 
 		/// <summary>
@@ -771,24 +977,8 @@ namespace Nebula
 				return;
 			}
 
-			// Per-peer property with context set?
-			if (_currentContextPeer != default && _propIsPerPeer != null && _propIsPerPeer[prop.Index])
-			{
-				var peerId = _currentContextPeer;
-
-				// Store in per-peer dictionary
-				var cache = new PropertyCache();
-				SetCachedValueToCache(prop.VariantType, value, ref cache);
-				PerPeerValues[prop.Index][peerId] = cache;
-
-				// Update per-peer dirty mask
-				if (!PerPeerDirtyMask.TryGetValue(peerId, out var mask))
-					mask = 0;
-				PerPeerDirtyMask[peerId] = mask | (1L << prop.Index);
-				return;
-			}
-
-			// Broadcast path - update global dirty mask
+			// Broadcast path - update global dirty mask. Per-peer routing happens in the
+			// generated property setter (TryWritePerPeer) before MarkDirty is ever called.
 			DirtyMask |= (1L << prop.Index);
 			
 			// Skip caching for predicted properties on owned clients.

--- a/addons/Nebula/Core/NetworkController.cs
+++ b/addons/Nebula/Core/NetworkController.cs
@@ -475,7 +475,10 @@ namespace Nebula
 
 		public void RemovePeerInterest(NetPeer peer, long interestLayers, bool recurse = true)
 		{
-			SetPeerInterest(NetRunner.Instance.GetPeerId(peer), interestLayers, recurse);
+			// Route through the UUID overload: calling SetPeerInterest directly here *assigned* the
+			// mask instead of clearing it, so removing a layer granted the caller's bits and dropped
+			// every other layer the peer held.
+			RemovePeerInterest(NetRunner.Instance.GetPeerId(peer), interestLayers, recurse);
 		}
 
 		public void RemovePeerInterest(UUID peerId, long interestLayers, bool recurse = true)

--- a/addons/Nebula/Core/Serialization/Serializers/IStateSerializer.cs
+++ b/addons/Nebula/Core/Serialization/Serializers/IStateSerializer.cs
@@ -14,7 +14,14 @@ namespace Nebula.Serialization.Serializers
         /// <param name="currentWorld">The current world runner</param>
         /// <param name="data">The network buffer containing serialized data</param>
         /// <param name="nodeOut">Output network controller</param>
-        public void Import(WorldRunner currentWorld, NetBuffer data, out NetworkController nodeOut);
+        /// <returns>
+        /// True if the payload was fully applied. False if it was parsed but (partly)
+        /// discarded — the stream is still aligned, but the caller must NOT ack this
+        /// tick: an ack tells the server "I have this tick's data", and acking a
+        /// discarded payload permanently latches delta encoding onto a baseline the
+        /// client never recorded.
+        /// </returns>
+        public bool Import(WorldRunner currentWorld, NetBuffer data, out NetworkController nodeOut);
 
         /// <summary>
         /// Server-side only. Serialize and write data to the provided buffer.
@@ -45,5 +52,15 @@ namespace Nebula.Serialization.Serializers
         /// </summary>
         /// <param name="peerId">The UUID of the disconnecting peer</param>
         public void CleanupPeer(UUID peerId) { }
+
+        /// <summary>
+        /// Server-side only. Called when the client is about to receive a fresh copy of this
+        /// node (a spawn or interest-regain respawn). The client rebuilds the node from
+        /// scratch, so any per-peer delta/ack baseline held here describes state the new
+        /// client-side instance does not have and must be forgotten — otherwise the next
+        /// export deltas against a tick the client can never resolve.
+        /// </summary>
+        /// <param name="peerId">The UUID of the peer being (re)sent this node</param>
+        public void ResetPeerBaseline(UUID peerId) { }
     }
 }

--- a/addons/Nebula/Core/Serialization/Serializers/InterestResyncSerializer.cs
+++ b/addons/Nebula/Core/Serialization/Serializers/InterestResyncSerializer.cs
@@ -46,10 +46,10 @@ namespace Nebula.Serialization.Serializers
             NetWriter.WriteByte(buffer, isInterested ? (byte)1 : (byte)0);
         }
 
-        public void Import(WorldRunner currentWorld, NetBuffer buffer, out NetworkController nodeOut)
+        public bool Import(WorldRunner currentWorld, NetBuffer buffer, out NetworkController nodeOut)
         {
             nodeOut = network;
-            if (network == null) return;
+            if (network == null) return true;
 
             byte interestByte = NetReader.ReadByte(buffer);
             bool hasInterest = interestByte == 1;
@@ -60,6 +60,7 @@ namespace Nebula.Serialization.Serializers
                 clientHasInterest = hasInterest;
                 network.FireInterestChanged(hasInterest);
             }
+            return true;
         }
     }
 }

--- a/addons/Nebula/Core/Serialization/Serializers/NetPropertiesSerializer.cs
+++ b/addons/Nebula/Core/Serialization/Serializers/NetPropertiesSerializer.cs
@@ -483,23 +483,32 @@ namespace Nebula.Serialization.Serializers
         /// Creates a new PeerPropertyState, either from pool or fresh allocation.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        /// <summary>
+        /// Returns a peer state to "never sent anything, never heard an ack" - the arrays are
+        /// kept (they are peer-size-independent) but every mask, the sent history, and the
+        /// delta baseline are wiped. Shared by pool reuse and <see cref="ResetPeerBaseline"/>.
+        /// </summary>
+        private static void ClearPeerState(ref PeerPropertyState state)
+        {
+            Array.Clear(state.AckedMask, 0, state.AckedMask.Length);
+            Array.Clear(state.PendingDirtyMask, 0, state.PendingDirtyMask.Length);
+            Array.Clear(state.SentHistory, 0, state.SentHistory.Length);
+            for (int i = 0; i < state.SentHistory.Length; i++)
+            {
+                state.SentHistory[i].Tick = -1;
+            }
+            Array.Clear(state.DeltaChain, 0, state.DeltaChain.Length);
+            Array.Clear(state.LossyMask, 0, state.LossyMask.Length);
+            state.LatestAckedTick = -1;
+            state.IsInitialized = true;
+        }
+
         private PeerPropertyState CreateOrGetPooledState()
         {
             if (_statePool.Count > 0)
             {
                 var state = _statePool.Pop();
-                // Clear the arrays for reuse
-                Array.Clear(state.AckedMask, 0, state.AckedMask.Length);
-                Array.Clear(state.PendingDirtyMask, 0, state.PendingDirtyMask.Length);
-                Array.Clear(state.SentHistory, 0, state.SentHistory.Length);
-                for (int i = 0; i < state.SentHistory.Length; i++)
-                {
-                    state.SentHistory[i].Tick = -1;
-                }
-                Array.Clear(state.DeltaChain, 0, state.DeltaChain.Length);
-                Array.Clear(state.LossyMask, 0, state.LossyMask.Length);
-                state.LatestAckedTick = -1;
-                state.IsInitialized = true;
+                ClearPeerState(ref state);
                 return state;
             }
 
@@ -762,7 +771,59 @@ namespace Nebula.Serialization.Serializers
             }
         }
 
-        private Data Deserialize(NetBuffer buffer, Tick currentTick)
+        // ============================================================
+        // TEST SEAMS (unit tests only - same-assembly access)
+        // ============================================================
+
+        /// <summary>
+        /// Test seam: builds a serializer with hand-supplied property metadata, bypassing the
+        /// Protocol registry (which requires a registered net scene). Only the client-side
+        /// Deserialize paths are exercised on instances built this way; Export/Acknowledge
+        /// depend on Protocol and a live WorldRunner and must not be called.
+        /// </summary>
+        internal NetPropertiesSerializer(NetworkController _network, SerialVariantType[] propTypes)
+        {
+            network = _network;
+            _cachedSceneFilePath = network.RawNode.SceneFilePath;
+
+            _propertyCount = propTypes.Length;
+            _byteCount = (_propertyCount + BitConstants.BitsInByte - 1) / BitConstants.BitsInByte;
+
+            _propTypes = propTypes;
+            _propSupportsDelta = new bool[_propertyCount];
+            _propIsObject = new bool[_propertyCount];
+            _propClassIndex = new int[_propertyCount];
+            for (int i = 0; i < _propertyCount; i++) _propClassIndex[i] = -1;
+            _propIsPerPeer = new bool[_propertyCount];
+            _propInterestMask = new long[_propertyCount];
+            _propInterestRequired = new long[_propertyCount];
+            _propIntWidth = new IntWidth[_propertyCount];
+            _propChunkBudget = new int[_propertyCount];
+
+            _propertiesUpdated = new byte[_byteCount];
+            _actualMask = new byte[_byteCount];
+            _dirtyOnlyMask = new byte[_byteCount];
+            _decodedMask = new byte[_byteCount];
+            _decodedValues = new PropertyCache[_propertyCount];
+            _incomingMask = new byte[_byteCount];
+        }
+
+        /// <summary>Test seam: runs Deserialize and reports whether the payload was applied.</summary>
+        internal bool DeserializeForTests(NetBuffer buffer, Tick currentTick)
+        {
+            Deserialize(buffer, currentTick, out bool discarded);
+            return !discarded;
+        }
+
+        /// <summary>Test seam: whether the applied-state ring holds an entry for this exact tick.</summary>
+        internal bool HasAppliedEntryForTests(Tick tick)
+        {
+            if (_appliedRing == null) return false;
+            ref var entry = ref _appliedRing[tick % SNAPSHOT_RING_SIZE];
+            return entry.Values != null && entry.Tick == tick;
+        }
+
+        private Data Deserialize(NetBuffer buffer, Tick currentTick, out bool discarded)
         {
             int startPos = buffer.ReadPosition;
             int byteCount = _byteCount;
@@ -795,23 +856,40 @@ namespace Nebula.Serialization.Serializers
             if (baselineAge > 0)
             {
                 Tick baselineTick = currentTick - baselineAge;
-                if (_appliedRing != null)
-                {
-                    ref var baseEntry = ref _appliedRing[baselineTick % SNAPSHOT_RING_SIZE];
-                    if (baseEntry.Values != null && baseEntry.Tick == baselineTick)
-                    {
-                        baselineValues = baseEntry.Values;
-                    }
-                }
 
-                if (baselineValues == null)
+                // The age byte comes off the wire unvalidated. A server never writes more
+                // than MAX_DELTA_AGE, so anything larger means a desynced/corrupt stream;
+                // and a negative baselineTick (age exceeding a young world's tick count)
+                // would index the ring with a negative value and throw, aborting the whole
+                // tick import. Both are handled as a discard, same as a missing baseline.
+                if (baselineAge > MAX_DELTA_AGE || baselineTick < 0)
                 {
-                    // Should be unreachable: the server only picks acked send-ticks within
-                    // MAX_DELTA_AGE, and we record an entry for every applied payload.
-                    // Parse the payload to keep the stream aligned, but discard the values.
                     Debugger.Instance.Log(Debugger.DebugLevel.ERROR,
-                        $"[NetPropertiesSerializer.Deserialize] NetId={network.NetId} missing applied-state baseline for tick {baselineTick} (age {baselineAge}). Discarding payload.");
+                        $"[NetPropertiesSerializer.Deserialize] NetId={network.NetId} invalid baseline age {baselineAge} at tick {currentTick}. Discarding payload.");
                     discardPayload = true;
+                }
+                else
+                {
+                    if (_appliedRing != null)
+                    {
+                        ref var baseEntry = ref _appliedRing[baselineTick % SNAPSHOT_RING_SIZE];
+                        if (baseEntry.Values != null && baseEntry.Tick == baselineTick)
+                        {
+                            baselineValues = baseEntry.Values;
+                        }
+                    }
+
+                    if (baselineValues == null)
+                    {
+                        // Reachable when this node was rebuilt client-side (respawn) while the
+                        // server retained a baseline, or when a prior payload was discarded.
+                        // Parse the payload to keep the stream aligned, but discard the values;
+                        // reporting the discard (instead of acking) is what lets the server
+                        // fall back to the last shared baseline or an absolute send.
+                        Debugger.Instance.Log(Debugger.DebugLevel.ERROR,
+                            $"[NetPropertiesSerializer.Deserialize] NetId={network.NetId} missing applied-state baseline for tick {baselineTick} (age {baselineAge}). Discarding payload.");
+                        discardPayload = true;
+                    }
                 }
             }
 
@@ -1015,6 +1093,7 @@ namespace Nebula.Serialization.Serializers
             }
 
             // Debugger.Instance.Log(Debugger.DebugLevel.VERBOSE, $"[Props.Import] NetId={network.NetId} total={buffer.ReadPosition - startPos} endPos={buffer.ReadPosition}");
+            discarded = discardPayload;
             return new Data(_decodedMask, _decodedValues);
         }
 
@@ -1288,11 +1367,11 @@ namespace Nebula.Serialization.Serializers
             cachedPropertyChanges.Clear();
         }
 
-        public void Import(WorldRunner currentWorld, NetBuffer buffer, out NetworkController nodeOut)
+        public bool Import(WorldRunner currentWorld, NetBuffer buffer, out NetworkController nodeOut)
         {
             nodeOut = network;
 
-            var data = Deserialize(buffer, currentWorld.CurrentTick);
+            var data = Deserialize(buffer, currentWorld.CurrentTick, out bool discarded);
 
             // Cache IsNodeReady() once before the loop to avoid repeated Godot calls
             bool isReady = network.RawNode.IsNodeReady();
@@ -1314,8 +1393,16 @@ namespace Nebula.Serialization.Serializers
             // old Dictionary happened to yield (insertion order: decode pass 1, then pass 2),
             // so any OnNetworkChange handler that observes a sibling property still sees the
             // same ordering it did before.
+            //
+            // In discard mode the decoded mask only carries object-property bits (primitives
+            // are suppressed at decode; objects still apply - their chunk streams are
+            // self-contained and resend-tolerant), so these calls stay unconditional.
             ApplyDecoded(data, currentWorld.CurrentTick, isReady, objectPass: false);
             ApplyDecoded(data, currentWorld.CurrentTick, isReady, objectPass: true);
+
+            // A discarded payload must not be acked: the applied ring has no entry for this
+            // tick, so an ack would invite the server to delta against it forever.
+            return !discarded;
         }
 
         /// <summary>
@@ -2131,6 +2218,24 @@ namespace Nebula.Serialization.Serializers
         /// Removes all cached data for a specific peer. Call this when a peer disconnects.
         /// Returns the PeerPropertyState to the pool for reuse.
         /// </summary>
+        /// <summary>
+        /// Forget everything ever sent to this peer, because the client is about to rebuild
+        /// this node from scratch (spawn or interest-regain respawn). The fresh client-side
+        /// serializer starts with an empty applied ring, so any delta baseline retained here
+        /// would point at a tick the client can never resolve - the next payload after a
+        /// respawn must be fully absolute, and initial sync must re-ship non-default values.
+        /// </summary>
+        public void ResetPeerBaseline(UUID peerId)
+        {
+            peerInitialPropSync.Remove(peerId);
+
+            ref var state = ref CollectionsMarshal.GetValueRefOrNullRef(_peerStates, peerId);
+            if (!Unsafe.IsNullRef(ref state) && state.IsInitialized)
+            {
+                ClearPeerState(ref state);
+            }
+        }
+
         public void CleanupPeer(UUID peerId)
         {
             peerInitialPropSync.Remove(peerId);

--- a/addons/Nebula/Core/Serialization/Serializers/NetPropertiesSerializer.cs
+++ b/addons/Nebula/Core/Serialization/Serializers/NetPropertiesSerializer.cs
@@ -357,6 +357,37 @@ namespace Nebula.Serialization.Serializers
                             }
                         }
                     }
+
+                    // Per-peer overrides re-ship on visibility gain the same way. They are
+                    // not in nonDefaultProperties (per-peer writes bypass the shared dirty
+                    // mask), so without this a peer regaining interest keeps a stale value.
+                    if (network.PerPeerPropIndices != null && network.PerPeerValues != null)
+                    {
+                        foreach (var propIndex in network.PerPeerPropIndices)
+                        {
+                            if (propIndex >= _propertyCount) continue;
+                            var overrides = network.PerPeerValues[propIndex];
+                            if (overrides == null || !overrides.ContainsKey(peerId)) continue;
+
+                            long interestMask = _propInterestMask[propIndex];
+                            long interestRequired = _propInterestRequired[propIndex];
+
+                            bool wasVisible = (interestMask & oldInterest) != 0
+                                && (interestRequired & oldInterest) == interestRequired;
+                            bool isNowVisible = (interestMask & newInterest) != 0
+                                && (interestRequired & newInterest) == interestRequired;
+
+                            if (!wasVisible && isNowVisible)
+                            {
+                                ClearBit(syncMask, propIndex);
+                                ref var state = ref CollectionsMarshal.GetValueRefOrNullRef(_peerStates, peerId);
+                                if (!Unsafe.IsNullRef(ref state) && state.IsInitialized)
+                                {
+                                    ClearBit(state.AckedMask, propIndex);
+                                }
+                            }
+                        }
+                    }
                 };
                 network.InterestChanged += _interestChangedHandler;
             }
@@ -1424,14 +1455,6 @@ namespace Nebula.Serialization.Serializers
             var peerId = NetRunner.Instance.GetPeerId(peer);
             int byteCount = _byteCount;
 
-            // Snapshot AND CLEAR per-peer dirty mask for this peer
-            long perPeerDirty = 0;
-            if (network.PerPeerDirtyMask != null &&
-                network.PerPeerDirtyMask.TryGetValue(peerId, out perPeerDirty))
-            {
-                network.PerPeerDirtyMask[peerId] = 0; // Clear after snapshot
-            }
-
             Array.Clear(_propertiesUpdated, 0, byteCount);
 
             if (!peerInitialPropSync.TryGetValue(peerId, out var initialSync))
@@ -1460,6 +1483,13 @@ namespace Nebula.Serialization.Serializers
                 return;
             }
 
+            // Snapshot the per-peer dirty mask AFTER the interest early-return, and do NOT
+            // clear it here: bits are cleared at the bottom of Export only for properties
+            // that actually shipped, so interest-filtered (or not-yet-visible) changes stay
+            // armed and retry next tick instead of being lost permanently.
+            long perPeerDirty = 0;
+            network.PerPeerDirtyMask?.TryGetValue(peerId, out perPeerDirty);
+
             // Build dirty mask for PRIMITIVE properties only from processingDirtyMask
             // Object properties (INetSerializable) are handled separately - they self-filter
             // Per-peer properties use per-peer dirty mask instead of global
@@ -1473,7 +1503,12 @@ namespace Nebula.Serialization.Serializers
                 bool isDirty;
                 if (_propIsPerPeer[propIndex])
                 {
-                    isDirty = (perPeerDirty & (1L << propIndex)) != 0;
+                    // A base (unscoped) write broadcasts to exactly the peers WITHOUT an
+                    // override; peers with an override keep their per-peer value.
+                    var overrides = network.PerPeerValues?[propIndex];
+                    isDirty = (perPeerDirty & (1L << propIndex)) != 0
+                        || ((processingDirtyMask & (1L << propIndex)) != 0
+                            && (overrides == null || !overrides.ContainsKey(peerId)));
                 }
                 else
                 {
@@ -1503,6 +1538,27 @@ namespace Nebula.Serialization.Serializers
                 if ((initialSync[byteIndex] & propSlot) == 0)
                 {
                     _propertiesUpdated[byteIndex] |= propSlot;
+                }
+            }
+
+            // Per-peer overrides join initial sync directly: per-peer writes never enter the
+            // shared dirty mask, so nonDefaultProperties can't cover them. Without this a
+            // peer that joins (or respawns) after its override was written receives nothing.
+            if (network.PerPeerPropIndices != null && network.PerPeerValues != null)
+            {
+                foreach (var propIndex in network.PerPeerPropIndices)
+                {
+                    if (propIndex >= _propertyCount || _propIsObject[propIndex]) continue;
+
+                    var overrides = network.PerPeerValues[propIndex];
+                    if (overrides == null || !overrides.ContainsKey(peerId)) continue;
+
+                    var byteIndex = propIndex / BitConstants.BitsInByte;
+                    var propSlot = (byte)(1 << (propIndex % BitConstants.BitsInByte));
+                    if ((initialSync[byteIndex] & propSlot) == 0)
+                    {
+                        _propertiesUpdated[byteIndex] |= propSlot;
+                    }
                 }
             }
 
@@ -1758,6 +1814,7 @@ namespace Nebula.Serialization.Serializers
             // properties - object properties (INetSerializable) manage their own per-peer
             // pending/resend state and are acked through their own tick-gated callbacks.
             long primitiveSentMask = 0;
+            long perPeerSentMask = 0;
             for (var byteIdx = 0; byteIdx < byteCount; byteIdx++)
             {
                 var b = actualMask[byteIdx];
@@ -1773,8 +1830,21 @@ namespace Nebula.Serialization.Serializers
                     if (propIdx < 64)
                     {
                         primitiveSentMask |= 1L << propIdx;
+                        if (_propIsPerPeer[propIdx])
+                        {
+                            perPeerSentMask |= 1L << propIdx;
+                        }
                     }
                 }
+            }
+
+            // Clear only the per-peer dirty bits that actually shipped this export.
+            // Bits filtered out (interest, budget) stay armed and retry next tick;
+            // loss recovery from here on is PendingDirtyMask's job.
+            if (perPeerSentMask != 0 && network.PerPeerDirtyMask != null &&
+                network.PerPeerDirtyMask.TryGetValue(peerId, out var remainingPerPeerDirty))
+            {
+                network.PerPeerDirtyMask[peerId] = remainingPerPeerDirty & ~perPeerSentMask;
             }
 
             // Record what was sent at this tick so a future ack can be matched to exactly

--- a/addons/Nebula/Core/Serialization/Serializers/SpawnSerializer.cs
+++ b/addons/Nebula/Core/Serialization/Serializers/SpawnSerializer.cs
@@ -36,7 +36,21 @@ namespace Nebula.Serialization.Serializers
         private NetworkController netController;
         private Dictionary<UUID, Tick> setupTicks = new();
         private Dictionary<UUID, Tick> despawnTicks = new(); // Track when despawn was sent per peer
+
+        /// <summary>
+        /// The most recent tick at which spawn data was written for each peer. Spawn data
+        /// re-ships every tick while Spawning (see Export), so together with the soft-interest
+        /// revert this keeps the invariant "spawn rode every exported tick in
+        /// [setupTick, lastSpawnSendTick]" - which is what makes the cumulative ack commit in
+        /// Acknowledge sound: an acked tick inside that range is a packet that provably
+        /// contained the spawn data.
+        /// </summary>
+        private Dictionary<UUID, Tick> lastSpawnSendTicks = new();
+
         private bool hasImported = false; // Track if this serializer has already imported
+
+        /// <summary>One-shot guard so an unpackable spawn path logs once, not every tick.</summary>
+        private bool _loggedUnpackableSpawnPath = false;
 
         /// <summary>
         /// Despawn marker byte - when first byte is 255, it's a despawn message.
@@ -61,6 +75,26 @@ namespace Nebula.Serialization.Serializers
         {
             setupTicks.Remove(peerId);
             despawnTicks.Remove(peerId);
+            lastSpawnSendTicks.Remove(peerId);
+        }
+
+        /// <summary>
+        /// Tells every sibling serializer to forget its per-peer delta/ack baseline. Called at
+        /// each NotSpawned -&gt; Spawning transition: the client is about to build this node from
+        /// scratch (first spawn, or a respawn after interest loss destroyed its copy), so its
+        /// applied-state history is empty. Any baseline retained server-side from a previous
+        /// incarnation would make the next export delta against a tick the fresh client node
+        /// can never resolve - the payload gets discarded, and (before Import reported
+        /// discards) the ack latched the mismatch in place permanently.
+        /// </summary>
+        private static void ResetPeerBaselines(NetworkController controller, UUID peerId)
+        {
+            var serializers = controller.NetNode?.Serializers;
+            if (serializers == null) return;
+            for (int i = 0; i < serializers.Length; i++)
+            {
+                serializers[i].ResetPeerBaseline(peerId);
+            }
         }
 
         public void Export(WorldRunner currentWorld, NetPeer peer, NetBuffer buffer)
@@ -93,9 +127,22 @@ namespace Nebula.Serialization.Serializers
                 return;
             }
 
-            // Soft path (unchanged): fails interest LAYERS / [NetInterest].
+            // Soft path: fails interest LAYERS / [NetInterest].
             if (!netController.IsPeerInterested(peer))
             {
+                // Interest dropped while the spawn was still in flight. Resends stop here, so
+                // an unacked Spawning state would break the contiguity invariant behind the
+                // Acknowledge commit rule ("spawn rode every tick in [setupTick, lastSent]")
+                // and a later cumulative ack could commit a spawn the client never received.
+                // Revert to never-spawned: on interest regain the node runs a fresh spawn
+                // cycle - same local id (registration is idempotent), and a client that did
+                // receive one of the earlier sends consumes-and-skips the duplicate.
+                if (spawnState == WorldRunner.ClientSpawnState.Spawning && setupTicks.ContainsKey(peerId))
+                {
+                    setupTicks.Remove(peerId);
+                    lastSpawnSendTicks.Remove(peerId);
+                    currentWorld.SetClientSpawnState(netController.NetId, peer, WorldRunner.ClientSpawnState.NotSpawned);
+                }
                 return;
             }
 
@@ -107,12 +154,20 @@ namespace Nebula.Serialization.Serializers
                 spawnState = WorldRunner.ClientSpawnState.NotSpawned;
             }
 
-            // Check if spawn data has already been sent (Spawning or Spawned state)
-            if (spawnState != WorldRunner.ClientSpawnState.NotSpawned)
+            // Fully delivered - the peer acked a packet that contained the spawn data.
+            if (spawnState == WorldRunner.ClientSpawnState.Spawned)
             {
-                // Already sent spawn data (or ACKed), skip
                 return;
             }
+
+            // Spawning falls through: spawn data re-ships every tick until the ack commits it.
+            // The tick channel is unreliable, so a fire-once spawn on a lost packet left the
+            // client with props for a node it never built (a blank NetNode3D whose props
+            // serializer then misreads the stream), while the cumulative ack still marked it
+            // Spawned server-side. Resending until acked is the same contract despawn already
+            // uses (see ExportDespawn's Despawning case). First-send-only side effects below
+            // are gated on this flag.
+            bool firstSend = spawnState == WorldRunner.ClientSpawnState.NotSpawned;
 
             if (netController.NetParent != null && !currentWorld.HasSpawnedForClient(netController.NetParent.NetId, peer))
             {
@@ -142,6 +197,36 @@ namespace Nebula.Serialization.Serializers
                     $"SceneId {sceneId} exceeds safe limit (245). Too many registered scenes.");
             }
 
+            // Child spawns address their attachment point as (parent scene, packed node path).
+            // Resolve it BEFORE writing anything: an unpackable path must not throw out of
+            // Export (that aborts the whole export tick for every node and peer) and must not
+            // leave partial bytes in the buffer. Unpackable happens when the node's Godot
+            // parent is a path the protocol registry doesn't cover - e.g. a node reparented
+            // at runtime under an unregistered container.
+            byte nodePathId = 0;
+            if (netController.NetParent != null)
+            {
+                var relativePath = netController.NetParent.RawNode.GetPathTo(netController.RawNode.GetParent());
+                if (relativePath == "." || relativePath.IsEmpty)
+                {
+                    // Direct child of parent's root - 255 is the special marker
+                    nodePathId = 255;
+                }
+                else if (!Protocol.PackNode(netController.NetParent.RawNode.SceneFilePath, relativePath, out nodePathId))
+                {
+                    // Nothing written; the node simply stays pending and retries next tick
+                    // (delivery becomes possible if the path is registered in a future
+                    // protocol build). Logged once per node, not per tick.
+                    if (!_loggedUnpackableSpawnPath)
+                    {
+                        _loggedUnpackableSpawnPath = true;
+                        Debugger.Instance.Log(Debugger.DebugLevel.ERROR,
+                            $"[SpawnSerializer] Cannot spawn {netController.RawNode.GetPath()}: node path '{relativePath}' is not in the protocol registry for scene '{netController.NetParent.RawNode.SceneFilePath}'. Spawn stays pending; further occurrences suppressed.");
+                    }
+                    return;
+                }
+            }
+
             // Only set setupTick on FIRST export - don't overwrite on re-exports
             // Otherwise the ACK can never catch up (setupTick keeps moving forward)
             if (!setupTicks.ContainsKey(peerId))
@@ -158,31 +243,23 @@ namespace Nebula.Serialization.Serializers
                 // Write nested NetScenes for root scene
                 ExportNestedScenes(currentWorld, peer, buffer);
 
+                // Stamped every send (first and resends) - the upper bound of the ack window.
+                lastSpawnSendTicks[peerId] = currentWorld.CurrentTick;
+
                 // Mark spawn as being sent (waiting for ACK)
-                currentWorld.SetClientSpawnState(netController.NetId, peer, WorldRunner.ClientSpawnState.Spawning);
+                if (firstSend)
+                {
+                    ResetPeerBaselines(netController, peerId);
+                    currentWorld.SetClientSpawnState(netController.NetId, peer, WorldRunner.ClientSpawnState.Spawning);
+                }
                 return;
             }
 
             var parentId = currentWorld.GetPeerNodeId(peer, netController.NetParent);
             NetWriter.WriteUInt16(buffer, parentId);
 
-            // Get the path from parent's root to the spawned node's parent
-            byte nodePathId = 0;
-            var relativePath = netController.NetParent.RawNode.GetPathTo(netController.RawNode.GetParent());
-            if (relativePath == "." || relativePath.IsEmpty)
-            {
-                // Direct child of parent's root - use 255 as special marker
-                nodePathId = 255;
-                NetWriter.WriteByte(buffer, 255);
-            }
-            else if (Protocol.PackNode(netController.NetParent.RawNode.SceneFilePath, relativePath, out nodePathId))
-            {
-                NetWriter.WriteByte(buffer, nodePathId);
-            }
-            else
-            {
-                throw new System.Exception($"FAILED TO PACK FOR SPAWN: Node path not found for {netController.RawNode.GetPath()}, relativePath={relativePath}");
-            }
+            // Attachment path within the parent scene, resolved (or bailed on) above.
+            NetWriter.WriteByte(buffer, nodePathId);
 
             // Use ID comparison instead of Equals - more reliable for ENet.Peer structs
             var hasInputAuth = netController.InputAuthority.IsSet && netController.InputAuthority.ID == peer.ID ? (byte)1 : (byte)0;
@@ -191,8 +268,15 @@ namespace Nebula.Serialization.Serializers
             // Write nested NetScenes
             ExportNestedScenes(currentWorld, peer, buffer);
 
+            // Stamped every send (first and resends) - the upper bound of the ack window.
+            lastSpawnSendTicks[peerId] = currentWorld.CurrentTick;
+
             // Mark spawn as being sent (waiting for ACK)
-            currentWorld.SetClientSpawnState(netController.NetId, peer, WorldRunner.ClientSpawnState.Spawning);
+            if (firstSend)
+            {
+                ResetPeerBaselines(netController, peerId);
+                currentWorld.SetClientSpawnState(netController.NetId, peer, WorldRunner.ClientSpawnState.Spawning);
+            }
 
             currentWorld.Debug?.Send("Spawn", $"Exported:{netController.RawNode.SceneFilePath}");
         }
@@ -306,6 +390,24 @@ namespace Nebula.Serialization.Serializers
                     continue;
                 }
 
+                var peerUUID = NetRunner.Instance.GetPeerId(peer);
+
+                // Nested scenes ride along in the parent's spawn data, so the client is about
+                // to build them from scratch - their per-peer baselines must reset like the
+                // parent's own NotSpawned -> Spawning transition. This must cover EVERY state
+                // except Spawning (which means "already in this parent's resend stream" -
+                // resetting per resend would wipe props delta state every tick). Notably it
+                // must cover stale Spawned: a parent that was per-peer despawned takes its
+                // nested subtree down with it CLIENT-side (QueueFree frees children), but
+                // despawn does not cascade server-side, so the nested node still reads
+                // Spawned here while the client is about to rebuild it with an empty applied
+                // ring. Skipping the reset then leaves a delta baseline the rebuilt node can
+                // never resolve ("missing applied-state baseline" bursts on respawn).
+                if (currentWorld.GetClientSpawnState(nested.NetId, peer) != WorldRunner.ClientSpawnState.Spawning)
+                {
+                    ResetPeerBaselines(nested, peerUUID);
+                }
+
                 // IMPORTANT: Set the nested scene's state to Spawning since we're including it in the parent's spawn data.
                 // Without this, despawn logic would see NotSpawned and skip sending despawn data.
                 currentWorld.SetClientSpawnState(nested.NetId, peer, WorldRunner.ClientSpawnState.Spawning);
@@ -314,11 +416,13 @@ namespace Nebula.Serialization.Serializers
                 if (nested.NetNode?.Serializers != null && nested.NetNode.Serializers.Length > 0
                     && nested.NetNode.Serializers[0] is SpawnSerializer nestedSpawnSerializer)
                 {
-                    var peerUUID = NetRunner.Instance.GetPeerId(peer);
                     if (!nestedSpawnSerializer.setupTicks.ContainsKey(peerUUID))
                     {
                         nestedSpawnSerializer.setupTicks[peerUUID] = currentWorld.CurrentTick;
                     }
+                    // Every inclusion (the nested payload rides every parent resend), so the
+                    // nested node's own ack window tracks the parent's resend stream.
+                    nestedSpawnSerializer.lastSpawnSendTicks[peerUUID] = currentWorld.CurrentTick;
                 }
 
                 var nestedSceneId = Protocol.PackScene(nested.NetSceneFilePath);
@@ -368,6 +472,7 @@ namespace Nebula.Serialization.Serializers
                     currentWorld.SetClientSpawnState(netController.NetId, peer, WorldRunner.ClientSpawnState.Despawned);
                     despawnTicks.Remove(peerId); // Clean up after successful ack
                     setupTicks.Remove(peerId); // Also clean up spawn tracking since despawn supersedes it
+                    lastSpawnSendTicks.Remove(peerId);
 
                     // Free the local NetId for this peer so it can be reused
                     currentWorld.DeregisterPeerNode(netController, peer);
@@ -387,13 +492,24 @@ namespace Nebula.Serialization.Serializers
                 return despawnTicks.ContainsKey(peerId) || setupTicks.ContainsKey(peerId);
             }
 
-            // Handle spawn acknowledgment (only if no despawn is pending)
+            // Handle spawn acknowledgment (only if no despawn is pending).
+            //
+            // Commit only when the acked tick falls inside [setupTick, lastSpawnSendTick]:
+            // spawn data rides every exported tick in that window (Export resends while
+            // Spawning; the soft-interest revert keeps the window contiguous), so an ack
+            // inside it is a packet that provably contained the spawn data. A bare
+            // `tick >= setupTick` would also commit on acks of ticks that carried only this
+            // node's props - which is exactly how a lost spawn packet used to get marked
+            // Spawned while the client sat on a blank node.
             if (setupTicks.TryGetValue(peerId, out var setupTick) && setupTick != 0)
             {
-                if (tick >= setupTick)
+                if (tick >= setupTick
+                    && lastSpawnSendTicks.TryGetValue(peerId, out var lastSent)
+                    && tick <= lastSent)
                 {
                     currentWorld.SetSpawnedForClient(netController.NetId, peer);
                     setupTicks.Remove(peerId); // Clean up after successful ack
+                    lastSpawnSendTicks.Remove(peerId);
                 }
             }
 
@@ -402,7 +518,7 @@ namespace Nebula.Serialization.Serializers
         }
 
         // Import is client-only and infrequent, less critical to optimize
-        public void Import(WorldRunner currentWorld, NetBuffer buffer, out NetworkController controllerOut)
+        public bool Import(WorldRunner currentWorld, NetBuffer buffer, out NetworkController controllerOut)
         {
             controllerOut = netController;
 
@@ -411,7 +527,7 @@ namespace Nebula.Serialization.Serializers
             if (firstByte == DESPAWN_MARKER)
             {
                 ImportDespawn(currentWorld, buffer);
-                return;
+                return true;
             }
 
             // Not a despawn - continue with normal spawn import
@@ -421,7 +537,7 @@ namespace Nebula.Serialization.Serializers
             // Skip if this node was already properly imported
             if (hasImported)
             {
-                return;
+                return true;
             }
 
             // Note: The node is already registered by WorldRunner before Import is called.
@@ -437,7 +553,12 @@ namespace Nebula.Serialization.Serializers
             if (data.parentId != 0 && networkParent == null)
             {
                 Debugger.Instance.Log(Debugger.DebugLevel.ERROR, $"Parent node not found for: {Protocol.UnpackScene(data.classId).ResourcePath} - Parent ID: {data.parentId}");
-                return;
+                // The spawn bytes were consumed but the node was never built. Withholding the
+                // ack keeps this tick out of the delta-baseline bookkeeping, and since the
+                // server resends spawn data every tick until an ack inside its send window
+                // commits it, the spawn simply re-arrives next tick (by which point the
+                // parent may exist).
+                return false;
             }
 
             var newNode = Protocol.UnpackScene(data.classId).Instantiate<INetNodeBase>();
@@ -474,7 +595,7 @@ namespace Nebula.Serialization.Serializers
 
                 // Check for pending despawn after spawn completes
                 CheckPendingDespawn(currentWorld, controllerOut);
-                return;
+                return true;
             }
 
             if (data.hasInputAuthority == 1)
@@ -500,6 +621,7 @@ namespace Nebula.Serialization.Serializers
 
             // Check for pending despawn after spawn completes
             CheckPendingDespawn(currentWorld, controllerOut);
+            return true;
         }
 
         /// <summary>

--- a/addons/Nebula/Core/WorldRunner.cs
+++ b/addons/Nebula/Core/WorldRunner.cs
@@ -1923,6 +1923,12 @@ namespace Nebula
             // into entirely the wrong nodes. The destination world also restarts near tick 0, which
             // would otherwise collide with retained ring slots.
             _clientPackWindow.Reset();
+
+            // A parked ack still references an old-world tick. Acks are routed by peer, not by
+            // world, so flushing it after the migration would land it in the destination world's
+            // PeerAcknowledge - and if the tick number happens to be valid there, it marks state
+            // this client never applied as acked (delta baselines, spawn commits).
+            _pendingAckTick = -1;
             TimeSinceLastTick = 0f;
             _ownedEntities.Clear();
             _ownedEntitiesDirty = true;
@@ -2513,6 +2519,13 @@ namespace Nebula
         /// </summary>
         internal bool ImportState(NetBuffer stateBytes)
         {
+            // Set when any serializer parses its payload but reports it was not applied
+            // (e.g. a props delta whose baseline this client doesn't have). The stream stays
+            // aligned - unlike the corrupted-buffer aborts below - but the tick must not be
+            // acked: an ack tells the server "I have this tick's data", and acking a
+            // discarded payload latches delta encoding onto a baseline we never recorded.
+            bool anyDiscarded = false;
+
             // Read hierarchical bitmask: groupMask (1 byte) + nodeMasks for active groups
             var groupMask = NetReader.ReadByte(stateBytes);
             var nodeMasks = new long[NodeIdUtils.NODE_GROUPS];
@@ -2573,19 +2586,28 @@ namespace Nebula
                             // Log($"[ImportState] Node {localNodeId}: Skipping serializer {serializerIdx} (bit not set)");
                             continue;
                         }
-                        
-                        // Skip if node was queued for despawn during import (e.g., by SpawnSerializer handling despawn)
-                        if (netController.IsQueuedForDespawn || netController.IsMarkedForDeletion)
-                        {
-                            break;
-                        }
-                        
+
+                        // A node queued for despawn (mid-import by SpawnSerializer, or earlier by a
+                        // pending client despawn) still has its serializer bytes in this packet -
+                        // the mask bit proves the server wrote them. The serializers must still
+                        // run so those bytes are consumed; breaking out here would leave them in
+                        // the buffer and misalign every node after this one. Applying values to a
+                        // dying node is harmless: QueueDespawnedNodes is drained at the end of
+                        // this same ClientProcessTick and the free is deferred, so the node is
+                        // alive for the duration of the import. We just don't let a discard from
+                        // a doomed node veto the tick ack.
+                        bool nodeIsDoomed = netController.IsQueuedForDespawn || netController.IsMarkedForDeletion;
+
                         var serializerInstance = netController.NetNode.Serializers[serializerIdx];
                         // Log($"[ImportState] Node {localNodeId}: Running serializer {serializerIdx} ({serializerInstance.GetType().Name})");
 
                         try
                         {
-                            serializerInstance.Import(this, stateBytes, out NetworkController nodeOut);
+                            bool applied = serializerInstance.Import(this, stateBytes, out NetworkController nodeOut);
+                            if (!applied && !nodeIsDoomed)
+                            {
+                                anyDiscarded = true;
+                            }
                             if (netController != nodeOut)
                             {
                                 // Log($"[ImportState] Node {localNodeId}: Serializer {serializerIdx} replaced node, new scenePath='{nodeOut.NetSceneFilePath}', restarting loop");
@@ -2626,7 +2648,7 @@ namespace Nebula
                 }
             }
 
-            return true;
+            return !anyDiscarded;
         }
 
         // Reusable list for objects that had all data acked (avoids modifying HashSet during iteration)

--- a/addons/Nebula/Generator/NetPropertyGenerator.cs
+++ b/addons/Nebula/Generator/NetPropertyGenerator.cs
@@ -41,6 +41,33 @@ public class NetPropertyGenerator : IIncrementalGenerator
         DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
+    // Diagnostic for per-peer properties that are not declared partial
+    private static readonly DiagnosticDescriptor PerPeerNotPartialDiagnostic = new(
+        id: "NEBULA006",
+        title: "Per-peer property must be declared partial",
+        messageFormat: "Property '{0}' has PerPeerState=true and must be declared 'partial' so the generator can implement per-peer accessors, e.g.: public partial {1} {0} {{ get; set; }} (move any initializer into the constructor)",
+        category: "Nebula",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    // Diagnostic for per-peer properties of unsupported types
+    private static readonly DiagnosticDescriptor PerPeerInvalidTypeDiagnostic = new(
+        id: "NEBULA007",
+        title: "Per-peer property type not supported",
+        messageFormat: "Property '{0}' has PerPeerState=true but type '{1}' is not supported. Per-peer properties must be primitive value types (int, bool, long, float, enums, Vector*, UUID, NetId, ...) - reference types, string, INetSerializable and NetArray are not supported",
+        category: "Nebula",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    // Diagnostic for per-peer properties combined with incompatible flags
+    private static readonly DiagnosticDescriptor PerPeerInvalidComboDiagnostic = new(
+        id: "NEBULA008",
+        title: "Per-peer property has incompatible flags",
+        messageFormat: "Property '{0}' has PerPeerState=true which cannot be combined with Predicted or Interpolate",
+        category: "Nebula",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
 
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
@@ -65,6 +92,7 @@ public class NetPropertyGenerator : IIncrementalGenerator
         bool interpolate = false;
         float interpolateSpeed = 15f;
         bool predicted = false;
+        bool perPeerState = false;
 
         foreach (var attr in propertySymbol.GetAttributes())
         {
@@ -87,11 +115,19 @@ public class NetPropertyGenerator : IIncrementalGenerator
                         case "Predicted" when namedArg.Value.Value is bool b3:
                             predicted = b3;
                             break;
+                        case "PerPeerState" when namedArg.Value.Value is bool b4:
+                            perPeerState = b4;
+                            break;
                     }
                 }
                 break;
             }
         }
+
+        // Partial detection must be syntax-based: IPropertySymbol.IsPartialDefinition is not
+        // available on the Roslyn version this generator compiles against (4.3.0).
+        bool isPartial = context.TargetNode is PropertyDeclarationSyntax propSyntax
+            && propSyntax.Modifiers.Any(m => m.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.PartialKeyword));
 
         // Check if the property type implements IBsonValue<T> or IBsonSerializable<T>
         bool isBsonSerializable = false;
@@ -168,8 +204,34 @@ public class NetPropertyGenerator : IIncrementalGenerator
             propertyLocation,
             predicted,
             hasToleranceProperty,
-            implementsINetSerializable);
+            implementsINetSerializable,
+            perPeerState,
+            isPartial,
+            GetAccessibilityKeyword(propertySymbol.DeclaredAccessibility));
     }
+
+    private static string GetAccessibilityKeyword(Accessibility accessibility) => accessibility switch
+    {
+        Accessibility.Public => "public",
+        Accessibility.Internal => "internal",
+        Accessibility.Protected => "protected",
+        Accessibility.ProtectedOrInternal => "protected internal",
+        Accessibility.ProtectedAndInternal => "private protected",
+        _ => "private",
+    };
+
+    /// <summary>
+    /// True when the generator emits the per-peer partial-property implementation for this
+    /// property (all validity conditions hold; otherwise a NEBULA006-008 diagnostic fired and
+    /// the legacy broadcast hook is emitted so the class still compiles behind the error).
+    /// </summary>
+    private static bool EmitsPerPeerImplementation(PropertyInfo prop) =>
+        prop.IsPerPeer
+        && prop.IsPartial
+        && prop.IsValueType
+        && !prop.ImplementsINetSerializable
+        && !prop.Predicted
+        && !prop.Interpolate;
 
     /// <summary>
     /// Counts the number of [NetProperty] properties in all base classes of the given type.
@@ -492,6 +554,36 @@ public class NetPropertyGenerator : IIncrementalGenerator
                 }
             }
 
+            // Report diagnostics for invalid per-peer property declarations
+            foreach (var prop in propList)
+            {
+                if (!prop!.IsPerPeer || prop.PropertyLocation == null) continue;
+
+                if (!prop.IsValueType || prop.ImplementsINetSerializable)
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        PerPeerInvalidTypeDiagnostic,
+                        prop.PropertyLocation,
+                        prop.PropertyName,
+                        prop.PropertyType));
+                }
+                else if (prop.Predicted || prop.Interpolate)
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        PerPeerInvalidComboDiagnostic,
+                        prop.PropertyLocation,
+                        prop.PropertyName));
+                }
+                else if (!prop.IsPartial)
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        PerPeerNotPartialDiagnostic,
+                        prop.PropertyLocation,
+                        prop.PropertyName,
+                        prop.PropertyType));
+                }
+            }
+
             // Get the base class property count offset - all props in this class have the same value
             var baseOffset = propList.FirstOrDefault()?.BaseClassPropertyCount ?? 0;
 
@@ -507,10 +599,55 @@ public class NetPropertyGenerator : IIncrementalGenerator
             sb.AppendLine($"partial class {className}");
             sb.AppendLine("{");
 
-            // Generate On{PropertyName}Changed methods
+            // Generate On{PropertyName}Changed methods (broadcast properties: Fody-woven setters
+            // call these hooks). Per-peer properties get a generated partial-property
+            // implementation instead - the setter owns dirty routing, with no Fody equality
+            // short-circuit, so writing the same value for a second peer still delivers it.
             for (int i = 0; i < propList.Count; i++)
             {
                 var prop = propList[i]!;
+
+                if (EmitsPerPeerImplementation(prop))
+                {
+                    var readExpr = GetCacheReadExpression(prop, "__cache");
+                    sb.AppendLine($"    private {prop.PropertyType} __netBase_{prop.PropertyName};");
+                    sb.AppendLine($"    private int __netPerPeerIdx_{prop.PropertyName} = -1;");
+                    sb.AppendLine($"    private Nebula.NetworkController __netPerPeerRoot_{prop.PropertyName};");
+                    sb.AppendLine();
+                    sb.AppendLine("    /// <summary>");
+                    sb.AppendLine("    /// Per-peer property: inside Network.ForPeer(peer) accessors target that peer's");
+                    sb.AppendLine("    /// value; outside any scope they target the base value broadcast to peers without");
+                    sb.AppendLine("    /// an override. See NetProperty.PerPeerState.");
+                    sb.AppendLine("    /// </summary>");
+                    sb.AppendLine("    [global::PropertyChanged.DoNotNotify]");
+                    sb.AppendLine($"    {prop.Accessibility} partial {prop.PropertyType} {prop.PropertyName}");
+                    sb.AppendLine("    {");
+                    sb.AppendLine("        get");
+                    sb.AppendLine("        {");
+                    sb.AppendLine("            // Network is null in the editor (node ctors skip controller creation there)");
+                    sb.AppendLine("            if (Network is not null");
+                    sb.AppendLine($"                && Network.TryReadPerPeer(this, \"{prop.PropertyName}\", ref __netPerPeerIdx_{prop.PropertyName}, ref __netPerPeerRoot_{prop.PropertyName}, out var __cache))");
+                    sb.AppendLine("            {");
+                    sb.AppendLine($"                return {readExpr};");
+                    sb.AppendLine("            }");
+                    sb.AppendLine($"            return __netBase_{prop.PropertyName};");
+                    sb.AppendLine("        }");
+                    sb.AppendLine("        set");
+                    sb.AppendLine("        {");
+                    sb.AppendLine("            // Per-peer route first: a write inside ForPeer must not touch the base value");
+                    sb.AppendLine("            if (Network is not null");
+                    sb.AppendLine($"                && Network.TryWritePerPeer(this, \"{prop.PropertyName}\", value, ref __netPerPeerIdx_{prop.PropertyName}, ref __netPerPeerRoot_{prop.PropertyName}))");
+                    sb.AppendLine("            {");
+                    sb.AppendLine("                return;");
+                    sb.AppendLine("            }");
+                    sb.AppendLine($"            __netBase_{prop.PropertyName} = value;");
+                    sb.AppendLine($"            Network?.MarkDirty(this, \"{prop.PropertyName}\", value);");
+                    sb.AppendLine("        }");
+                    sb.AppendLine("    }");
+                    sb.AppendLine();
+                    continue;
+                }
+
                 var markDirtyMethod = prop.IsValueType ? "MarkDirty" : "MarkDirtyRef";
 
                 sb.AppendLine($"    public void On{prop.PropertyName}Changed({prop.FullyQualifiedPropertyType} oldVal, {prop.FullyQualifiedPropertyType} newVal)");
@@ -1106,5 +1243,9 @@ public class NetPropertyGenerator : IIncrementalGenerator
         bool Predicted,
         bool HasToleranceProperty,
         // True for INetSerializable object properties (need their ref seeded into the cache at init)
-        bool ImplementsINetSerializable);
+        bool ImplementsINetSerializable,
+        // Per-peer fields
+        bool IsPerPeer,
+        bool IsPartial,
+        string Accessibility);
 }

--- a/addons/Nebula/Generator/ProtocolBuilder/Models.cs
+++ b/addons/Nebula/Generator/ProtocolBuilder/Models.cs
@@ -14,6 +14,20 @@ namespace Nebula.Generators
         public List<StaticNetNode> StaticNetNodes { get; } = new();
         public Dictionary<string, Dictionary<string, PropertyData>> Properties { get; } = new();
         public Dictionary<string, Dictionary<string, FunctionData>> Functions { get; } = new();
+        /// <summary>
+        /// Nested NetScenes authored under containers that violate the parenting invariant
+        /// (a NetScene may only be a child of another NetScene, a NetNode, or the scene
+        /// root). Reported as NEBULA009 build errors.
+        /// </summary>
+        public List<InvalidNestedContainer> InvalidNestedContainers { get; } = new();
+    }
+
+    /// <summary>A nested NetScene placed under a non-networked container node.</summary>
+    internal sealed class InvalidNestedContainer
+    {
+        public string ScenePath { get; set; } = "";
+        public string NestedNodePath { get; set; } = "";
+        public string ContainerPath { get; set; } = "";
     }
 
     internal sealed class StaticNetNode
@@ -109,6 +123,8 @@ namespace Nebula.Generators
         /// protocol hash so builds on different Nebula versions refuse to connect.
         /// </summary>
         public string NebulaVersion { get; set; } = "";
+        /// <summary>All NEBULA009 parenting violations across scenes.</summary>
+        public List<InvalidNestedContainer> InvalidNestedContainers { get; } = new();
     }
 
     internal sealed class SceneInterestData

--- a/addons/Nebula/Generator/ProtocolBuilder/ProtocolGenerator.cs
+++ b/addons/Nebula/Generator/ProtocolBuilder/ProtocolGenerator.cs
@@ -127,6 +127,10 @@ namespace Nebula.Generators
             // (C# masks shift counts) and index out of bounds. Fail the build instead.
             ReportPropertyLimitViolations(context, protocolData);
 
+            // Enforce the NetScene parenting invariant (NEBULA009): a nested NetScene under
+            // a plain container node is unaddressable by late spawn delivery at runtime.
+            ReportInvalidNestedContainers(context, protocolData);
+
             // Emit code
             var code = CodeEmitter.Emit(protocolData);
             context.AddSource("Protocol.g.cs", SourceText.From(code, Encoding.UTF8));
@@ -154,6 +158,27 @@ namespace Nebula.Generators
             "Nebula.Generator",
             DiagnosticSeverity.Error,
             isEnabledByDefault: true);
+
+        private static readonly DiagnosticDescriptor InvalidNestedContainerDescriptor = new(
+            "NEBULA009",
+            "Nested NetScene under a non-networked container",
+            "Scene '{0}': nested NetScene '{1}' is parented under '{2}', which is neither a NetNode nor the scene root. A NetScene must be a child of another NetScene or a NetNode: late spawn delivery (interest gained after the parent scene committed) addresses the attachment point through the protocol registry, which only contains networked nodes - this spawn would be undeliverable at runtime. Attach a NetNode-derived script to '{2}', or reparent '{1}'.",
+            "Nebula.Generator",
+            DiagnosticSeverity.Error,
+            isEnabledByDefault: true);
+
+        private static void ReportInvalidNestedContainers(SourceProductionContext context, ProtocolData data)
+        {
+            foreach (var violation in data.InvalidNestedContainers)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    InvalidNestedContainerDescriptor,
+                    Location.None,
+                    violation.ScenePath,
+                    violation.NestedNodePath,
+                    violation.ContainerPath));
+            }
+        }
 
         private static void ReportPropertyLimitViolations(SourceProductionContext context, ProtocolData data)
         {
@@ -211,6 +236,10 @@ namespace Nebula.Generators
                     fileContents,
                     analysisResult,
                     sceneDataCache);
+
+                // Collected before the NetScene filter: a violation inside a rolled-up
+                // (non-NetScene) scene is just as unaddressable at runtime.
+                data.InvalidNestedContainers.AddRange(bytecode.InvalidNestedContainers);
 
                 if (!bytecode.IsNetScene) continue;
 
@@ -403,6 +432,10 @@ namespace Nebula.Generators
             var propertyCount = 0;
             var functionCount = 0;
 
+            // Paths of nested NetScene instances seen so far in this scene - legal parents
+            // for deeper nested NetScenes (tscn orders parents before children).
+            var nestedNetScenePaths = new HashSet<string>();
+
             foreach (var node in parsed.Nodes)
             {
                 var nodePath = node.Parent == null
@@ -428,8 +461,35 @@ namespace Nebula.Generators
                         analysisResult,
                         cache);
 
-                    // Nested network scenes don't roll up
-                    if (nestedBytecode.IsNetScene) continue;
+                    // Nested network scenes don't roll up. Their PLACEMENT is validated
+                    // instead: a NetScene may only be a child of another NetScene, a NetNode,
+                    // or the scene root (architectural invariant). Late spawn delivery
+                    // addresses the attachment point as (parent scene, packed node path), and
+                    // the registry only contains networked nodes - a plain container there
+                    // makes the spawn unaddressable at runtime. Fail the build (NEBULA009)
+                    // rather than let it surface as an undeliverable spawn.
+                    if (nestedBytecode.IsNetScene)
+                    {
+                        var containerPath = node.Parent;
+                        bool legalContainer = string.IsNullOrEmpty(containerPath)
+                            || containerPath == "."
+                            || nestedNetScenePaths.Contains(containerPath)
+                            || HasStaticNetNodePath(result, containerPath);
+                        if (!legalContainer)
+                        {
+                            result.InvalidNestedContainers.Add(new InvalidNestedContainer
+                            {
+                                ScenePath = sceneResPath,
+                                NestedNodePath = nodePath,
+                                ContainerPath = containerPath!
+                            });
+                        }
+
+                        // Legal parent for any deeper nested NetScenes in this scene
+                        // (NetScene-under-NetScene is allowed by the invariant).
+                        nestedNetScenePaths.Add(nodePath);
+                        continue;
+                    }
 
                     // Merge static net nodes
                     foreach (var entry in nestedBytecode.StaticNetNodes)
@@ -599,6 +659,21 @@ namespace Nebula.Generators
 
             cache[sceneResPath] = result;
             return result;
+        }
+
+        /// <summary>
+        /// Whether a path is already registered as a static net node for this scene. Guards
+        /// against duplicate ids when several nested NetScenes share one container, or when
+        /// the container itself is a scripted NetNode (registered when its own tscn entry was
+        /// processed - parents precede children in tscn order).
+        /// </summary>
+        private static bool HasStaticNetNodePath(SceneBytecode result, string path)
+        {
+            for (int i = 0; i < result.StaticNetNodes.Count; i++)
+            {
+                if (result.StaticNetNodes[i].Path == path) return true;
+            }
+            return false;
         }
 
         private static bool IsNetNode(string scriptPath, TypeAnalyzer.AnalysisResult analysis)

--- a/addons/Nebula/NEBULA_OVERVIEW.mdc
+++ b/addons/Nebula/NEBULA_OVERVIEW.mdc
@@ -233,10 +233,36 @@ Marks a property for network synchronization. Only modified on the server.
 [NetProperty(Interpolate = true, InterpolateSpeed = 20f)]  // Custom lerp speed (default: 15)
 [NetProperty(Predicted = true)]                 // Client-side prediction for owned entities
                                                 // REQUIRES: {PropertyName}PredictionTolerance property
+[NetProperty(PerPeerState = true)]              // Distinct value per peer; property MUST be partial
 ```
 
 **Prediction + Interpolation:**
 When both are enabled, prediction handles owned entities (you control it) and interpolation handles non-owned entities (other players/NPCs smoothly interpolated).
+
+**Per-peer properties (`PerPeerState = true`):**
+Each peer holds (and receives) its own value. The property must be declared `partial` — the
+generator implements peer-aware accessors — and any non-default initial value moves to the
+constructor (partial definitions can't carry initializers):
+
+```csharp
+[NetProperty(PerPeerState = true, NotifyOnChange = true)]
+public partial int ChunkState { get; set; }
+
+public ScrapYard() { ChunkState = -1; }
+
+// Server-side: scope reads/writes to one peer. Reads fall back to the base value
+// when the peer has no override; writes always deliver (no equality short-circuit).
+using (Network.ForPeer(peerId))
+{
+    ChunkState &= ~bit;   // read-modify-write on THIS peer's value
+}
+```
+
+Outside a `ForPeer` scope, accessors target the *base value*; a base write broadcasts to
+exactly the peers without an override. The scope is lexical and process-wide (any per-peer
+property on any node accessed inside it targets that peer), and scopes nest. Value types
+only (NEBULA007); cannot combine with `Predicted`/`Interpolate` (NEBULA008); clients treat
+the property as plain imported state.
 
 **Supported Types:**
 - Primitives: `bool`, `byte`, `int`, `long`, `float`, `double`

--- a/addons/Nebula/NEBULA_OVERVIEW.mdc
+++ b/addons/Nebula/NEBULA_OVERVIEW.mdc
@@ -51,7 +51,7 @@ Nebula is a custom tick-based, server-authoritative networking library for Godot
 - Network runs at `TPS = PhysicsTicksPerSecond / PhysicsTicksPerNetworkTick` (default: 30hz)
 - Every tick, server exports state to all interested peers
 - Clients acknowledge received ticks for reliability tracking
-- Unreliable UDP with manual acknowledgment for state, reliable for spawns/despawns/RPCs
+- Unreliable UDP with manual acknowledgment for state; RPCs ride a reliable channel. Spawns and despawns ride the unreliable tick stream but re-send every tick until acknowledged, so they are effectively reliable (a spawn only commits on an ack of a tick that provably carried it)
 
 ### 3. Network Scenes (NetScenes)
 - A scene whose root node inherits from `NetNode`, `NetNode2D`, or `NetNode3D`

--- a/addons/Nebula/Testing/Unit/PerPeerStateTests.cs
+++ b/addons/Nebula/Testing/Unit/PerPeerStateTests.cs
@@ -1,0 +1,270 @@
+using System.Collections.Generic;
+using System.ComponentModel;
+using Nebula;
+using Nebula.Serialization;
+using Xunit;
+
+namespace Nebula.Testing.Unit;
+
+/// <summary>
+/// Unit tests for PerPeerState property storage: the thread-static ForPeer scope, the
+/// TryReadPerPeer/TryWritePerPeer accessors the generated partial properties call, and
+/// disconnect cleanup. These drive NetworkController's internal seams directly (no live
+/// NetRunner/WorldRunner); export-level behavior is covered by manual multi-client runs.
+/// </summary>
+[NebulaUnitTest]
+public class PerPeerStateTests
+{
+    /// <summary>Creates a node whose controller has one per-peer int prop (index 0) and one per-peer bool prop (index 1).</summary>
+    private static NetNode CreateNodeWithPerPeerStorage()
+    {
+        var node = new NetNode();
+        node.Network.InitializePerPeerStorageForTests(
+            [true, true],
+            [SerialVariantType.Int, SerialVariantType.Bool]);
+        return node;
+    }
+
+    // 1. Scopes nest and Dispose restores the OUTER peer, not default (regression: the old
+    //    PeerScope reset to default unconditionally).
+    [NebulaUnitTest]
+    public void ScopeNesting_RestoresOuterPeer()
+    {
+        var node = new NetNode();
+        var a = UUID.NewUUID();
+        var b = UUID.NewUUID();
+
+        Assert.Equal(default, NetworkController.CurrentContextPeer);
+        using (node.Network.ForPeer(a))
+        {
+            Assert.Equal(a, NetworkController.CurrentContextPeer);
+            using (node.Network.ForPeer(b))
+            {
+                Assert.Equal(b, NetworkController.CurrentContextPeer);
+            }
+            Assert.Equal(a, NetworkController.CurrentContextPeer);
+        }
+        Assert.Equal(default, NetworkController.CurrentContextPeer);
+
+        node.Free();
+    }
+
+    // 2. Two peers hold distinct values in the same property slot; reads resolve per peer and
+    //    a no-scope read finds no override.
+    [NebulaUnitTest]
+    public void WriteRead_RoundTrip_TwoPeersDistinct()
+    {
+        var node = CreateNodeWithPerPeerStorage();
+        var net = node.Network;
+        var a = UUID.NewUUID();
+        var b = UUID.NewUUID();
+        NetworkController.ForcePerPeerServerContextForTests = true;
+        try
+        {
+            int idx = 0;
+            NetworkController root = null;
+
+            using (net.ForPeer(a))
+                Assert.True(net.TryWritePerPeer(node, "P", 11, ref idx, ref root));
+            using (net.ForPeer(b))
+                Assert.True(net.TryWritePerPeer(node, "P", 22, ref idx, ref root));
+
+            using (net.ForPeer(a))
+            {
+                Assert.True(net.TryReadPerPeer(node, "P", ref idx, ref root, out var cacheA));
+                Assert.Equal(11, cacheA.IntValue);
+            }
+            using (net.ForPeer(b))
+            {
+                Assert.True(net.TryReadPerPeer(node, "P", ref idx, ref root, out var cacheB));
+                Assert.Equal(22, cacheB.IntValue);
+            }
+
+            // No scope open: no override is readable (generated getter falls back to base field)
+            Assert.False(net.TryReadPerPeer(node, "P", ref idx, ref root, out _));
+        }
+        finally
+        {
+            NetworkController.ForcePerPeerServerContextForTests = false;
+        }
+        node.Free();
+    }
+
+    // 3. THE original bug: peer B writing the value peer A already holds must still create B's
+    //    override and dirty bit (Fody's woven equality guard used to suppress the whole write).
+    [NebulaUnitTest]
+    public void EqualValueForSecondPeer_StillStoredAndDirty()
+    {
+        var node = CreateNodeWithPerPeerStorage();
+        var net = node.Network;
+        var a = UUID.NewUUID();
+        var b = UUID.NewUUID();
+        NetworkController.ForcePerPeerServerContextForTests = true;
+        try
+        {
+            int idx = 0;
+            NetworkController root = null;
+
+            using (net.ForPeer(a))
+                net.TryWritePerPeer(node, "P", 5, ref idx, ref root);
+            using (net.ForPeer(b))
+                net.TryWritePerPeer(node, "P", 5, ref idx, ref root);
+
+            Assert.True(net.PerPeerValues[0].ContainsKey(a));
+            Assert.True(net.PerPeerValues[0].ContainsKey(b));
+            Assert.Equal(1L << 0, net.PerPeerDirtyMask[a]);
+            Assert.Equal(1L << 0, net.PerPeerDirtyMask[b]);
+        }
+        finally
+        {
+            NetworkController.ForcePerPeerServerContextForTests = false;
+        }
+        node.Free();
+    }
+
+    // 4. Writes without a scope (or without storage) refuse and leave routing to the broadcast
+    //    path; dirty bits accumulate per property.
+    [NebulaUnitTest]
+    public void WriteGates_And_DirtyBitAccumulation()
+    {
+        var node = CreateNodeWithPerPeerStorage();
+        var net = node.Network;
+        var a = UUID.NewUUID();
+        NetworkController.ForcePerPeerServerContextForTests = true;
+        try
+        {
+            int idx0 = 0;
+            int idx1 = 1;
+            NetworkController root = null;
+
+            // No scope open -> refused
+            Assert.False(net.TryWritePerPeer(node, "P", 1, ref idx0, ref root));
+
+            // Storage absent (plain node) -> refused even inside a scope
+            var bare = new NetNode();
+            int bareIdx = 0;
+            NetworkController bareRoot = null;
+            using (net.ForPeer(a))
+                Assert.False(bare.Network.TryWritePerPeer(bare, "P", 1, ref bareIdx, ref bareRoot));
+            bare.Free();
+
+            // Both per-peer props written for one peer -> both bits set
+            using (net.ForPeer(a))
+            {
+                Assert.True(net.TryWritePerPeer(node, "P0", 7, ref idx0, ref root));
+                Assert.True(net.TryWritePerPeer(node, "P1", true, ref idx1, ref root));
+            }
+            Assert.Equal((1L << 0) | (1L << 1), net.PerPeerDirtyMask[a]);
+            Assert.True(net.PerPeerValues[1][a].BoolValue);
+        }
+        finally
+        {
+            NetworkController.ForcePerPeerServerContextForTests = false;
+        }
+        node.Free();
+    }
+
+    // 5. Disconnect cleanup evicts exactly the departing peer from values and dirty masks.
+    [NebulaUnitTest]
+    public void CleanupPeerState_EvictsOnlyThatPeer()
+    {
+        var node = CreateNodeWithPerPeerStorage();
+        var net = node.Network;
+        var a = UUID.NewUUID();
+        var b = UUID.NewUUID();
+        NetworkController.ForcePerPeerServerContextForTests = true;
+        try
+        {
+            int idx = 0;
+            NetworkController root = null;
+            using (net.ForPeer(a))
+                net.TryWritePerPeer(node, "P", 1, ref idx, ref root);
+            using (net.ForPeer(b))
+                net.TryWritePerPeer(node, "P", 2, ref idx, ref root);
+
+            net.CleanupPeerState(a);
+
+            Assert.False(net.PerPeerValues[0].ContainsKey(a));
+            Assert.False(net.PerPeerDirtyMask.ContainsKey(a));
+            Assert.True(net.PerPeerValues[0].ContainsKey(b));
+            Assert.Equal(2, net.PerPeerValues[0][b].IntValue);
+        }
+        finally
+        {
+            NetworkController.ForcePerPeerServerContextForTests = false;
+        }
+        node.Free();
+    }
+
+    // 6. PropertyChanged.Fody must NOT weave the generated per-peer setters ([DoNotNotify]):
+    //    its woven equality guard was the original bug (second peer writing an equal value was
+    //    silently dropped). Woven setters raise PropertyChanged; per-peer setters must not.
+    //    BroadcastValue (a plain woven property on the same fixture) is the positive control.
+    [NebulaUnitTest]
+    public void Fody_DoesNotWeave_PerPeerSetters()
+    {
+        var node = new PerPeerTestNode();
+        var fired = new List<string>();
+        ((INotifyPropertyChanged)node).PropertyChanged += (_, e) => fired.Add(e.PropertyName);
+
+        node.BroadcastValue = 123;
+        Assert.Contains("BroadcastValue", fired);
+
+        node.PerPeerValue = 99;
+        Assert.DoesNotContain("PerPeerValue", fired);
+
+        node.Free();
+    }
+
+    // 7. Regression: a constructor-time per-peer default routes through the generated setter
+    //    -> MarkDirty -> IsNetScene() while SceneFilePath is still empty (exactly what
+    //    PackedScene.Instantiate does before assigning the path). That probe must NOT cache,
+    //    or a real NetScene is permanently demoted - no serializers, no property sync.
+    [NebulaUnitTest]
+    public void CtorWrite_DoesNotPoison_IsNetSceneCache()
+    {
+        // Fixture ctor writes PerPeerValue = -1, firing the probe.
+        var node = new PerPeerTestNode();
+        Assert.False(node.Network.IsNetSceneCacheForTests.HasValue);
+        Assert.False(node.Network.IsNetScene());
+        Assert.False(node.Network.IsNetSceneCacheForTests.HasValue);
+
+        // Once a non-empty path exists (instantiation done), the answer is derived from the
+        // protocol registry and cached.
+        node.SceneFilePath = "res://addons/Nebula/Testing/Unit/PerPeerTestNode.tscn";
+        Assert.False(node.Network.IsNetScene());
+        Assert.True(node.Network.IsNetSceneCacheForTests.HasValue);
+
+        node.Free();
+    }
+
+    // 8. The peer context is process-wide (thread-static): a scope opened through one node's
+    //    controller applies to per-peer writes on a DIFFERENT node. This is what lets static
+    //    children work - their MarkDirty forwarding used to lose the instance-bound context.
+    [NebulaUnitTest]
+    public void Context_IsProcessWide_AcrossControllers()
+    {
+        var nodeA = CreateNodeWithPerPeerStorage();
+        var nodeB = CreateNodeWithPerPeerStorage();
+        var peer = UUID.NewUUID();
+        NetworkController.ForcePerPeerServerContextForTests = true;
+        try
+        {
+            int idx = 0;
+            NetworkController root = null;
+
+            // Scope opened via nodeA's controller; write lands through nodeB's controller
+            using (nodeA.Network.ForPeer(peer))
+                Assert.True(nodeB.Network.TryWritePerPeer(nodeB, "P", 42, ref idx, ref root));
+
+            Assert.Equal(42, nodeB.Network.PerPeerValues[0][peer].IntValue);
+            Assert.False(nodeA.Network.PerPeerValues[0].ContainsKey(peer));
+        }
+        finally
+        {
+            NetworkController.ForcePerPeerServerContextForTests = false;
+        }
+        nodeA.Free();
+        nodeB.Free();
+    }
+}

--- a/addons/Nebula/Testing/Unit/PerPeerStateTests.cs.uid
+++ b/addons/Nebula/Testing/Unit/PerPeerStateTests.cs.uid
@@ -1,0 +1,1 @@
+uid://tktm1hvnc7xy

--- a/addons/Nebula/Testing/Unit/PerPeerTestNode.cs
+++ b/addons/Nebula/Testing/Unit/PerPeerTestNode.cs
@@ -1,0 +1,24 @@
+using Nebula;
+
+namespace Nebula.Testing.Unit;
+
+/// <summary>
+/// Test fixture for PerPeerStateTests: a real NetNode with a generated per-peer partial
+/// property (exercising the actual generator output + Fody interaction) and a plain
+/// broadcast property as the weaving positive control. Not part of any scene; the
+/// constructor write deliberately replicates the "per-peer default assigned before
+/// SceneFilePath exists" sequence that once poisoned the IsNetScene cache.
+/// </summary>
+public partial class PerPeerTestNode : NetNode
+{
+    [NetProperty(PerPeerState = true)]
+    public partial int PerPeerValue { get; set; }
+
+    [NetProperty]
+    public int BroadcastValue { get; set; }
+
+    public PerPeerTestNode()
+    {
+        PerPeerValue = -1;
+    }
+}

--- a/addons/Nebula/Testing/Unit/PerPeerTestNode.cs.uid
+++ b/addons/Nebula/Testing/Unit/PerPeerTestNode.cs.uid
@@ -1,0 +1,1 @@
+uid://benneuvp8dww2

--- a/addons/Nebula/Testing/Unit/SnapshotBaselineTests.cs
+++ b/addons/Nebula/Testing/Unit/SnapshotBaselineTests.cs
@@ -1,0 +1,114 @@
+using Nebula;
+using Nebula.Serialization;
+using Nebula.Serialization.Serializers;
+using Xunit;
+
+namespace Nebula.Testing.Unit;
+
+/// <summary>
+/// Client-side tests for the snapshot-delta baseline in NetPropertiesSerializer.Deserialize:
+/// a payload whose baseline the client cannot resolve must be reported as discarded (so the
+/// tick is never acked - acking a discarded tick latches the server onto a baseline the
+/// client never recorded, which was the "missing applied-state baseline" spam every tick),
+/// and a malformed age byte must discard rather than index the ring negatively and throw.
+///
+/// Built on the Protocol-free test constructor; wire format per payload is
+/// [presence mask x byteCount][baselineAge byte][property data], and these tests use an
+/// empty presence mask so no property bytes follow.
+/// </summary>
+[NebulaUnitTest]
+public class SnapshotBaselineTests
+{
+    private static NetPropertiesSerializer CreateClientSerializer(out NetNode node)
+    {
+        node = new NetNode();
+        return new NetPropertiesSerializer(
+            node.Network,
+            [SerialVariantType.Int, SerialVariantType.Bool]);
+    }
+
+    /// <summary>One payload with an empty presence mask: [mask=0][age], no property bytes.</summary>
+    private static NetBuffer Payload(byte baselineAge)
+    {
+        var buf = new NetBuffer(16, usePool: false);
+        NetWriter.WriteByte(buf, 0);
+        NetWriter.WriteByte(buf, baselineAge);
+        buf.ResetRead();
+        return buf;
+    }
+
+    // 1. The respawn scenario: a fresh serializer (empty applied ring) receives a delta
+    //    payload. It must report "not applied" and record nothing - the caller withholding
+    //    the ack on this signal is what lets the server fall back to an absolute send.
+    [NebulaUnitTest]
+    public void MissingBaseline_DiscardsAndRecordsNothing()
+    {
+        var serializer = CreateClientSerializer(out var node);
+
+        bool applied = serializer.DeserializeForTests(Payload(baselineAge: 5), currentTick: 40);
+
+        Assert.False(applied);
+        Assert.False(serializer.HasAppliedEntryForTests(40));
+
+        node.Free();
+    }
+
+    // 2. The exact numbers from the field bug: baseline recorded at tick 37, delta age 19
+    //    arriving at tick 56 resolves against it and is applied.
+    [NebulaUnitTest]
+    public void AppliedAbsolute_RecordsBaseline_LaterDeltaResolves()
+    {
+        var serializer = CreateClientSerializer(out var node);
+
+        Assert.True(serializer.DeserializeForTests(Payload(baselineAge: 0), currentTick: 37));
+        Assert.True(serializer.HasAppliedEntryForTests(37));
+
+        Assert.True(serializer.DeserializeForTests(Payload(baselineAge: 19), currentTick: 56));
+        Assert.True(serializer.HasAppliedEntryForTests(56));
+
+        node.Free();
+    }
+
+    // 3. The latch, and the recovery: a discarded tick must not become a usable baseline
+    //    (a delta referencing it discards too), and one absolute payload restores the
+    //    chain. With the ack now gated on the applied flag, this sequence is exactly
+    //    "one error line, self-heals" instead of "error every tick forever".
+    [NebulaUnitTest]
+    public void DiscardedTickIsNotABaseline_AbsoluteRecovers()
+    {
+        var serializer = CreateClientSerializer(out var node);
+
+        Assert.False(serializer.DeserializeForTests(Payload(baselineAge: 5), currentTick: 40));
+        Assert.False(serializer.DeserializeForTests(Payload(baselineAge: 1), currentTick: 41)); // references 40
+        Assert.False(serializer.HasAppliedEntryForTests(41));
+
+        Assert.True(serializer.DeserializeForTests(Payload(baselineAge: 0), currentTick: 42)); // absolute
+        Assert.True(serializer.DeserializeForTests(Payload(baselineAge: 1), currentTick: 43)); // references 42
+
+        node.Free();
+    }
+
+    // 4. A corrupt age byte (beyond MAX_DELTA_AGE) discards instead of trusting garbage.
+    [NebulaUnitTest]
+    public void AgeBeyondMaxDeltaAge_Discarded()
+    {
+        var serializer = CreateClientSerializer(out var node);
+
+        Assert.False(serializer.DeserializeForTests(Payload(baselineAge: 200), currentTick: 300));
+
+        node.Free();
+    }
+
+    // 5. Regression: age exceeding a young world's tick count used to compute a negative
+    //    baseline tick and index the ring with it - IndexOutOfRangeException, aborting the
+    //    whole tick import. Must be a plain discard.
+    [NebulaUnitTest]
+    public void AgeOlderThanWorld_DiscardedNotThrown()
+    {
+        var serializer = CreateClientSerializer(out var node);
+
+        Assert.False(serializer.DeserializeForTests(Payload(baselineAge: 19), currentTick: 5));
+
+        node.Free();
+    }
+}

--- a/addons/Nebula/Testing/Unit/SnapshotBaselineTests.cs.uid
+++ b/addons/Nebula/Testing/Unit/SnapshotBaselineTests.cs.uid
@@ -1,0 +1,1 @@
+uid://bo6356y7lhntn

--- a/addons/Nebula/Tools/ProjectSettingsController.cs
+++ b/addons/Nebula/Tools/ProjectSettingsController.cs
@@ -118,6 +118,17 @@ public partial class ProjectSettingsController : Node
             {"hint_string", "100,65535,1"},
         });
 
+        // Network tick rate in ticks per second. The network tick fires on whole physics
+        // frames, so this should divide physics/common/physics_ticks_per_second evenly
+        // (with 60 physics: 60, 30, 20, 15, 12, 10, ...); anything else snaps to the
+        // nearest achievable rate with a startup warning naming it. Read once at startup,
+        // so changes take effect on the next run.
+        Register("Nebula/config/network/ticks_per_second", 30, new(){
+            {"type", (int)Variant.Type.Int},
+            {"hint", (int)PropertyHint.Range},
+            {"hint_string", "1,120,1"},
+        });
+
         // ── World ────────────────────────────────────────────────────────
         // Default world scene
         var defaultScene = ProjectSettings.GetSetting("application/run/main_scene", "");
@@ -155,6 +166,15 @@ public partial class ProjectSettingsController : Node
         // Debug: log the full hex of every server tick payload on the client
         Register("Nebula/config/debug/log_tick_payloads", false, new(){
             {"type", (int)Variant.Type.Bool},
+        });
+
+        // Debug: percentage of received tick packets the client drops before processing.
+        // Simulates an unreliable link on a lossless LAN, to exercise loss-recovery paths
+        // (spawn resend-until-acked, delta baseline fallback). 0 = off.
+        Register("Nebula/config/debug/simulate_incoming_tick_loss", 0, new(){
+            {"type", (int)Variant.Type.Int},
+            {"hint", (int)PropertyHint.Range},
+            {"hint_string", "0,100,1"},
         });
 
         // ── Pack ─────────────────────────────────────────────────────────

--- a/addons/Nebula/plugin.cfg
+++ b/addons/Nebula/plugin.cfg
@@ -3,5 +3,5 @@
 name="Nebula"
 description="Netcode Framework for Online Multiplayer Games"
 author="Heavenlode"
-version="1.6.1"
+version="1.7.0"
 script="Tools/Main.cs"


### PR DESCRIPTION
PerPeerState=true existed as a flag but never delivered a per-peer value over the wire. This makes it work, and moves the routing out of MarkDirty into a generated partial-property implementation.

Generator: per-peer properties are now emitted as partial properties whose setter routes through TryWritePerPeer before touching the base field. That sidesteps Fody's woven equality guard, which previously swallowed a write whenever a second peer was assigned a value some other peer already held — the original bug. Adds NEBULA006/007/008 for non-partial declarations, unsupported types, and Predicted/Interpolate combinations.

NetworkController: the ForPeer scope becomes thread-static and nests, so disposing restores the enclosing peer instead of clearing to default. Accessors cache their property index and NetScene root, keeping reads and writes allocation-free. IsNetScene and the scene-path lookup no longer cache an empty result from before instantiation completes; a constructor write on a per-peer property used to poison that cache and permanently demote a real NetScene.

Serializer: per-peer overrides now participate in initial sync and in visibility regain, since per-peer writes never enter the shared dirty mask. A base write broadcasts only to peers without an override. Per-peer dirty bits are cleared only for properties that actually shipped, so changes filtered by interest or budget retry next tick instead of being lost.

Adds unit coverage for scope nesting, per-peer round-trips, the equal-value write, and disconnect cleanup.