### PR TITLE
Fix nested NetScene despawn desync and expand the NetScene inspector

### DIFF
--- a/addons/Nebula/Core/NetRunner.cs
+++ b/addons/Nebula/Core/NetRunner.cs
@@ -447,6 +447,20 @@ namespace Nebula
         /// <summary>RNG for <see cref="SimulateIncomingTickLoss"/>. Debug-only, client-local.</summary>
         private static readonly RandomNumberGenerator _tickLossRng = new();
 
+        private static bool? _traceSpawnIds;
+        /// <summary>
+        /// Debug: arms the server-side spawn-contract breach detector in ExportState
+        /// ("a packet may carry data without spawn bytes only for a node whose id the
+        /// client provably has or gets") - the export-side counterpart of the client's
+        /// "[ImportState] Data for unknown node" tripwire, catching the leak at the source
+        /// with the node named. Enable via the <c>NEBULA_TRACE_SPAWN_IDS</c> environment
+        /// variable or <c>Nebula/config/debug/trace_spawn_ids</c>. Allocates log strings
+        /// when a breach fires; default off. Cached on first read.
+        /// </summary>
+        public static bool TraceSpawnIds =>
+            _traceSpawnIds ??= OS.HasEnvironment("NEBULA_TRACE_SPAWN_IDS")
+                || ProjectSettings.GetSetting("Nebula/config/debug/trace_spawn_ids", false).AsBool();
+
         private static bool? _packEnabled;
         /// <summary>
         /// When enabled via <c>Nebula/config/pack/enabled</c>, the server delta-compresses tick

--- a/addons/Nebula/Core/Serialization/BitConstants.cs
+++ b/addons/Nebula/Core/Serialization/BitConstants.cs
@@ -14,5 +14,13 @@ namespace Nebula.Serialization.Serializers
         /// and at runtime by NetPropertiesSerializer's constructor.
         /// </summary>
         public const int MaxSceneProperties = BitsInLong;
+
+        /// <summary>
+        /// Maximum static network nodes per NetScene, excluding the scene root (which is
+        /// implicitly static child id 0). Bound by the byte-wide static child id the
+        /// protocol generator assigns from 1 upward and that NetNode serializes on the
+        /// wire, so ids 1..255 are available.
+        /// </summary>
+        public const int MaxStaticNetNodes = 255;
     }
 }

--- a/addons/Nebula/Core/Serialization/Serializers/SpawnSerializer.cs
+++ b/addons/Nebula/Core/Serialization/Serializers/SpawnSerializer.cs
@@ -79,6 +79,70 @@ namespace Nebula.Serialization.Serializers
         }
 
         /// <summary>
+        /// Server-side despawn cascade over every nested NetScene under a despawning parent.
+        /// The client applies a despawn by freeing the parent's whole Godot subtree - nested
+        /// NetScenes included - so their per-peer server state must follow. Runs twice per
+        /// despawn, split by what is safe when:
+        ///
+        /// Send-time (freeIds: false), from ExportDespawn at each transition into despawn:
+        /// marks the children Despawned, which silences their props/resync exporters in the
+        /// same tick the parent's despawn marker first ships. ClientProcessTick's monotonic
+        /// tick guard means the client never applies a packet older than an applied despawn,
+        /// so no packet the client processes after freeing the subtree can carry child data -
+        /// the "props for an unknown node" window is unreachable through this path. Children
+        /// already running their own despawn (IsQueuedForDespawn, or Despawning for this
+        /// peer) are left alone: their exporters are already silenced by their own state, and
+        /// flipping them Despawned here would clear their pending despawn ack and let the
+        /// AreAllPeersDespawned sweep delete them before anything freed their per-peer local
+        /// ids - a permanent id leak against the per-peer node cap.
+        ///
+        /// Ack-time (freeIds: true), from Acknowledge's despawn branch: the ack proves the
+        /// client's subtree is gone, so now - and only now - the children's local ids are
+        /// freed. Freeing at send-time would let TryRegisterPeerNode hand an id to a new node
+        /// while the client's old node still occupies it; the old node's hasImported guard
+        /// would consume-and-skip the new node's spawn, silently binding the stream to the
+        /// wrong node. DeregisterPeerNode is idempotent, so the id sweep runs unconditionally
+        /// - most children were already marked Despawned by the send-time pass and the state
+        /// guard must not skip their deregistration.
+        ///
+        /// Recurses unconditionally: a grandchild can be spawned for the peer even when the
+        /// intermediate child is not (spawn tables collect the whole subtree,
+        /// interest-filtered per node).
+        /// </summary>
+        private static void CascadeDespawnToNestedChildren(WorldRunner currentWorld, NetPeer peer, UUID peerId, NetworkController parent, bool freeIds)
+        {
+            foreach (var child in parent.DynamicNetworkChildren)
+            {
+                var state = currentWorld.GetClientSpawnState(child.NetId, peer);
+                bool active = state != WorldRunner.ClientSpawnState.NotSpawned
+                    && state != WorldRunner.ClientSpawnState.Despawned;
+                bool ownDespawnInFlight = child.IsQueuedForDespawn
+                    || state == WorldRunner.ClientSpawnState.Despawning;
+
+                if (active && (freeIds || !ownDespawnInFlight))
+                {
+                    currentWorld.SetClientSpawnState(child.NetId, peer, WorldRunner.ClientSpawnState.Despawned);
+                    ResetPeerBaselines(child, peerId);
+
+                    if (child.NetNode?.Serializers != null && child.NetNode.Serializers.Length > 0
+                        && child.NetNode.Serializers[0] is SpawnSerializer childSpawn)
+                    {
+                        childSpawn.setupTicks.Remove(peerId);
+                        childSpawn.despawnTicks.Remove(peerId);
+                        childSpawn.lastSpawnSendTicks.Remove(peerId);
+                    }
+                }
+
+                if (freeIds)
+                {
+                    currentWorld.DeregisterPeerNode(child, peer);
+                }
+
+                CascadeDespawnToNestedChildren(currentWorld, peer, peerId, child, freeIds);
+            }
+        }
+
+        /// <summary>
         /// Tells every sibling serializer to forget its per-peer delta/ack baseline. Called at
         /// each NotSpawned -&gt; Spawning transition: the client is about to build this node from
         /// scratch (first spawn, or a respawn after interest loss destroyed its copy), so its
@@ -241,7 +305,7 @@ namespace Nebula.Serialization.Serializers
                 NetWriter.WriteUInt16(buffer, 0);
 
                 // Write nested NetScenes for root scene
-                ExportNestedScenes(currentWorld, peer, buffer);
+                ExportNestedScenes(currentWorld, peer, buffer, firstSend);
 
                 // Stamped every send (first and resends) - the upper bound of the ack window.
                 lastSpawnSendTicks[peerId] = currentWorld.CurrentTick;
@@ -266,7 +330,7 @@ namespace Nebula.Serialization.Serializers
             NetWriter.WriteByte(buffer, hasInputAuth);
 
             // Write nested NetScenes
-            ExportNestedScenes(currentWorld, peer, buffer);
+            ExportNestedScenes(currentWorld, peer, buffer, firstSend);
 
             // Stamped every send (first and resends) - the upper bound of the ack window.
             lastSpawnSendTicks[peerId] = currentWorld.CurrentTick;
@@ -294,8 +358,11 @@ namespace Nebula.Serialization.Serializers
             switch (spawnState)
             {
                 case WorldRunner.ClientSpawnState.NotSpawned:
-                    // Peer never received spawn, mark as despawned immediately (no data to send)
+                    // Peer never received spawn, mark as despawned immediately (no data to send).
+                    // Children can still be Spawning/Spawned via an ancestor's spawn table even
+                    // though this parent never spawned for the peer - silence them too.
                     currentWorld.SetClientSpawnState(netController.NetId, peer, WorldRunner.ClientSpawnState.Despawned);
+                    CascadeDespawnToNestedChildren(currentWorld, peer, peerId, netController, freeIds: false);
                     break;
 
                 case WorldRunner.ClientSpawnState.Spawning:
@@ -307,11 +374,15 @@ namespace Nebula.Serialization.Serializers
                         Debugger.Instance.Log(Debugger.DebugLevel.ERROR,
                             $"[SpawnSerializer] BUG: Node {netController.RawNode?.Name} (NetId={netController.NetId}) has state {spawnState} but isn't registered for peer. This indicates a state machine violation.");
                         currentWorld.SetClientSpawnState(netController.NetId, peer, WorldRunner.ClientSpawnState.Despawned);
+                        CascadeDespawnToNestedChildren(currentWorld, peer, peerId, netController, freeIds: false);
                         break;
                     }
-                    // Peer received (or is receiving) spawn, send despawn data
+                    // Peer received (or is receiving) spawn, send despawn data. Silence the
+                    // nested subtree in the same tick the marker first ships - this is what
+                    // closes the orphan-props window (see CascadeDespawnToNestedChildren).
                     WriteDespawnData(currentWorld, peer, peerId, localNodeId, buffer);
                     currentWorld.SetClientSpawnState(netController.NetId, peer, WorldRunner.ClientSpawnState.Despawning);
+                    CascadeDespawnToNestedChildren(currentWorld, peer, peerId, netController, freeIds: false);
                     break;
 
                 case WorldRunner.ClientSpawnState.Despawning:
@@ -355,21 +426,45 @@ namespace Nebula.Serialization.Serializers
         /// <summary>
         /// Exports all nested NetScenes in the subtree that the peer has interest in.
         /// </summary>
-        private void ExportNestedScenes(WorldRunner currentWorld, NetPeer peer, NetBuffer buffer)
+        private void ExportNestedScenes(WorldRunner currentWorld, NetPeer peer, NetBuffer buffer, bool firstSend)
         {
+            var peerUUID = NetRunner.Instance.GetPeerId(peer);
+
             // Collect nested NetScenes recursively (entire subtree)
             _nestedSceneBuffer.Clear();
-            CollectNestedNetScenesRecursive(netController, _nestedSceneBuffer);
+            CollectNestedNetScenesRecursive(currentWorld, peer, netController, _nestedSceneBuffer);
 
             // Filter to only include scenes the peer has interest in
             _interestedNestedBuffer.Clear();
             for (int i = 0; i < _nestedSceneBuffer.Count; i++)
             {
                 var nested = _nestedSceneBuffer[i];
-                if (nested.IsPeerInterested(peer))
+                if (!nested.IsPeerInterested(peer))
                 {
-                    _interestedNestedBuffer.Add(nested);
+                    continue;
                 }
+
+                // Table membership is FROZEN per peer while this spawn is in flight: on a
+                // resend, only children whose setupTick proves they rode an earlier send of
+                // this table may appear. A client that already imported this spawn consume-
+                // and-skips every resend (hasImported), so a child ADDED to the table
+                // mid-resend rides only payloads that client is guaranteed to discard - it
+                // can never learn the id, and the child's props exporter (switched on by the
+                // Spawning flip below) then feeds it props for an unknown node: tick-import
+                // abort, no acks, and the abort starves the very ack that would commit this
+                // parent and let the child spawn standalone. Deadlock until something else
+                // acks (or the peer times out). New children instead stay NotSpawned (props
+                // gated) and spawn via their own Export once this parent commits.
+                if (!firstSend
+                    && (nested.NetNode?.Serializers == null
+                        || nested.NetNode.Serializers.Length == 0
+                        || nested.NetNode.Serializers[0] is not SpawnSerializer memberCheck
+                        || !memberCheck.setupTicks.ContainsKey(peerUUID)))
+                {
+                    continue;
+                }
+
+                _interestedNestedBuffer.Add(nested);
             }
 
             NetWriter.WriteByte(buffer, (byte)_interestedNestedBuffer.Count);
@@ -389,8 +484,6 @@ namespace Nebula.Serialization.Serializers
                     NetWriter.WriteByte(buffer, 0);
                     continue;
                 }
-
-                var peerUUID = NetRunner.Instance.GetPeerId(peer);
 
                 // Nested scenes ride along in the parent's spawn data, so the client is about
                 // to build them from scratch - their per-peer baselines must reset like the
@@ -446,15 +539,25 @@ namespace Nebula.Serialization.Serializers
         private List<NetworkController> _interestedNestedBuffer = new(64);
 
         /// <summary>
-        /// Recursively collects all nested NetScenes in the subtree.
+        /// Recursively collects all nested NetScenes in the subtree, pruning any scene (and
+        /// everything under it) whose despawn is in flight for this peer. Re-including one
+        /// would flip its per-peer state back to Spawning mid-despawn (ExportNestedScenes
+        /// sets every included scene Spawning), reopening the props exporters the despawn
+        /// cascade just silenced. Stale Despawned with no despawn pending stays included -
+        /// that is the legitimate re-add path when a parent respawns.
         /// </summary>
-        private static void CollectNestedNetScenesRecursive(NetworkController parent, List<NetworkController> results)
+        private static void CollectNestedNetScenesRecursive(WorldRunner currentWorld, NetPeer peer, NetworkController parent, List<NetworkController> results)
         {
             foreach (var child in parent.DynamicNetworkChildren)
             {
+                if (child.IsQueuedForDespawn
+                    || currentWorld.GetClientSpawnState(child.NetId, peer) == WorldRunner.ClientSpawnState.Despawning)
+                {
+                    continue;
+                }
                 results.Add(child);
                 // Recurse into child's nested scenes
-                CollectNestedNetScenesRecursive(child, results);
+                CollectNestedNetScenesRecursive(currentWorld, peer, child, results);
             }
         }
 
@@ -476,6 +579,13 @@ namespace Nebula.Serialization.Serializers
 
                     // Free the local NetId for this peer so it can be reused
                     currentWorld.DeregisterPeerNode(netController, peer);
+
+                    // The acked despawn proves the client freed the whole subtree, so the
+                    // nested children's local ids are now safe to free for reuse. State and
+                    // baselines were already handled by the send-time pass in ExportDespawn;
+                    // this pass is the id sweep plus an idempotent backstop (see
+                    // CascadeDespawnToNestedChildren).
+                    CascadeDespawnToNestedChildren(currentWorld, peer, peerId, netController, freeIds: true);
 
                     // Check if all peers have acknowledged despawn.
                     // Only delete the node globally for a genuine global despawn (IsQueuedForDespawn).

--- a/addons/Nebula/Core/WorldRunner.cs
+++ b/addons/Nebula/Core/WorldRunner.cs
@@ -2441,9 +2441,42 @@ namespace Nebula
                     // Safety check: ensure node is registered before lookup
                     if (!PeerStates[peerId].WorldToPeerNodeMap.TryGetValue(netController.NetId, out var localNodeId))
                     {
-                        Log(Debugger.DebugLevel.ERROR, 
+                        Log(Debugger.DebugLevel.ERROR,
                             $"[ExportState] Node {netController.RawNode?.Name} (NetId={netController.NetId}) wrote data but isn't registered for peer {peerId}.");
                         continue;
+                    }
+
+                    // Spawn-contract breach detector: a packet may carry data WITHOUT the
+                    // spawn bit only for a node whose id the client provably has or gets:
+                    // either its spawn is committed (Spawned = the peer acked a packet that
+                    // contained the spawn data), or an ancestor's spawn is in flight and this
+                    // node rides that ancestor's nested table in this same packet (sound
+                    // because table membership is frozen per peer while a spawn is in flight -
+                    // see ExportNestedScenes). Anything else means the client may not know the
+                    // id, and then the payload length is unknowable client-side - the exact
+                    // precondition of the "[ImportState] Data for unknown node" abort.
+                    // Catching it at the SOURCE names the node and state that leaked.
+                    if (NetRunner.TraceSpawnIds && (serializersRun & 1) == 0)
+                    {
+                        var contractState = GetClientSpawnState(netController.NetId, peer);
+                        if (contractState != ClientSpawnState.Spawned)
+                        {
+                            bool ridesInFlightAncestorTable = false;
+                            for (var ancestor = netController.NetParent; ancestor != null; ancestor = ancestor.NetParent)
+                            {
+                                var ancestorState = GetClientSpawnState(ancestor.NetId, peer);
+                                if (ancestorState == ClientSpawnState.NotSpawned || ancestorState == ClientSpawnState.Spawning)
+                                {
+                                    ridesInFlightAncestorTable = contractState == ClientSpawnState.Spawning;
+                                    break;
+                                }
+                            }
+                            if (!ridesInFlightAncestorTable)
+                            {
+                                Log(Debugger.DebugLevel.ERROR,
+                                    $"[IdTrace] BREACH tick={CurrentTick} peer={peerId} id={localNodeId} NetId={netController.NetId} node={netController.RawNode?.Name} mask=0b{Convert.ToString(serializersRun, 2)} state={contractState}: exported without spawn data while spawn is not committed");
+                            }
+                        }
                     }
                     NodeIdUtils.SetBit(_updatedNodesMask, localNodeId);
                     _peerNodesSerializersList[localNodeId] = serializersRun;
@@ -2568,6 +2601,22 @@ namespace Nebula
 
                     if (netController == null)
                     {
+                        // Data for a node this client doesn't know. Legitimate only when the
+                        // payload carries the node's spawn data (serializer bit 0): the blank
+                        // placeholder below gets replaced by the real scene mid-import and the
+                        // stream stays aligned. Props-only data for an unknown id means state
+                        // desync - the blank node's zero-property serializer would consume the
+                        // wrong byte count and garble every node after it in this packet (the
+                        // "invalid baseline age N" bursts, N being a mask byte misread as an
+                        // age). The payload's length is unknowable here, so abort the tick:
+                        // it is not acked, and resend machinery re-delivers everything.
+                        if ((serializerMask & 1) == 0)
+                        {
+                            Log(Debugger.DebugLevel.ERROR,
+                                $"[ImportState] tick={CurrentTick} Data for unknown node {localNodeId} without spawn data (mask=0b{Convert.ToString(serializerMask, 2)}). Aborting tick import.");
+                            return false;
+                        }
+
                         var blankScene = new NetNode3D();
                         blankScene.Network.NetId = AllocateNetId(localNodeId);
                         blankScene.Network.CurrentWorld = this; // Set CurrentWorld so handleDespawn uses QueueDespawn instead of immediate QueueFree
@@ -2649,6 +2698,31 @@ namespace Nebula
             }
 
             return !anyDiscarded;
+        }
+
+        /// <summary>
+        /// Client-side: deregisters a despawned node AND its nested NetScene subtree.
+        /// QueueFree takes the whole Godot subtree with it, nested NetScenes included - but
+        /// nothing despawns those children individually. A stale NetScenes entry for a
+        /// freed child both routes incoming data into a disposed node (aborting the tick
+        /// import) and blocks re-registration of the authored replacement when the parent
+        /// later respawns (client TryRegisterPeerNode refuses ids that appear registered).
+        /// </summary>
+        private void DeregisterDespawnedSubtree(NetworkController netController)
+        {
+            // Safe to iterate directly: nothing below mutates DynamicNetworkChildren
+            // (deregistration and deletion-queueing never touch NetParentId).
+            foreach (var child in netController.DynamicNetworkChildren)
+            {
+                DeregisterDespawnedSubtree(child);
+            }
+            DeregisterPeerNode(netController);
+            // A child that already went through its own despawn may be freed by now -
+            // deregistering is still required, but don't touch the disposed node.
+            if (IsInstanceValid(netController.RawNode))
+            {
+                netController.QueueNodeForDeletion();
+            }
         }
 
         // Reusable list for objects that had all data acked (avoids modifying HashSet during iteration)
@@ -2758,7 +2832,12 @@ namespace Nebula
 
         public void ClientProcessTick(int incomingTick, byte[] stateBytes)
         {
-            // Skip old/duplicate ticks
+            // Skip old/duplicate ticks. Load-bearing beyond dedup: the server stops
+            // exporting a despawned parent's nested children from the tick the despawn
+            // marker first ships (SpawnSerializer's send-time cascade), which only closes
+            // the orphan-props window if a packet older than an applied despawn is never
+            // applied after it. The tick channel's ENet flag is Unsequenced, so this
+            // guard - not the transport - is what enforces send-order apply.
             if (incomingTick <= CurrentTick)
             {
                 return;
@@ -2892,8 +2971,7 @@ namespace Nebula
             // ============================================================
             foreach (var netController in QueueDespawnedNodes)
             {
-                DeregisterPeerNode(netController);
-                netController.QueueNodeForDeletion();
+                DeregisterDespawnedSubtree(netController);
             }
             QueueDespawnedNodes.Clear();
 

--- a/addons/Nebula/Tools/Inspector/NetSceneInspector.cs
+++ b/addons/Nebula/Tools/Inspector/NetSceneInspector.cs
@@ -1,6 +1,7 @@
 #if TOOLS
 using Godot;
 using Nebula.Serialization;
+using Nebula.Serialization.Serializers;
 using System.Linq;
 
 namespace Nebula.Internal.Editor
@@ -26,7 +27,7 @@ namespace Nebula.Internal.Editor
 
         public override void _ParseBegin(GodotObject obj)
         {
-            if (!ResolveTarget(obj, out _, out string scenePath, out string nodePath))
+            if (!ResolveTarget(obj, out Node node, out string scenePath, out string nodePath))
                 return;
 
             inspectorScene ??= GD.Load<PackedScene>("res://addons/Nebula/Tools/Inspector/inspect_network_scene.tscn");
@@ -37,6 +38,11 @@ namespace Nebula.Internal.Editor
             inspector.Call("set_title", isNetScene ? "NetScene" : "NetNode");
             inspector.Call("set_path", nodePath);
 
+            if (isNetScene)
+                PopulateSceneOverview(inspector, node, scenePath);
+            else
+                PopulateNetSceneLink(inspector, scenePath);
+
             foreach (var property in Protocol.ListProperties(scenePath, nodePath))
                 inspector.Call("add_property", property.Name, property.VariantType.ToString());
 
@@ -45,6 +51,48 @@ namespace Nebula.Internal.Editor
                 inspector.Call("add_function", function.Name,
                     $"({string.Join(", ", function.Arguments.Select(a => a.VariantType.ToString()))})");
             }
+        }
+
+        /// <summary>
+        /// NetScene-only: the two per-scene protocol budgets plus the list of static
+        /// NetNodes rolled up into this scene's network state.
+        ///
+        /// <para>The property count is scene-wide (static children and nested
+        /// non-NetScene instances roll up into the root's serializer), which is the
+        /// number the 64-property limit applies to — not the root's own count shown in
+        /// the Properties row.</para>
+        /// </summary>
+        private static void PopulateSceneOverview(Control inspector, Node node, string scenePath)
+        {
+            var staticNodes = Protocol.ListStaticNodes(scenePath);
+            inspector.Call("set_scene_stats",
+                Protocol.GetPropertyCount(scenePath), BitConstants.MaxSceneProperties,
+                staticNodes.Count, BitConstants.MaxStaticNetNodes);
+
+            // Only the edited scene's own root has its static children in the scene
+            // tree dock: the children of a NetScene *instanced* into the edited scene
+            // are not editable there, so there is nothing to select.
+            bool childrenSelectable = node == EditorInterface.Singleton.GetEditedSceneRoot();
+
+            foreach (var staticNodePath in staticNodes)
+            {
+                int propertyCount = Protocol.ListProperties(scenePath, staticNodePath).Count;
+                bool selectable = childrenSelectable && node.GetNodeOrNull(staticNodePath) is not null;
+                inspector.Call("add_static_node", staticNodePath, propertyCount, selectable);
+            }
+        }
+
+        /// <summary>
+        /// NetNode-only: a link up to the NetScene that owns this node's network state.
+        /// <see cref="ResolveTarget"/> only resolves a static child against the edited
+        /// scene root, so that root is always the owning NetScene.
+        /// </summary>
+        private static void PopulateNetSceneLink(Control inspector, string scenePath)
+        {
+            var root = EditorInterface.Singleton.GetEditedSceneRoot();
+            if (root is null)
+                return;
+            inspector.Call("set_net_scene_link", root.Name.ToString(), scenePath);
         }
 
         /// <summary>

--- a/addons/Nebula/Tools/Inspector/inspect_network_scene.gd
+++ b/addons/Nebula/Tools/Inspector/inspect_network_scene.gd
@@ -7,20 +7,31 @@ class_name InspectNetScene extends Accordion
 @export var functions_parent: Accordion
 @export var functions_container: VBoxContainer
 
-@export var children_parent: Accordion
-@export var children_container: VBoxContainer
+@export var static_nodes_parent: Accordion
+@export var static_nodes_container: VBoxContainer
 
 @export var title_label: Label
 @export var path_label: Label
 @export var property_count_label: Label
 @export var function_count_label: Label
 
+## Per-scene budget rows: hidden unless set_scene_stats() is called (i.e. only on
+## a NetScene, since both limits are per-NetScene).
+@export var scene_property_row: Control
+@export var scene_property_label: Label
+@export var static_node_count_row: Control
+@export var static_node_count_label: Label
+
+## Shown on a static NetNode instead: a link up to the NetScene that owns it.
+@export var net_scene_link_row: Control
+@export var net_scene_link_button: Button
+
 var function_row_scene = preload("res://addons/Nebula/Tools/Inspector/property_row.tscn")
 var property_row_scene = preload("res://addons/Nebula/Tools/Inspector/property_row.tscn")
-var net_node_details_scene = load("res://addons/Nebula/Tools/Inspector/net_node_details.tscn")
 
-var child_details: Array[InspectNetScene] = []
 var properties: Dictionary = {}
+var _property_count := 0
+var _function_count := 0
 
 func _ready() -> void:
     _apply_bold_title()
@@ -53,20 +64,14 @@ func set_title(title: String) -> void:
         return
     title_label.text = title
 
-func set_path(path: String, child_detail_id: int = -1) -> void:
-    if child_detail_id != -1:
-        child_details[child_detail_id].set_path(path)
-        return
+func set_path(path: String) -> void:
     if path_label == null:
         return
     path_label.text = path
 
-func add_property(name: String, value: String, child_detail_id: int = -1) -> void:
-    property_count_label.text = str(int(property_count_label.text) + 1)
-
-    if child_detail_id != -1:
-        child_details[child_detail_id].add_property(name, value)
-        return
+func add_property(name: String, value: String) -> void:
+    _property_count += 1
+    property_count_label.text = str(_property_count)
 
     var property_row = property_row_scene.instantiate()
     property_row.get_node("Name").text = name
@@ -74,19 +79,18 @@ func add_property(name: String, value: String, child_detail_id: int = -1) -> voi
     properties_parent.visible = true
     properties_container.add_child(property_row)
 
-    var property_key = name + ":" + str(child_detail_id)
-    properties[property_key] = property_row
+    properties[name] = property_row
 
-func set_property(name: String, value: String, child_detail_id: int = -1) -> void:
-    var property_key = name + ":" + str(child_detail_id)
-    properties[property_key].get_node("Value").text = value
-
-func add_function(name: String, type: String, child_detail_id: int = -1) -> void:
-    function_count_label.text = str(int(function_count_label.text) + 1)
-
-    if child_detail_id != -1:
-        child_details[child_detail_id].add_function(name, type)
+func set_property(name: String, value: String) -> void:
+    # Guarded: the live debugger streams whatever properties a node reports, which
+    # need not match the set this panel was built from.
+    if not properties.has(name):
         return
+    properties[name].get_node("Value").text = value
+
+func add_function(name: String, type: String) -> void:
+    _function_count += 1
+    function_count_label.text = str(_function_count)
 
     var function_row = function_row_scene.instantiate()
     function_row.get_node("Name").text = name
@@ -94,14 +98,121 @@ func add_function(name: String, type: String, child_detail_id: int = -1) -> void
     functions_container.add_child(function_row)
     functions_parent.visible = true
 
-func add_child_detail(name: String) -> int:
-    var child_detail = net_node_details_scene.instantiate()
-    child_detail.get_node("Button").text = child_detail.get_node("Button").text + " " + name
-    child_details.append(child_detail)
-    children_container.add_child(child_detail)
 
-    # split the name on slashes and use the last part as the title
-    var title = name.split("/")[-1]
-    child_detail.set_title(title)
-    children_parent.visible = true
-    return child_details.size() - 1
+## Reports the two per-NetScene protocol budgets, so the headroom is visible
+## before a build fails on it: properties are bound by the 64-bit dirty mask
+## (NEBULA004) and static NetNodes by the byte-wide static child id.
+##
+## The property figure is scene-wide — it includes everything rolled up from
+## static children and nested non-NetScene instances — which is deliberately a
+## different number from the "Properties" row above (that one is just this node's).
+func set_scene_stats(scene_properties: int, max_properties: int, static_nodes: int, max_static_nodes: int) -> void:
+    var remaining := max_properties - scene_properties
+    scene_property_label.text = "%d / %d  (%d left)" % [scene_properties, max_properties, remaining]
+    _tint_budget(scene_property_label, scene_properties, max_properties)
+    scene_property_row.visible = true
+
+    static_node_count_label.text = "%d / %d  (%d left)" % [static_nodes, max_static_nodes, max_static_nodes - static_nodes]
+    _tint_budget(static_node_count_label, static_nodes, max_static_nodes)
+    static_node_count_row.visible = true
+
+
+## One row of the "Static NetNodes" list. Selectable rows are buttons that
+## reveal the node in the scene tree; a node that isn't reachable from the scene
+## being edited (a NetScene instanced into another scene keeps its children
+## non-editable) is shown as a plain label instead of a button that would do
+## nothing.
+func add_static_node(node_path: String, property_count: int, selectable: bool) -> void:
+    var row := HBoxContainer.new()
+
+    if selectable:
+        var button := Button.new()
+        button.text = node_path
+        button.flat = true
+        button.alignment = HORIZONTAL_ALIGNMENT_LEFT
+        button.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+        button.tooltip_text = "Select \"%s\" in the scene tree." % node_path
+        button.pressed.connect(_select_in_scene_tree.bind(node_path))
+        _tint_link(button)
+        row.add_child(button)
+    else:
+        var label := Label.new()
+        label.text = node_path
+        label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+        label.tooltip_text = "Not part of the scene being edited — open the NetScene itself to select this node."
+        label.modulate = Color(1, 1, 1, 0.6)
+        row.add_child(label)
+
+    var count := Label.new()
+    count.text = "1 prop" if property_count == 1 else "%d props" % property_count
+    count.modulate = Color(1, 1, 1, 0.6)
+    row.add_child(count)
+
+    static_nodes_container.add_child(row)
+    static_nodes_parent.visible = true
+
+
+## Links a static NetNode back to the NetScene that owns its network state — the
+## scene whose 64-property / 255-node budgets this node spends, and the node the
+## serializer actually lives on.
+func set_net_scene_link(scene_root_name: String, scene_path: String) -> void:
+    net_scene_link_button.text = scene_root_name
+    net_scene_link_button.tooltip_text = "Select the owning NetScene root in the scene tree.\n%s" % scene_path
+    _tint_link(net_scene_link_button)
+    net_scene_link_button.pressed.connect(_select_in_scene_tree.bind("."))
+    net_scene_link_row.visible = true
+
+
+## Reveals a node of the edited scene in the scene tree dock (and the inspector).
+## Paths come from the generated protocol, so they describe the last successful
+## build — a node renamed since then no longer resolves.
+func _select_in_scene_tree(node_path: String) -> void:
+    if not Engine.is_editor_hint():
+        return
+
+    var root := EditorInterface.get_edited_scene_root()
+    if root == null:
+        return
+
+    var target: Node = root if node_path == "." else root.get_node_or_null(node_path)
+    if target == null:
+        push_warning("Nebula: \"%s\" is not in the edited scene. The protocol reflects the last C# build — rebuild to refresh it." % node_path)
+        return
+
+    var selection := EditorInterface.get_selection()
+    selection.clear()
+    selection.add_node(target)
+    EditorInterface.edit_node(target)
+
+
+## Warns as a budget fills up, so a scene near a hard protocol limit reads as
+## such without the developer doing the arithmetic.
+func _tint_budget(label: Label, used: int, maximum: int) -> void:
+    if not Engine.is_editor_hint():
+        return
+    var editor_theme := EditorInterface.get_editor_theme()
+    if editor_theme == null:
+        return
+
+    var color_name := ""
+    if used >= maximum:
+        color_name = "error_color"
+    elif used >= maximum * 0.85:
+        color_name = "warning_color"
+    if color_name.is_empty():
+        return
+    if editor_theme.has_color(color_name, "Editor"):
+        label.add_theme_color_override("font_color", editor_theme.get_color(color_name, "Editor"))
+
+
+## Paints a clickable row in the editor's accent color so it reads as a link.
+func _tint_link(button: Button) -> void:
+    if not Engine.is_editor_hint():
+        return
+    var editor_theme := EditorInterface.get_editor_theme()
+    if editor_theme == null or not editor_theme.has_color("accent_color", "Editor"):
+        return
+    var accent := editor_theme.get_color("accent_color", "Editor")
+    button.add_theme_color_override("font_color", accent)
+    button.add_theme_color_override("font_hover_color", accent.lightened(0.2))
+    button.add_theme_color_override("font_pressed_color", accent)

--- a/addons/Nebula/Tools/Inspector/inspect_network_scene.tscn
+++ b/addons/Nebula/Tools/Inspector/inspect_network_scene.tscn
@@ -9,7 +9,7 @@ bg_color = Color(0.31175, 0.1935, 0.43, 1)
 corner_radius_top_left = 2
 corner_radius_top_right = 2
 
-[node name="VBoxContainer" type="VBoxContainer" node_paths=PackedStringArray("properties_parent", "properties_container", "functions_parent", "functions_container", "children_parent", "children_container", "title_label", "property_count_label", "function_count_label")]
+[node name="VBoxContainer" type="VBoxContainer" node_paths=PackedStringArray("properties_parent", "properties_container", "functions_parent", "functions_container", "static_nodes_parent", "static_nodes_container", "title_label", "property_count_label", "function_count_label", "scene_property_row", "scene_property_label", "static_node_count_row", "static_node_count_label", "net_scene_link_row", "net_scene_link_button")]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -21,11 +21,17 @@ properties_parent = NodePath("Items/Properties")
 properties_container = NodePath("Items/Properties/Container/Container")
 functions_parent = NodePath("Items/Functions")
 functions_container = NodePath("Items/Functions/Container/Container")
-children_parent = NodePath("Items/Children")
-children_container = NodePath("Items/Children/Container/Container")
+static_nodes_parent = NodePath("Items/StaticNodes")
+static_nodes_container = NodePath("Items/StaticNodes/Container/Container")
 title_label = NodePath("Heading/Label")
 property_count_label = NodePath("Items/PropertyCount/Value")
 function_count_label = NodePath("Items/FunctionCount/Value")
+scene_property_row = NodePath("Items/SceneProperties")
+scene_property_label = NodePath("Items/SceneProperties/Value")
+static_node_count_row = NodePath("Items/StaticNodeCount")
+static_node_count_label = NodePath("Items/StaticNodeCount/Value")
+net_scene_link_row = NodePath("Items/NetSceneLink")
+net_scene_link_button = NodePath("Items/NetSceneLink/Button")
 
 [node name="Heading" type="Panel" parent="."]
 custom_minimum_size = Vector2(0, 57)
@@ -53,6 +59,22 @@ vertical_alignment = 1
 layout_mode = 2
 theme_override_constants/separation = 0
 
+[node name="NetSceneLink" type="HBoxContainer" parent="Items"]
+visible = false
+layout_mode = 2
+
+[node name="Name" type="Label" parent="Items/NetSceneLink"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "NetScene"
+vertical_alignment = 1
+
+[node name="Button" type="Button" parent="Items/NetSceneLink"]
+layout_mode = 2
+size_flags_horizontal = 3
+flat = true
+alignment = 0
+
 [node name="PropertyCount" parent="Items" instance=ExtResource("3_gp7ba")]
 layout_mode = 2
 
@@ -71,6 +93,26 @@ text = "Functions"
 [node name="Value" parent="Items/FunctionCount" index="1"]
 text = "0"
 
+[node name="SceneProperties" parent="Items" instance=ExtResource("3_gp7ba")]
+visible = false
+layout_mode = 2
+
+[node name="Name" parent="Items/SceneProperties" index="0"]
+text = "Scene properties"
+
+[node name="Value" parent="Items/SceneProperties" index="1"]
+text = "0 / 64"
+
+[node name="StaticNodeCount" parent="Items" instance=ExtResource("3_gp7ba")]
+visible = false
+layout_mode = 2
+
+[node name="Name" parent="Items/StaticNodeCount" index="0"]
+text = "Static NetNodes"
+
+[node name="Value" parent="Items/StaticNodeCount" index="1"]
+text = "0 / 255"
+
 [node name="Properties" parent="Items" instance=ExtResource("2_w37so")]
 visible = false
 layout_mode = 2
@@ -82,15 +124,17 @@ layout_mode = 2
 [node name="Button" parent="Items/Functions" index="0"]
 text = "▶ Functions"
 
-[node name="Children" parent="Items" instance=ExtResource("2_w37so")]
+[node name="StaticNodes" parent="Items" instance=ExtResource("2_w37so")]
 visible = false
 layout_mode = 2
 
-[node name="Button" parent="Items/Children" index="0"]
-text = "▶ Children"
+[node name="Button" parent="Items/StaticNodes" index="0"]
+text = "▶ Static NetNodes"
 
 [editable path="Items/PropertyCount"]
 [editable path="Items/FunctionCount"]
+[editable path="Items/SceneProperties"]
+[editable path="Items/StaticNodeCount"]
 [editable path="Items/Properties"]
 [editable path="Items/Functions"]
-[editable path="Items/Children"]
+[editable path="Items/StaticNodes"]

--- a/addons/Nebula/plugin.cfg
+++ b/addons/Nebula/plugin.cfg
@@ -3,5 +3,5 @@
 name="Nebula"
 description="Netcode Framework for Online Multiplayer Games"
 author="Heavenlode"
-version="1.7.0"
+version="1.7.1"
 script="Tools/Main.cs"


### PR DESCRIPTION
Despawning a parent NetScene left its nested children half-alive on both sides of the wire, producing "invalid baseline age N" bursts and stuck streams:

- SpawnSerializer now cascades a despawn over the whole nested subtree. The send-time pass (at each transition into despawn) marks children Despawned so their props/resync exporters go quiet in the same tick the parent's despawn marker first ships; the ack-time pass frees their per-peer local ids only once the ack proves the client's subtree is gone. Children running their own despawn are skipped at send-time so their pending ack isn't cleared out from under them.
- Nested scene collection prunes any child whose despawn is in flight, which would otherwise be flipped back to Spawning mid-despawn.
- Nested table membership is frozen per peer while a spawn is in flight. A child added mid-resend rides only payloads the client discards, so it never learns the id, and its props then starve the ack that would let it spawn standalone.
- Client-side, freeing a despawned node now deregisters its nested subtree too. QueueFree takes the children with it, but nothing deregistered them, so stale entries routed data into disposed nodes and blocked re-registration on respawn.
- ImportState aborts the tick on props-only data for an unknown id instead of building a blank placeholder that misreads the rest of the packet.
- NetRunner.TraceSpawnIds (NEBULA_TRACE_SPAWN_IDS / Nebula/config/debug/trace_spawn_ids) arms an export-side breach detector that names the leaking node at the source.

Inspector: NetScenes now show their scene-wide property and static-node budgets (tinted as they fill) plus the list of static NetNodes with click-to-select; NetNodes get a link up to the owning NetScene. Drops the unused child-detail recursion in favor of that flat list, and adds BitConstants.MaxStaticNetNodes for the 255-node bound.