### PR TITLE
Async world creation, optional per-world threading, bots and metrics

### DIFF
--- a/addons/Nebula/Core/Authentication/DefaultAuthenticator.cs
+++ b/addons/Nebula/Core/Authentication/DefaultAuthenticator.cs
@@ -1,5 +1,4 @@
-using System;
-using System.Linq;
+using Nebula.Utility.Tools;
 
 namespace Nebula.Authentication {
   public class DefaultAuthenticator : IAuthenticator {
@@ -9,7 +8,22 @@ namespace Nebula.Authentication {
     }
 
     public void ServerAuthenticateClient(NetPeer peer) {
-      NetRunner.Instance.PeerJoinWorld(peer, NetRunner.Instance.Worlds.Values.First().WorldId, NetRunner.Instance.Peers.Count.ToString());
+      // FirstLiveWorld rather than Worlds.Values.First(): the registry holds a world from the
+      // moment its creation starts, so it can contain one that is still generating -- and, while
+      // the very first world is being built, can be empty, which threw "Sequence contains no
+      // elements" straight out of the ENet pump.
+      //
+      // NetRunner holds peers that arrive before any world is ready and re-authenticates them once
+      // one goes Live, so reaching here with no live world means something admitted this peer out
+      // of order rather than that the server is merely still starting up.
+      var world = NetRunner.Instance.FirstLiveWorld();
+      if (world == null) {
+        Debugger.Instance.Log(Debugger.DebugLevel.ERROR,
+          $"DefaultAuthenticator: no live world to admit peer {peer.ID} into.");
+        return;
+      }
+
+      NetRunner.Instance.PeerJoinWorld(peer, world.WorldId, NetRunner.Instance.Peers.Count.ToString());
     }
   }
 }

--- a/addons/Nebula/Core/Bots/BotBehavior.cs
+++ b/addons/Nebula/Core/Bots/BotBehavior.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Godot;
+
+namespace Nebula.Bots
+{
+    /// <summary>
+    /// Base class for a scripted bot client. Games subclass this outside Nebula and point a
+    /// play configuration at the script; <see cref="BotRunner"/> instantiates one per bot
+    /// process and drives it.
+    ///
+    /// <para>A bot is a <em>real</em> client — full spawn stream, prediction, reconciliation.
+    /// The only difference from a human is where its input comes from. The intended way to
+    /// act is <see cref="Godot.Input.ActionPress(StringName, float)"/> /
+    /// <see cref="Godot.Input.ActionRelease(StringName)"/> from <see cref="NetworkProcess"/>:
+    /// the game's own input-sampling code then reads those actions exactly as it reads a
+    /// keyboard, so nothing downstream can drift from the path a player takes. (Verified to
+    /// work under <c>--headless</c>; the action state is engine-internal, not display-server
+    /// backed.)</para>
+    ///
+    /// <para>Behaviors that need to do more than move — calling a NetFunction, say — can reach
+    /// their own nodes through <see cref="OwnedNodes"/>.</para>
+    /// </summary>
+    public abstract partial class BotBehavior : Node
+    {
+        /// <summary>
+        /// Zero-based index of this bot within the launched set, from <c>--botId</c>. Stable for
+        /// the life of the process, so it is safe to derive an identity (account, spawn point,
+        /// role) from it.
+        /// </summary>
+        public int BotId { get; internal set; }
+
+        /// <summary>
+        /// The client's world. Null until <see cref="NetRunner.StartClient"/> has run, so
+        /// <see cref="BotStartup"/> must not assume it.
+        /// </summary>
+        public WorldRunner World => WorldRunner.CurrentWorld;
+
+        /// <summary>
+        /// The nodes this bot owns — its character, its ship. Empty until the server has spawned
+        /// them and ownership has replicated, which is what <see cref="BotReady"/> waits for.
+        /// </summary>
+        public IReadOnlyList<NetworkController> OwnedNodes =>
+            World?.OwnedNodes ?? (IReadOnlyList<NetworkController>)Array.Empty<NetworkController>();
+
+        /// <summary>
+        /// Runs before the client connects, and is awaited — the game's entry flow can block on
+        /// <see cref="BotRunner.StartupTask"/> so a bot establishes its session before anything
+        /// tries to use it. Override to log in, pick a character, or otherwise assume an identity.
+        /// </summary>
+        public virtual Task BotStartup() => Task.CompletedTask;
+
+        /// <summary>
+        /// Runs once, on the first tick where <see cref="OwnedNodes"/> is non-empty. This is the
+        /// earliest point at which the bot has a body to act on.
+        /// </summary>
+        public virtual void BotReady() { }
+
+        /// <summary>
+        /// Runs once per network tick, before the prediction pass, which is where a human's input
+        /// would have been sampled. Press and release input actions here.
+        /// </summary>
+        /// <param name="tick">The client's confirmed tick.</param>
+        /// <param name="delta">Seconds since the previous network tick.</param>
+        public abstract void NetworkProcess(Tick tick, double delta);
+    }
+}

--- a/addons/Nebula/Core/Bots/BotBehavior.cs.uid
+++ b/addons/Nebula/Core/Bots/BotBehavior.cs.uid
@@ -1,0 +1,1 @@
+uid://csludbgd733w

--- a/addons/Nebula/Core/Bots/BotRunner.cs
+++ b/addons/Nebula/Core/Bots/BotRunner.cs
@@ -1,0 +1,259 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading.Tasks;
+using Godot;
+using Nebula.Utility.Tools;
+
+namespace Nebula.Bots
+{
+    /// <summary>
+    /// Process-wide owner of this instance's <see cref="BotBehavior"/>. Created by
+    /// <see cref="NetRunner"/> only when the process was launched with <c>--bot</c>, so a normal
+    /// client or server never carries any of this.
+    ///
+    /// <para>Command line: <c>--bot --botId=N --botBehavior=TypeName</c>. The behavior is resolved
+    /// by type name rather than by script path — a C# script resource cannot be instantiated
+    /// through the Godot script API the way a GDScript one can, and reflection over the loaded
+    /// assemblies is both reliable and what lets the editor offer a dropdown of the behaviors that
+    /// actually exist.</para>
+    /// </summary>
+    public partial class BotRunner : Node
+    {
+        public const string BotArg = "--bot";
+        public const string BotIdArg = "--botId=";
+        public const string BotBehaviorArg = "--botBehavior=";
+
+        public static BotRunner Instance { get; private set; }
+
+        /// <summary>True in a process launched with <c>--bot</c>.</summary>
+        public static bool IsBot => Instance != null;
+
+        public int BotId { get; private set; }
+        public BotBehavior Behavior { get; private set; }
+
+        /// <summary>
+        /// Completes once <see cref="BotBehavior.BotStartup"/> has finished. A game's entry flow
+        /// should await this before deciding how to proceed, so the bot has established its
+        /// identity first. Always non-null; a bot with no resolvable behavior completes
+        /// immediately rather than hanging the launch.
+        /// </summary>
+        public Task StartupTask { get; private set; } = Task.CompletedTask;
+
+        private WorldRunner _subscribedWorld;
+        private bool _botReadyFired;
+        private ulong _lastTickUsec;
+
+        /// <summary>
+        /// Called from <see cref="NetRunner"/>'s _Ready. Returns null (and adds nothing to the
+        /// tree) unless this process is a bot.
+        /// </summary>
+        internal static BotRunner TryCreate(Node parent)
+        {
+            string behaviorName = null;
+            int botId = 0;
+            bool isBot = false;
+
+            foreach (var argument in OS.GetCmdlineArgs())
+            {
+                if (argument == BotArg)
+                    isBot = true;
+                else if (argument.StartsWith(BotIdArg))
+                    int.TryParse(argument.Substring(BotIdArg.Length), out botId);
+                else if (argument.StartsWith(BotBehaviorArg))
+                    behaviorName = argument.Substring(BotBehaviorArg.Length);
+            }
+
+            if (!isBot)
+                return null;
+
+            var runner = new BotRunner
+            {
+                Name = "BotRunner",
+                BotId = botId,
+                _behaviorName = behaviorName,
+            };
+            parent.AddChild(runner);
+            return runner;
+        }
+
+        private string _behaviorName;
+
+        public override void _EnterTree()
+        {
+            Instance ??= this;
+        }
+
+        public override void _Ready()
+        {
+            if (string.IsNullOrEmpty(_behaviorName))
+            {
+                Debugger.Instance.Log(Debugger.DebugLevel.ERROR,
+                    $"[Bot {BotId}] launched with {BotArg} but no {BotBehaviorArg}<TypeName>; the bot will connect and then do nothing.");
+                return;
+            }
+
+            var type = ResolveBehaviorType(_behaviorName);
+            if (type == null)
+            {
+                Debugger.Instance.Log(Debugger.DebugLevel.ERROR,
+                    $"[Bot {BotId}] no non-abstract {nameof(BotBehavior)} subclass named '{_behaviorName}' in the loaded assemblies.");
+                return;
+            }
+
+            try
+            {
+                Behavior = (BotBehavior)Activator.CreateInstance(type);
+            }
+            catch (Exception ex)
+            {
+                Debugger.Instance.Log(Debugger.DebugLevel.ERROR,
+                    $"[Bot {BotId}] could not construct '{type.FullName}': {ex.Message}. It needs a parameterless constructor.");
+                return;
+            }
+
+            Behavior.BotId = BotId;
+            Behavior.Name = type.Name;
+            AddChild(Behavior);
+
+            Debugger.Instance.Log($"[Bot {BotId}] behavior '{type.FullName}' ready; running startup.");
+            StartupTask = RunStartup();
+        }
+
+        private async Task RunStartup()
+        {
+            try
+            {
+                // Yield a frame before running the behavior. This runs from NetRunner's _Ready, so
+                // autoloads declared after it have not initialized yet — and a behavior that
+                // establishes a session inevitably touches one of them. Assigning StartupTask
+                // synchronously (above) while deferring the body is what lets the game's entry
+                // scene await a task that is already pending by the time it looks.
+                await ToSignal(GetTree(), SceneTree.SignalName.ProcessFrame);
+                await Behavior.BotStartup();
+            }
+            catch (Exception ex)
+            {
+                // Swallowing here is deliberate: a failed startup should leave the bot inert and
+                // loudly logged, not tear down a play session that may have other instances in it.
+                Debugger.Instance.Log(Debugger.DebugLevel.ERROR,
+                    $"[Bot {BotId}] BotStartup failed: {ex.Message}\n{ex.StackTrace}");
+            }
+        }
+
+        /// <summary>
+        /// Finds a concrete <see cref="BotBehavior"/> subclass by full name or short name. Matching
+        /// on either means a configuration can hold the readable short name while a project with
+        /// colliding names can still disambiguate with the full one.
+        /// </summary>
+        public static Type ResolveBehaviorType(string name)
+        {
+            Type shortNameMatch = null;
+            foreach (var candidate in DiscoverBehaviorTypes())
+            {
+                if (candidate.FullName == name)
+                    return candidate;
+                if (candidate.Name == name)
+                    shortNameMatch = candidate;
+            }
+            return shortNameMatch;
+        }
+
+        /// <summary>
+        /// Every concrete <see cref="BotBehavior"/> subclass in the loaded assemblies. Used both to
+        /// resolve a configured name and to populate the editor's behavior dropdown.
+        /// </summary>
+        public static List<Type> DiscoverBehaviorTypes()
+        {
+            var found = new List<Type>();
+            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                Type[] types;
+                try
+                {
+                    types = assembly.GetTypes();
+                }
+                catch (ReflectionTypeLoadException ex)
+                {
+                    // A partially-loadable assembly still yields the types that did load, which is
+                    // enough — and is better than letting one bad reference hide every behavior.
+                    types = ex.Types;
+                }
+                catch (Exception)
+                {
+                    continue;
+                }
+
+                foreach (var type in types)
+                {
+                    if (type == null || type.IsAbstract) continue;
+                    if (!typeof(BotBehavior).IsAssignableFrom(type)) continue;
+                    found.Add(type);
+                }
+            }
+            return found;
+        }
+
+        public override void _PhysicsProcess(double delta)
+        {
+            if (Behavior == null) return;
+
+            // The client's world does not exist until StartClient has run, and is replaced by
+            // nothing afterwards, so a one-time subscribe on first sight is enough.
+            var world = WorldRunner.CurrentWorld;
+            if (world != null && world != _subscribedWorld)
+            {
+                if (_subscribedWorld != null)
+                    _subscribedWorld.OnClientNetworkTick -= HandleClientTick;
+                world.OnClientNetworkTick += HandleClientTick;
+                _subscribedWorld = world;
+                _lastTickUsec = Time.GetTicksUsec();
+            }
+        }
+
+        private void HandleClientTick(Tick tick)
+        {
+            if (Behavior == null) return;
+
+            ulong now = Time.GetTicksUsec();
+            double tickDelta = (now - _lastTickUsec) / 1_000_000.0;
+            _lastTickUsec = now;
+
+            if (!_botReadyFired && Behavior.OwnedNodes.Count > 0)
+            {
+                _botReadyFired = true;
+                try
+                {
+                    Behavior.BotReady();
+                }
+                catch (Exception ex)
+                {
+                    Debugger.Instance.Log(Debugger.DebugLevel.ERROR,
+                        $"[Bot {BotId}] BotReady threw: {ex.Message}\n{ex.StackTrace}");
+                }
+            }
+
+            try
+            {
+                Behavior.NetworkProcess(tick, tickDelta);
+            }
+            catch (Exception ex)
+            {
+                // One misbehaving tick should not kill the session; log and keep going.
+                Debugger.Instance.Log(Debugger.DebugLevel.ERROR,
+                    $"[Bot {BotId}] NetworkProcess threw on tick {tick}: {ex.Message}\n{ex.StackTrace}");
+            }
+        }
+
+        public override void _ExitTree()
+        {
+            if (_subscribedWorld != null)
+            {
+                _subscribedWorld.OnClientNetworkTick -= HandleClientTick;
+                _subscribedWorld = null;
+            }
+            if (Instance == this)
+                Instance = null;
+        }
+    }
+}

--- a/addons/Nebula/Core/Bots/BotRunner.cs.uid
+++ b/addons/Nebula/Core/Bots/BotRunner.cs.uid
@@ -1,0 +1,1 @@
+uid://mt1mpvol8fm3

--- a/addons/Nebula/Core/Bots/README.md
+++ b/addons/Nebula/Core/Bots/README.md
@@ -1,0 +1,97 @@
+# Nebula bots
+
+Scripted clients. A bot is a **real** Nebula client — full spawn stream, prediction,
+reconciliation — launched as its own process. The only thing that differs from a human player is
+where its input comes from.
+
+Use them to populate a world for play testing, to reproduce a desync with more than two
+participants, or as the basis for load scenarios.
+
+## Writing a behavior
+
+Subclass `BotBehavior` anywhere in your game project. It is discovered by reflection, so no
+registration step is needed.
+
+```csharp
+using Nebula;
+using Nebula.Bots;
+
+public partial class MyBot : BotBehavior
+{
+    public override Task BotStartup()
+    {
+        // Runs before the client connects, and is awaited. Establish a session here.
+        MyGame.Session.Token = $"bot-{BotId}";
+        return Task.CompletedTask;
+    }
+
+    public override void BotReady()
+    {
+        // First tick on which OwnedNodes is non-empty — the bot now has a body.
+    }
+
+    public override void NetworkProcess(Tick tick, double delta)
+    {
+        // Once per network tick, immediately before prediction.
+        Input.ActionPress("move_forward");
+    }
+}
+```
+
+### Act through input actions
+
+Prefer `Input.ActionPress` / `Input.ActionRelease` over touching the network layer. Your game's own
+input-sampling code then reads those actions exactly as it reads a keyboard, so prediction, input
+send, and reconciliation all follow the path a real player takes — there is no parallel "bot input"
+route that can drift from the real one. This works under `--headless`.
+
+`NetworkProcess` runs *before* the prediction pass for that tick, which is where a human's input
+has just been sampled, so an action pressed there lands on the same tick it would have for a player.
+
+Behaviors that need to do more than move can reach their own nodes through `OwnedNodes` — to call a
+NetFunction, for instance.
+
+### Two things worth knowing
+
+- **`OwnedNodes` is empty until the server spawns your character.** Guard on it, or do your setup in
+  `BotReady`.
+- **Release what you press.** A latched movement key survives a state change, and a bot that
+  switches control schemes mid-leg with thrust still held will accelerate forever. Release on
+  transitions and in `_ExitTree`.
+
+## Running them
+
+From the editor: **Nebula → Manage Configurations…**, set a bot count and pick a behavior, then use
+the Play button. Bots launch alongside the configuration's real clients and join the same world.
+
+By hand:
+
+```
+godot --path <project> --headless --bot --botId=0 --botBehavior=MyBot
+```
+
+| Argument | Meaning |
+| --- | --- |
+| `--bot` | Marks the process as a bot. Without it none of this runtime loads. |
+| `--botId=N` | Zero-based index. Stable for the process, so identity can be derived from it. |
+| `--botBehavior=Name` | `BotBehavior` subclass, by short or full type name. |
+
+The behavior is resolved by **type name rather than script path**: a C# script resource cannot be
+instantiated through the Godot script API the way a GDScript one can, and reflection is also what
+lets the editor offer a dropdown of the behaviors that actually exist.
+
+## Server metrics
+
+Bots are most useful with numbers attached. Launch the server with `--metrics` (optionally
+`--metricsInterval=<seconds>`, default 1) and it writes one JSON line per world per interval,
+prefixed `NEBULA_METRICS`:
+
+```
+NEBULA_METRICS {"world":"…","tick":1830,"peers":11,"tick_ms":{"p50":1.2,"p95":3.4,…},…}
+```
+
+Tick timing percentiles, bytes out per peer per second, GC collection deltas, RTT spread, and
+MTU-exceeded / ack-timeout counters. Recording is allocation-free so that measuring does not
+perturb what is measured. This goes to stdout rather than the debug channel deliberately —
+`DebugHub` only produces frames while a debugger is attached and drops lossy frames when its queue
+backs up, which would lose exactly the samples a loaded run exists to capture.

--- a/addons/Nebula/Core/Collections/NetArray.cs
+++ b/addons/Nebula/Core/Collections/NetArray.cs
@@ -554,6 +554,54 @@ namespace Nebula.Serialization
         }
 
         /// <summary>
+        /// Creates a content-identical copy of <paramref name="source"/> to serve one peer whose
+        /// view is about to diverge (see NetProperty.PerPeerState). Backs the fork-on-first-scoped-
+        /// access path in NetworkController.TryGetPerPeerArray.
+        ///
+        /// The peer's <see cref="PeerSyncState"/> is MOVED out of <paramref name="source"/> into the
+        /// fork rather than copied. That entry records what the peer has already acked, and because
+        /// the fork's contents are byte-identical to the base at this moment, it remains exactly
+        /// correct: a fork with no subsequent mutation sends nothing, and a fork that is then mutated
+        /// ships an ordinary delta. Without the move the fork would start with an empty _peerState,
+        /// NetworkSerialize would see InitialSyncComplete == false, and the whole array would be
+        /// re-chunked to a client that already holds identical bytes.
+        ///
+        /// Removing the entry from the base also stops the base array from tracking a peer it no
+        /// longer serves.
+        /// </summary>
+        internal static NetArray<T> ForkForPeer(NetArray<T> source, UUID peerId)
+        {
+            if (source == null)
+                throw new ArgumentNullException(nameof(source));
+
+            var fork = new NetArray<T>(source.Capacity);
+            fork._length = source._length;
+
+            if (typeof(T) == typeof(bool))
+                Array.Copy(source._bits, fork._bits, Math.Min(source._bits.Length, fork._bits.Length));
+            else
+                Array.Copy(source._data, fork._data, Math.Min(source._data.Length, fork._data.Length));
+
+            // Carry the base's un-exported dirty state across. A base mutation earlier in this same
+            // tick is present in the copied contents but has NOT reached the peer yet, so its dirty
+            // bit has to come along or the fork would silently swallow it. (Base mutations AFTER the
+            // fork are a different matter - those deliberately never reach this peer.)
+            Array.Copy(source._dirtyMask, fork._dirtyMask, Math.Min(source._dirtyMask.Length, fork._dirtyMask.Length));
+            fork._isFullDirty = source._isFullDirty;
+
+            if (source._peerState != null && source._peerState.TryGetValue(peerId, out var state))
+            {
+                source._peerState.Remove(peerId);
+                fork._peerState = new Dictionary<UUID, PeerSyncState> { [peerId] = state };
+            }
+
+            return fork;
+        }
+
+        /// <summary>Test seam: whether this instance still tracks sync state for a peer.</summary>
+        internal bool HasPeerStateForTests(UUID peerId) => _peerState != null && _peerState.ContainsKey(peerId);
+
+        /// <summary>
         /// Checks if we have state for a peer and they've completed initial sync.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/addons/Nebula/Core/Diagnostics/ServerMetrics.cs
+++ b/addons/Nebula/Core/Diagnostics/ServerMetrics.cs
@@ -1,0 +1,208 @@
+using System;
+using System.Globalization;
+using System.Text;
+using Godot;
+
+namespace Nebula.Diagnostics
+{
+    /// <summary>
+    /// Per-world server instrumentation, emitted as one JSON line per interval.
+    ///
+    /// <para>Off unless the process was launched with <c>--metrics</c>, and allocation-free on the
+    /// recording path so that having it on does not itself change what it measures — the counters
+    /// are plain field writes and the tick samples land in a preallocated ring. Only the once-per-
+    /// interval emit builds a string, through a reused builder.</para>
+    ///
+    /// <para>Goes to stdout rather than the debug channel on purpose: DebugHub only produces frames
+    /// while a debugger is attached and drops lossy ones when its queue backs up, which would lose
+    /// exactly the samples a loaded run exists to capture.</para>
+    /// </summary>
+    public sealed class ServerMetrics
+    {
+        public const string EnableArg = "--metrics";
+        public const string IntervalArg = "--metricsInterval=";
+
+        /// <summary>Prefix on every emitted line, so a run can be filtered out of a noisy log.</summary>
+        public const string LinePrefix = "NEBULA_METRICS ";
+
+        private const int SampleCapacity = 2048;
+
+        private static bool _parsed;
+        private static bool _enabled;
+        private static double _intervalSeconds = 1.0;
+
+        /// <summary>Whether metrics were requested on the command line. Parsed once.</summary>
+        public static bool Enabled
+        {
+            get
+            {
+                ParseArgs();
+                return _enabled;
+            }
+        }
+
+        public static double IntervalSeconds
+        {
+            get
+            {
+                ParseArgs();
+                return _intervalSeconds;
+            }
+        }
+
+        private static void ParseArgs()
+        {
+            if (_parsed) return;
+            _parsed = true;
+
+            foreach (var argument in OS.GetCmdlineArgs())
+            {
+                if (argument == EnableArg)
+                {
+                    _enabled = true;
+                }
+                else if (argument.StartsWith(IntervalArg))
+                {
+                    if (double.TryParse(argument.Substring(IntervalArg.Length), out double parsed) && parsed > 0)
+                        _intervalSeconds = parsed;
+                }
+            }
+        }
+
+        // ─── Recording state ─────────────────────────────────────────────────
+
+        private readonly double[] _tickMs = new double[SampleCapacity];
+        private int _tickCount;
+        /// <summary>Ticks observed since the last emit, including any past the ring's capacity.</summary>
+        private int _ticksThisWindow;
+
+        private long _bytesOut;
+        private long _packetsOut;
+        private int _mtuExceeded;
+        private int _ackTimeouts;
+
+        private readonly double[] _sortScratch = new double[SampleCapacity];
+        private readonly StringBuilder _line = new(512);
+
+        /// <summary>
+        /// Every number is formatted against this, never the ambient culture. On a machine with a
+        /// comma decimal separator the default produces "p50":1,747 — which is not merely ugly, it
+        /// is invalid JSON that silently reparses as two array elements.
+        /// </summary>
+        private static readonly CultureInfo Inv = CultureInfo.InvariantCulture;
+
+        private ulong _windowStartUsec;
+        private int _gc0, _gc1, _gc2;
+        private bool _started;
+
+        /// <summary>Records one completed server tick. Hot path — no allocation.</summary>
+        public void RecordTick(double elapsedMs)
+        {
+            _ticksThisWindow++;
+            if (_tickCount < SampleCapacity)
+                _tickMs[_tickCount++] = elapsedMs;
+        }
+
+        /// <summary>Records one per-peer tick packet as it goes on the wire. Hot path.</summary>
+        public void RecordPacket(int bytes)
+        {
+            _bytesOut += bytes;
+            _packetsOut++;
+        }
+
+        public void RecordMtuExceeded() => _mtuExceeded++;
+
+        public void RecordAckTimeout() => _ackTimeouts++;
+
+        /// <summary>
+        /// Whether the interval has elapsed. Separate from <see cref="Emit"/> so the caller only
+        /// pays for a peer scan on the tick that actually reports.
+        /// </summary>
+        public bool IsDue(out double elapsedSeconds)
+        {
+            ulong now = Time.GetTicksUsec();
+            if (!_started)
+            {
+                _started = true;
+                _windowStartUsec = now;
+                CaptureGcBaseline();
+                elapsedSeconds = 0;
+                return false;
+            }
+
+            elapsedSeconds = (now - _windowStartUsec) / 1_000_000.0;
+            return elapsedSeconds >= IntervalSeconds;
+        }
+
+        private void CaptureGcBaseline()
+        {
+            _gc0 = GC.CollectionCount(0);
+            _gc1 = GC.CollectionCount(1);
+            _gc2 = GC.CollectionCount(2);
+        }
+
+        /// <summary>
+        /// Writes one line and resets the window. Peer figures are supplied by the caller, which
+        /// owns the peer table.
+        /// </summary>
+        public void Emit(UUID worldId, Tick tick, int peers, double rttMean, uint rttMax, double elapsedSeconds)
+        {
+            Array.Copy(_tickMs, _sortScratch, _tickCount);
+            Array.Sort(_sortScratch, 0, _tickCount);
+
+            _line.Clear();
+            _line.Append(LinePrefix);
+            _line.Append("{\"world\":\"").Append(worldId.ToString()).Append('"');
+            _line.Append(",\"tick\":").Append(tick);
+            _line.Append(",\"window_s\":").Append(elapsedSeconds.ToString("F2", Inv));
+            _line.Append(",\"peers\":").Append(peers);
+            _line.Append(",\"ticks\":").Append(_ticksThisWindow);
+            _line.Append(",\"tick_ms\":{");
+            _line.Append("\"p50\":").Append(Percentile(0.50).ToString("F3", Inv));
+            _line.Append(",\"p95\":").Append(Percentile(0.95).ToString("F3", Inv));
+            _line.Append(",\"p99\":").Append(Percentile(0.99).ToString("F3", Inv));
+            _line.Append(",\"max\":").Append(Percentile(1.0).ToString("F3", Inv));
+            _line.Append('}');
+            _line.Append(",\"bytes_out\":").Append(_bytesOut);
+            _line.Append(",\"packets_out\":").Append(_packetsOut);
+            // Per peer per second, which is the number that scales to a bandwidth bill.
+            double bytesPerPeerPerSec = peers > 0 && elapsedSeconds > 0
+                ? _bytesOut / (double)peers / elapsedSeconds
+                : 0;
+            _line.Append(",\"bytes_per_peer_s\":").Append(bytesPerPeerPerSec.ToString("F0", Inv));
+            _line.Append(",\"rtt_ms\":{\"mean\":").Append(rttMean.ToString("F1", Inv));
+            _line.Append(",\"max\":").Append(rttMax).Append('}');
+            _line.Append(",\"gc\":[")
+                 .Append(GC.CollectionCount(0) - _gc0).Append(',')
+                 .Append(GC.CollectionCount(1) - _gc1).Append(',')
+                 .Append(GC.CollectionCount(2) - _gc2).Append(']');
+            _line.Append(",\"mtu_exceeded\":").Append(_mtuExceeded);
+            _line.Append(",\"ack_timeouts\":").Append(_ackTimeouts);
+            _line.Append('}');
+
+            GD.Print(_line.ToString());
+
+            _windowStartUsec = Time.GetTicksUsec();
+            _tickCount = 0;
+            _ticksThisWindow = 0;
+            _bytesOut = 0;
+            _packetsOut = 0;
+            _mtuExceeded = 0;
+            _ackTimeouts = 0;
+            CaptureGcBaseline();
+        }
+
+        /// <summary>
+        /// Nearest-rank percentile over the sorted scratch. Returns 0 with no samples, which reads
+        /// correctly as "this world did not tick during the window".
+        /// </summary>
+        private double Percentile(double fraction)
+        {
+            if (_tickCount == 0) return 0;
+            int index = (int)Math.Ceiling(fraction * _tickCount) - 1;
+            if (index < 0) index = 0;
+            if (index >= _tickCount) index = _tickCount - 1;
+            return _sortScratch[index];
+        }
+    }
+}

--- a/addons/Nebula/Core/Diagnostics/ServerMetrics.cs.uid
+++ b/addons/Nebula/Core/Diagnostics/ServerMetrics.cs.uid
@@ -1,0 +1,1 @@
+uid://bmvar8btnobjy

--- a/addons/Nebula/Core/IAsyncWorldGenerator.cs
+++ b/addons/Nebula/Core/IAsyncWorldGenerator.cs
@@ -1,0 +1,49 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Nebula
+{
+    /// <summary>
+    /// Implemented by a world's root scene when building that world is expensive enough that it
+    /// must not happen inside a single frame.
+    ///
+    /// <para><see cref="NetRunner.CreateWorld"/> calls <see cref="GenerateWorldAsync"/> after the
+    /// world is in the tree and <c>_NetworkPrepare</c>/<c>_WorldReady</c> have run, but before the
+    /// world starts ticking or admits any peer. The task it returns is what the caller's
+    /// <c>await CreateWorld(...)</c> is really waiting on, so a world is only ever handed out
+    /// fully built -- and a generation failure surfaces as a faulted task rather than as a world
+    /// that quietly came up empty.</para>
+    ///
+    /// <para><b>Implementations own their own threading.</b> Nebula does not move this call off the
+    /// main thread, because only the implementation knows which parts of its work are pure
+    /// computation and which have to touch the SceneTree. The shape that works:</para>
+    ///
+    /// <list type="bullet">
+    /// <item>Do the expensive computation on a worker (<c>Task.Factory.StartNew(...,
+    /// TaskCreationOptions.LongRunning, TaskScheduler.Default)</c>), building nodes that are
+    /// <b>not</b> in the SceneTree. Godot permits creating nodes and resources off-thread; it is
+    /// tree insertion that must not happen there.</item>
+    /// <item>Come back to the main thread to attach what you built --
+    /// <see cref="WorldRunner.Spawn"/> allocates NetIds, mutates the world's scene registry and
+    /// walks the peer list, none of which is safe off-thread.</item>
+    /// <item>Spread that attach phase across frames if it is large; a thousand colliders landing in
+    /// one frame is its own stall, just a different one.</item>
+    /// </list>
+    ///
+    /// <para>Awaiting pure I/O (an RPC, an upload) directly on the main thread is fine and does not
+    /// need a worker -- it does not block anything.</para>
+    /// </summary>
+    public interface IAsyncWorldGenerator
+    {
+        /// <summary>
+        /// Builds this world's contents. Throw to fail creation: the world is then torn down and
+        /// deregistered, and the caller's task faults.
+        /// </summary>
+        /// <param name="ct">
+        /// Cancelled if creation is abandoned (for example a generation timeout). Honour it on any
+        /// long loop or remote call so a wedged generation cannot pin a world in
+        /// <see cref="WorldRunner.WorldLifecycle.Generating"/> forever.
+        /// </param>
+        Task GenerateWorldAsync(CancellationToken ct);
+    }
+}

--- a/addons/Nebula/Core/IAsyncWorldGenerator.cs.uid
+++ b/addons/Nebula/Core/IAsyncWorldGenerator.cs.uid
@@ -1,0 +1,1 @@
+uid://df7np5pxdhsar

--- a/addons/Nebula/Core/NebulaThread.cs
+++ b/addons/Nebula/Core/NebulaThread.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Diagnostics;
+// System.Diagnostics also defines a Debugger; alias Nebula's so the two can't be confused here.
+using NebulaDebugger = Nebula.Utility.Tools.Debugger;
+
+namespace Nebula
+{
+    /// <summary>
+    /// Thread-affinity assertions for the netcode.
+    ///
+    /// Nebula was written when everything ran on Godot's main thread, and a good deal of code
+    /// depends on that without saying so -- shared scratch buffers, the ENet host, the peer
+    /// registries. Once worlds tick on their own threads (see the
+    /// <c>Nebula/config/threading/per_world_thread_group</c> setting) breaking one of those
+    /// assumptions does not crash; it corrupts state and surfaces later as a desync, which is the
+    /// most expensive bug class in this codebase to chase.
+    ///
+    /// These assertions exist to turn that silent corruption into a loud, located failure. They
+    /// compile out entirely in release builds, so annotate freely: any method that mutates
+    /// cross-world state, touches the SceneTree, or assumes serial execution is a candidate.
+    /// </summary>
+    public static class NebulaThread
+    {
+        /// <summary>
+        /// Managed id of Godot's main thread, captured in <see cref="NetRunner._EnterTree"/>.
+        /// Zero until then, which is what <see cref="IsMain"/> treats as "unknown, assume fine" --
+        /// static constructors and early autoload wiring must not trip an assertion.
+        /// </summary>
+        private static int _mainThreadId;
+
+        internal static void CaptureMainThread()
+        {
+            _mainThreadId = Environment.CurrentManagedThreadId;
+        }
+
+        /// <summary>True on Godot's main thread, or before the main thread has been identified.</summary>
+        public static bool IsMain => _mainThreadId == 0 || Environment.CurrentManagedThreadId == _mainThreadId;
+
+        /// <summary>
+        /// Asserts the caller is on Godot's main thread. Use on anything that mutates state shared
+        /// between worlds (the peer registries, <see cref="NetRunner.Worlds"/>) or touches the
+        /// SceneTree -- <c>AddChild</c>, <c>GetTree()</c>, reparenting. Work reached from a world
+        /// tick must be marshalled rather than called directly.
+        /// </summary>
+        [Conditional("DEBUG")]
+        public static void AssertMain(string context)
+        {
+            if (IsMain) return;
+            Report($"{context} must run on the main thread, but ran on thread {Environment.CurrentManagedThreadId}.");
+        }
+
+        /// <summary>
+        /// Asserts the caller is NOT on the main thread -- for work deliberately moved off it, so a
+        /// silent re-marshal back onto main (the classic captured-SynchronizationContext mistake,
+        /// which reintroduces the stall it was meant to remove) fails loudly instead of just
+        /// getting slow again.
+        /// </summary>
+        [Conditional("DEBUG")]
+        public static void AssertOffMain(string context)
+        {
+            if (!IsMain) return;
+            Report($"{context} is expected to run off the main thread, but ran on it.");
+        }
+
+        private static void Report(string message)
+        {
+            // Stack trace included deliberately: the useful information is the call path that got
+            // here, not the assertion site itself.
+            NebulaDebugger.Instance?.Log(
+                $"[NebulaThread] {message}\n{new StackTrace(true)}",
+                NebulaDebugger.DebugLevel.ERROR);
+        }
+    }
+}

--- a/addons/Nebula/Core/NebulaThread.cs.uid
+++ b/addons/Nebula/Core/NebulaThread.cs.uid
@@ -1,0 +1,1 @@
+uid://bmvrrfphtls3u

--- a/addons/Nebula/Core/NetNodeCommon.cs
+++ b/addons/Nebula/Core/NetNodeCommon.cs
@@ -120,6 +120,16 @@ namespace Nebula.Utility
             // Mark imported nodes accordingly
             if (!node.GetMeta("import_from_external", false).AsBool())
             {
+                // Deserialization reaches here from wherever its caller's awaits happened to resume,
+                // and that is not somewhere this method can afford to guess about: the block below
+                // parents the node into the live SceneTree, which Godot permits only from the main
+                // thread. With per-world thread groups the realistic caller -- a character load
+                // kicked off by OnPlayerJoined at the top of ServerProcessTick -- starts on a world
+                // tick thread, which has no SynchronizationContext, so every continuation after its
+                // first await lands on the ThreadPool. Hopping here rather than asking each caller
+                // to do it keeps the requirement with the code that actually has it.
+                await NetRunner.Instance.SwitchToMainThread();
+
                 var tcs = new TaskCompletionSource<bool>();
                 // Create the event handler as a separate method so we can disconnect it later
                 Action treeEnteredHandler = () =>

--- a/addons/Nebula/Core/NetProperty.cs
+++ b/addons/Nebula/Core/NetProperty.cs
@@ -75,12 +75,29 @@ namespace Nebula
         /// NetChangeListener fire as usual.</item>
         /// </list>
         ///
-        /// Restrictions: primitive value types only (int, bool, long, float, enums, Vector*,
-        /// UUID, NetId, ...) — reference types, string, INetSerializable and NetArray are
-        /// rejected (NEBULA007), as is combining with Predicted or Interpolate (NEBULA008).
-        /// Per-peer values are always sent absolute (never delta-encoded). Per-peer state is
-        /// cleaned up on disconnect; a peer that merely leaves a world keeps its entries on
-        /// that world's nodes until the world is torn down.
+        /// Restrictions: primitive value types (int, bool, long, float, enums, Vector*, UUID,
+        /// NetId, ...) and <c>NetArray&lt;T&gt;</c>. Other reference types, string and
+        /// INetSerializable are rejected (NEBULA007), as is combining with Predicted or
+        /// Interpolate (NEBULA008). Per-peer values are always sent absolute (never
+        /// delta-encoded). Per-peer state is cleaned up on disconnect; a peer that merely leaves
+        /// a world keeps its entries on that world's nodes until the world is torn down.
+        ///
+        /// <para><b>NetArray properties</b> follow the same scoping but differ in three ways,
+        /// because a collection is mutated in place rather than assigned:</para>
+        /// <list type="bullet">
+        /// <item>The server keeps a whole <c>NetArray&lt;T&gt;</c> instance per diverged peer.
+        /// The getter forks one from the base on the first access inside a scope — and since the
+        /// getter cannot tell <c>var x = Arr[3]</c> from <c>Arr[3] = x</c>, ANY scoped access
+        /// forks, including a read. The fork is content-identical and inherits the peer's sync
+        /// state, so it costs a server-side allocation but no bandwidth. Keep scoped access out
+        /// of hot loops.</item>
+        /// <item>Memory is O(peers × array). A 4096-element array across 64 diverged peers is
+        /// ~256 KB on this node alone. Only peers that actually diverge pay.</item>
+        /// <item><b>Once a peer is forked it is divorced from the base</b>: later base mutations
+        /// never reach it. This differs from the primitive contract above, where a base write
+        /// still broadcasts to every peer without an override — there is no cheap base+override
+        /// merge for a collection. Write per-peer arrays through the scope from then on.</item>
+        /// </list>
         /// </summary>
         public bool PerPeerState = false;
     }

--- a/addons/Nebula/Core/NetRunner.cs
+++ b/addons/Nebula/Core/NetRunner.cs
@@ -1,6 +1,10 @@
 global using NetPeer = ENet.Peer;
 global using Tick = System.Int32;
+using System.Buffers;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
 using Godot;
 using Nebula.Serialization;
 using System;
@@ -65,7 +69,7 @@ namespace Nebula
         internal Dictionary<UUID, NetPeer> Peers = [];
         internal Dictionary<uint, UUID> PeerIds = [];  // Key is peer.ID (ENet native ID)
         internal Dictionary<uint, NetPeer> PeersByNativeId = [];
-        internal Dictionary<UUID, List<NetPeer>> WorldPeerMap = [];
+        /// <summary>Which world each peer is currently in. Keyed by peer id.</summary>
         internal Dictionary<UUID, WorldRunner> PeerWorldMap = [];
 
         public NetPeer GetPeer(UUID id)
@@ -166,6 +170,10 @@ namespace Nebula
             }
             Instance = this;
 
+            // NetRunner is an autoload, so this is the earliest reliable point at which Godot's
+            // main thread can be identified for NebulaThread's assertions.
+            NebulaThread.CaptureMainThread();
+
             if (!_libraryInitialized)
             {
                 try
@@ -187,11 +195,16 @@ namespace Nebula
         {
             // Protocol is fully static - no initialization needed
             StartDebugHub();
+
+            // No-op unless this process was launched with --bot. Created here rather than added as
+            // an autoload so that adopting Nebula's bots costs a project no project.godot changes,
+            // and so a normal client or server never carries the runtime at all.
+            Bots.BotRunner.TryCreate(this);
         }
 
         public override void _ExitTree()
         {
-            ENetHost?.Flush();
+            lock (EnetLock) { ENetHost?.Flush(); }
             ENetHost?.Dispose();
             DebugHub?.Stop();
             DebugHub = null;
@@ -260,6 +273,75 @@ namespace Nebula
                 DebugHub = hub;
         }
 
+        /// <summary>
+        /// Peers (by native ENet id) that connected before any world was ready to take them.
+        /// Authenticated as soon as one goes Live; see <see cref="AuthenticateWaitingPeers"/>.
+        /// </summary>
+        private readonly List<uint> _peersAwaitingWorld = [];
+        private readonly List<uint> _waitingPeerScratch = [];
+
+        /// <summary>
+        /// The first world that is built and ready for peers, or null if none is yet.
+        ///
+        /// Prefer this over indexing <see cref="Worlds"/> directly: a world is registered from the
+        /// moment its creation starts, so the registry can contain worlds that are still
+        /// generating and must not be joined.
+        /// </summary>
+        public WorldRunner FirstLiveWorld()
+        {
+            // Enumerated as key-value pairs rather than through .Values: enumeration is a struct
+            // enumerator (allocation-free) either way, but touching .Values would also materialize
+            // the dictionary's cached ValueCollection wrapper on first use.
+            foreach (var pair in Worlds)
+            {
+                var world = pair.Value;
+                if (world != null && world.Lifecycle == WorldRunner.WorldLifecycle.Live)
+                {
+                    return world;
+                }
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// True when <paramref name="worldId"/> names a world that exists <em>and</em> is ready for
+        /// peers. Registered-but-generating worlds return false.
+        /// </summary>
+        public bool IsWorldLive(UUID worldId) =>
+            Worlds.TryGetValue(worldId, out var world)
+            && world != null
+            && world.Lifecycle == WorldRunner.WorldLifecycle.Live;
+
+        /// <summary>
+        /// Authenticates everything that connected while the server had no world yet.
+        ///
+        /// Called when a world goes Live. World creation is asynchronous, so there is a real window
+        /// between the socket opening and the first world being ready -- clients that connect in it
+        /// wait here rather than being rejected, because from their side the server is simply still
+        /// starting up.
+        /// </summary>
+        private void AuthenticateWaitingPeers()
+        {
+            if (_peersAwaitingWorld.Count == 0 || Authentication == null) return;
+
+            // Drained into scratch first: authenticating a peer can re-enter this list (a rejected
+            // peer disconnecting, say), and mutating it mid-iteration would throw.
+            _waitingPeerScratch.Clear();
+            _waitingPeerScratch.AddRange(_peersAwaitingWorld);
+            _peersAwaitingWorld.Clear();
+
+            Debugger.Instance.Log($"World ready; authenticating {_waitingPeerScratch.Count} peer(s) that connected while it was still generating.");
+
+            foreach (var nativeId in _waitingPeerScratch)
+            {
+                var peer = GetPeerByNativeId(nativeId);
+                if (peer.IsSet)
+                {
+                    Authentication.ServerAuthenticateClient(peer);
+                }
+            }
+        }
+
         public IAuthenticator Authentication { get; private set; }
 
         public void SetAuthentication(IAuthenticator authentication)
@@ -271,10 +353,21 @@ namespace Nebula
             OnPeerConnected += (uint peerId) =>
             {
                 var peer = GetPeerByNativeId(peerId);
-                if (peer.IsSet)
+                if (!peer.IsSet) return;
+
+                // Authenticators put peers into worlds, so there has to be a world to put them in.
+                // Since world creation is asynchronous the socket can be open before the first one
+                // is ready, and a client launched alongside the server routinely lands in that
+                // window. Hold the peer rather than failing it -- AuthenticateWaitingPeers picks it
+                // up the moment a world goes Live.
+                if (FirstLiveWorld() == null)
                 {
-                    Authentication.ServerAuthenticateClient(peer);
+                    _peersAwaitingWorld.Add(peerId);
+                    Debugger.Instance.Log($"Peer {peerId} connected before any world was ready; holding until one is.");
+                    return;
                 }
+
+                Authentication.ServerAuthenticateClient(peer);
             };
             OnConnectedToServer += () =>
             {
@@ -347,7 +440,10 @@ namespace Nebula
             }
 
             NetStarted = true;
-            var worldRunner = new WorldRunner();
+            // The client's single WorldRunner is a receiver, not something that gets generated: its
+            // contents arrive over the spawn stream. Lifecycle only gates server-side peer
+            // admission, but leaving it at the Generating default would be misleading here.
+            var worldRunner = new WorldRunner { Lifecycle = WorldRunner.WorldLifecycle.Live };
             WorldRunner.CurrentWorld = worldRunner;
             GetTree().CurrentScene.AddChild(worldRunner);
             Debugger.Instance.Log("Started");
@@ -483,6 +579,158 @@ namespace Nebula
         public static bool PackValidate =>
             _packValidate ??= ProjectSettings.GetSetting("Nebula/config/pack/validate", true).AsBool();
 
+        private static bool? _perWorldThreadGroup;
+        /// <summary>
+        /// When enabled via <c>Nebula/config/threading/per_world_thread_group</c>, each server
+        /// world's SubViewport gets its own <see cref="Node.ProcessThreadGroupEnum.SubThread"/>
+        /// group, so worlds run their ticks concurrently instead of being walked one after another
+        /// by the SceneTree on the main thread.
+        ///
+        /// What this does and does not do is worth being precise about: Godot's thread groups move
+        /// <c>_process</c>/<c>_physics_process</c> *callbacks* off the main thread. They do not
+        /// parallelize physics simulation -- PhysicsServer3D steps every active space sequentially
+        /// regardless of which thread requested it, so per-world World3Ds still simulate serially.
+        /// The win is ServerProcessTick (state serialization dominates) and gameplay scripts.
+        ///
+        /// Off by default. Everything the flag depends on is written to be correct in both modes --
+        /// an uncontended lock is nearly free and the inbound queue preserves ordering either way --
+        /// so flipping it changes timing, never behavior. Cached on first read.
+        /// </summary>
+        public static bool PerWorldThreadGroup =>
+            _perWorldThreadGroup ??= ProjectSettings.GetSetting("Nebula/config/threading/per_world_thread_group", false).AsBool();
+
+        /// <summary>
+        /// Serializes every touch of the shared ENet <see cref="Host"/>.
+        ///
+        /// One host serves all worlds, but sends originate from inside each world's tick
+        /// (WorldRunner.ExportState, net function dispatch) while the event pump services the same
+        /// host from the main thread. ENet is not thread-safe, so once worlds tick concurrently
+        /// those overlap.
+        ///
+        /// Held as briefly as possible -- around the ENet call itself and nothing else. In
+        /// particular the pump takes it to pull an event and releases it before dispatching, because
+        /// dispatch re-enters world code that sends, and holding it across that would deadlock.
+        /// </summary>
+        internal static readonly object EnetLock = new();
+
+        /// <summary>
+        /// Reusable wrapper for parsing inbound packets in place on the client. Re-pointed at each
+        /// rented payload via <see cref="NetBuffer.Attach"/> -- one long-lived object instead of a
+        /// NetBuffer allocation per packet. Only ever touched by the pump (main thread), and every
+        /// consumer copies what it keeps, so re-attaching for the next packet is safe.
+        /// </summary>
+        private readonly NetBuffer _inboundParseBuffer = new(System.Array.Empty<byte>());
+
+        /// <summary>
+        /// Work deferred from a world thread to the main thread, drained at the top of
+        /// <see cref="_PhysicsProcess"/>.
+        ///
+        /// This is for rare lifecycle events -- peer join/leave mutating the shared registries,
+        /// world creation touching the SceneTree -- NOT for anything on the per-tick path. Each
+        /// entry allocates a closure, which is fine at join/leave frequency and would not be inside
+        /// ExportState. Callers already on the main thread run inline and never queue.
+        /// </summary>
+        private readonly Queue<Action> _mainThreadWork = new();
+        private readonly object _mainThreadWorkLock = new();
+
+        /// <summary>
+        /// Runs <paramref name="work"/> on the main thread: inline if already there, otherwise
+        /// queued for the next <see cref="_PhysicsProcess"/>.
+        /// </summary>
+        internal void RunOnMainThread(Action work)
+        {
+            if (NebulaThread.IsMain)
+            {
+                work();
+                return;
+            }
+            lock (_mainThreadWorkLock)
+            {
+                _mainThreadWork.Enqueue(work);
+            }
+        }
+
+        /// <summary>
+        /// Awaitable hop to the main thread. Completes inline when already there, so awaiting it
+        /// from the main thread costs nothing and never defers by a frame.
+        ///
+        /// A custom awaitable rather than a TaskCompletionSource, deliberately: a task only
+        /// signals completion -- WHERE the awaiter resumes is decided by the scheduler it captured
+        /// at the await, and a world tick thread has no SynchronizationContext, so a TCS completed
+        /// from main would resume the caller on the ThreadPool. This awaitable hands the
+        /// continuation itself to <see cref="RunOnMainThread"/>, so resuming on main is structural
+        /// rather than a scheduling accident.
+        ///
+        /// Used by world creation, which may be initiated from a world tick thread (a
+        /// [NetFunction] is dispatched from inside ServerProcessTick) but has to do its SceneTree
+        /// work on the main thread.
+        /// </summary>
+        internal MainThreadAwaitable SwitchToMainThread() => new(this);
+
+        /// <summary>See <see cref="SwitchToMainThread"/>.</summary>
+        internal readonly struct MainThreadAwaitable
+        {
+            private readonly NetRunner _runner;
+            internal MainThreadAwaitable(NetRunner runner) { _runner = runner; }
+            public Awaiter GetAwaiter() => new(_runner);
+
+            internal readonly struct Awaiter : INotifyCompletion
+            {
+                private readonly NetRunner _runner;
+                internal Awaiter(NetRunner runner) { _runner = runner; }
+
+                /// <summary>Already on main: the await is a no-op and never defers a frame.</summary>
+                public bool IsCompleted => NebulaThread.IsMain;
+
+                /// <summary>
+                /// Only reached off-main (IsCompleted short-circuits otherwise), so this always
+                /// enqueues: the continuation runs during the next <see cref="DrainMainThreadWork"/>.
+                /// </summary>
+                public void OnCompleted(Action continuation) => _runner.RunOnMainThread(continuation);
+
+                public void GetResult()
+                {
+                    // Runs as the resumed continuation's first act. Anything but main here means
+                    // the marshal itself is broken -- fail loudly at the hop, not at whatever
+                    // SceneTree call would have corrupted state three frames later.
+                    NebulaThread.AssertMain(nameof(SwitchToMainThread));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Drains <see cref="_mainThreadWork"/>. Each item runs outside the lock so that work which
+        /// queues more work cannot deadlock, and the drain is bounded to the items present on entry
+        /// so a self-requeueing item cannot spin the frame.
+        /// </summary>
+        private void DrainMainThreadWork()
+        {
+            int pending;
+            lock (_mainThreadWorkLock)
+            {
+                pending = _mainThreadWork.Count;
+            }
+
+            while (pending-- > 0)
+            {
+                Action work;
+                lock (_mainThreadWorkLock)
+                {
+                    if (!_mainThreadWork.TryDequeue(out work)) return;
+                }
+
+                try
+                {
+                    work();
+                }
+                catch (Exception ex)
+                {
+                    Debugger.Instance.Log(Debugger.DebugLevel.ERROR,
+                        $"[Nebula] Deferred main-thread work threw: {ex.Message}\n{ex.StackTrace}");
+                }
+            }
+        }
+
         /// <summary>
         /// Accepts debug clients. Runs in _Process rather than _PhysicsProcess
         /// because _PhysicsProcess bails out until the network has started, and
@@ -536,18 +784,28 @@ namespace Nebula
         /// <inheritdoc/>
         public override void _PhysicsProcess(double delta)
         {
+            // Before anything else, and regardless of whether the network is up: work deferred from
+            // world threads (peer registry mutations, world creation) is owed a main-thread turn.
+            DrainMainThreadWork();
+
             if (!NetStarted)
                 return;
 
             Event netEvent;
-            int checkResult = ENetHost.CheckEvents(out netEvent);
+            int checkResult;
             int serviceResult = 0;
-            
-            if (checkResult <= 0)
+
+            // Pull an event under the lock, then release it before dispatching -- dispatch re-enters
+            // world code that sends on this same host.
+            lock (EnetLock)
             {
-                serviceResult = ENetHost.Service(0, out netEvent);
+                checkResult = ENetHost.CheckEvents(out netEvent);
+                if (checkResult <= 0)
+                {
+                    serviceResult = ENetHost.Service(0, out netEvent);
+                }
             }
-            
+
             while (checkResult > 0 || serviceResult > 0)
             {
                 switch (netEvent.Type)
@@ -565,7 +823,7 @@ namespace Nebula
                             {
                                 Debugger.Instance.Log(Debugger.DebugLevel.ERROR,
                                     $"Rejecting peer {netEvent.Peer.ID}: protocol hash mismatch (server 0x{Protocol.HandshakeHash:X8}, client 0x{netEvent.Data:X8}). Client is running a different build.");
-                                netEvent.Peer.Disconnect(ProtocolMismatchDisconnectCode);
+                                DisconnectPeer(netEvent.Peer, ProtocolMismatchDisconnectCode);
                                 break;
                             }
 
@@ -603,11 +861,29 @@ namespace Nebula
                     case EventType.Receive:
                     {
                         var channel = netEvent.ChannelID;
-                        var packetData = new byte[netEvent.Packet.Length];
+                        var packetLength = netEvent.Packet.Length;
+
+                        // The per-tick channels (acks, inputs, functions) arrive every network tick
+                        // from every peer, so their payloads rent from the shared pool instead of
+                        // allocating -- a fresh byte[] per packet was steady-state garbage. The rare
+                        // channels (World handoffs, reserved custom handlers) keep exact-size
+                        // allocations, because their consumers receive a bare byte[] and rely on
+                        // its .Length.
+                        bool pooledPayload = channel == (byte)ENetChannelId.Tick
+                            || channel == (byte)ENetChannelId.Input
+                            || channel == (byte)ENetChannelId.Function;
+                        var packetData = pooledPayload
+                            ? ArrayPool<byte>.Shared.Rent(packetLength)
+                            : new byte[packetLength];
+                        // Packet.CopyTo copies exactly packet-Length bytes, so an oversized rented
+                        // array is fine; only [0, packetLength) is ever read downstream.
                         netEvent.Packet.CopyTo(packetData);
                         netEvent.Packet.Dispose();
 
-                        using var data = new NetBuffer(packetData);
+                        // A rented payload is owned by whoever consumes it: EnqueueInboundPacket
+                        // takes ownership (the world's drain returns it to the pool), everything
+                        // else parses inline here and the finally below returns it.
+                        bool payloadHandedOff = false;
 
                         // A malformed packet must never abort the event pump: an unhandled
                         // exception here would drop every remaining queued event this frame for
@@ -619,25 +895,24 @@ namespace Nebula
                             case ENetChannelId.Tick:
                                 if (IsServer)
                                 {
-                                    if (packetData.Length == 0)
-                                    {
-                                        break;
-                                    }
-                                    var tick = NetReader.ReadInt32(data);
+                                    // Queued, not applied: this world may be mid-tick on its own
+                                    // thread. See WorldRunner.EnqueueInboundPacket.
                                     var peerId = GetPeerId(netEvent.Peer);
                                     if (PeerWorldMap.TryGetValue(peerId, out var world))
                                     {
-                                        world.PeerAcknowledge(netEvent.Peer, tick);
+                                        world.EnqueueInboundPacket(netEvent.Peer, channel, packetData, packetLength);
+                                        payloadHandedOff = true;
                                     }
                                 }
                                 else
                                 {
-                                    if (packetData.Length == 0)
+                                    if (packetLength == 0)
                                     {
                                         break;
                                     }
-                                    var tick = NetReader.ReadInt32(data);
-                                    var bytes = NetReader.ReadRemainingBytes(data);
+                                    _inboundParseBuffer.Attach(packetData, packetLength);
+                                    var tick = NetReader.ReadInt32(_inboundParseBuffer);
+                                    var bytes = NetReader.ReadRemainingBytes(_inboundParseBuffer);
                                     // Debug: dump the full payload hex for every server tick
                                     // (gated behind the Nebula/config/debug/log_tick_payloads setting).
                                     if (LogTickPayloads)
@@ -664,7 +939,8 @@ namespace Nebula
                                     var peerId = GetPeerId(netEvent.Peer);
                                     if (PeerWorldMap.TryGetValue(peerId, out var world))
                                     {
-                                        world.ReceiveInput(netEvent.Peer, data);
+                                        world.EnqueueInboundPacket(netEvent.Peer, channel, packetData, packetLength);
+                                        payloadHandedOff = true;
                                     }
                                 }
                                 // Clients should never receive messages on the Input channel
@@ -676,12 +952,14 @@ namespace Nebula
                                     var peerId = GetPeerId(netEvent.Peer);
                                     if (PeerWorldMap.TryGetValue(peerId, out var world))
                                     {
-                                        world.ReceiveNetFunction(netEvent.Peer, data);
+                                        world.EnqueueInboundPacket(netEvent.Peer, channel, packetData, packetLength);
+                                        payloadHandedOff = true;
                                     }
                                 }
                                 else
                                 {
-                                    WorldRunner.CurrentWorld.ReceiveNetFunction(ServerPeer, data);
+                                    _inboundParseBuffer.Attach(packetData, packetLength);
+                                    WorldRunner.CurrentWorld.ReceiveNetFunction(ServerPeer, _inboundParseBuffer);
                                 }
                                 break;
 
@@ -710,7 +988,16 @@ namespace Nebula
                                 $"[Nebula][MalformedPacket] Failed to parse packet on channel {channel} from peer {netEvent.Peer.ID}: {ex.Message}");
                             if (IsServer)
                             {
-                                netEvent.Peer.Disconnect(MalformedPacketDisconnectCode);
+                                DisconnectPeer(netEvent.Peer, MalformedPacketDisconnectCode);
+                            }
+                        }
+                        finally
+                        {
+                            // Covers every non-handoff exit: parsed inline, no world found for the
+                            // peer, empty packet, simulated loss, or a parse exception.
+                            if (pooledPayload && !payloadHandedOff)
+                            {
+                                ArrayPool<byte>.Shared.Return(packetData);
                             }
                         }
                         break;
@@ -718,10 +1005,13 @@ namespace Nebula
                 }
 
                 // Check for more events
-                checkResult = ENetHost.CheckEvents(out netEvent);
-                if (checkResult <= 0)
+                lock (EnetLock)
                 {
-                    serviceResult = ENetHost.Service(0, out netEvent);
+                    checkResult = ENetHost.CheckEvents(out netEvent);
+                    if (checkResult <= 0)
+                    {
+                        serviceResult = ENetHost.Service(0, out netEvent);
+                    }
                 }
             }
         }
@@ -731,9 +1021,14 @@ namespace Nebula
         /// </summary>
         public static void SendPacket(Peer peer, byte channelId, byte[] data, PacketFlags flags)
         {
-            var packet = default(Packet);
-            packet.Create(data, flags);
-            peer.Send(channelId, ref packet);
+            // Reached from world tick threads (ExportState, net functions) as well as the main
+            // thread. See EnetLock.
+            lock (EnetLock)
+            {
+                var packet = default(Packet);
+                packet.Create(data, flags);
+                peer.Send(channelId, ref packet);
+            }
         }
 
         /// <summary>
@@ -742,9 +1037,26 @@ namespace Nebula
         /// </summary>
         public static void SendPacket(Peer peer, byte channelId, NetBuffer buffer, PacketFlags flags)
         {
-            var packet = default(Packet);
-            packet.Create(buffer.RawBuffer, buffer.Length, flags);
-            peer.Send(channelId, ref packet);
+            // See EnetLock. packet.Create copies the bytes out of the buffer synchronously, so the
+            // caller's pooled NetBuffer stays reusable the moment this returns.
+            lock (EnetLock)
+            {
+                var packet = default(Packet);
+                packet.Create(buffer.RawBuffer, buffer.Length, flags);
+                peer.Send(channelId, ref packet);
+            }
+        }
+
+        /// <summary>
+        /// Disconnects a peer. Goes through <see cref="EnetLock"/> like every other host touch,
+        /// because the ack-timeout sweep drops peers from inside a world's tick.
+        /// </summary>
+        internal static void DisconnectPeer(Peer peer, uint data)
+        {
+            lock (EnetLock)
+            {
+                peer.Disconnect(data);
+            }
         }
 
         /// <summary>
@@ -797,10 +1109,34 @@ namespace Nebula
 
         public void PeerJoinWorld(NetPeer peer, UUID worldId, string token = "")
         {
+            // Admission mutates the shared peer registries, which belong to the main thread. The
+            // pump-driven callers are already there and run inline; a caller resuming from an await
+            // (whose continuation lands wherever its scheduler chose) is deferred a frame instead.
+            // Same posture as MigratePeerToWorld.
+            if (!NebulaThread.IsMain)
+            {
+                RunOnMainThread(() => PeerJoinWorld(peer, worldId, token));
+                return;
+            }
+
+            if (!Worlds.TryGetValue(worldId, out var world) || world == null)
+            {
+                Debugger.Instance.Log(Debugger.DebugLevel.ERROR, $"PeerJoinWorld: no world {worldId}.");
+                return;
+            }
+            if (world.Lifecycle != WorldRunner.WorldLifecycle.Live)
+            {
+                // A world is registered from the moment creation starts, so being findable is not
+                // the same as being ready. Await the creation task instead of joining early.
+                Debugger.Instance.Log(Debugger.DebugLevel.ERROR,
+                    $"PeerJoinWorld: world {worldId} is {world.Lifecycle}, not Live. Refusing to admit peer {peer.ID}.");
+                return;
+            }
+
             var peerId = new UUID();
             Peers[peerId] = peer;
             PeerIds[peer.ID] = peerId;
-            Worlds[worldId].JoinPeer(peer, token);
+            world.JoinPeer(peer, token);
         }
 
         // --- Live cross-world migration (World ENet channel) ---
@@ -833,6 +1169,26 @@ namespace Nebula
         public void MigratePeerToWorld(NetPeer peer, WorldRunner target)
         {
             if (!IsServer || target == null) return;
+
+            // The documented pattern is "await CreateWorld, then migrate" -- and when that await
+            // was entered on a world tick thread, the continuation resumes wherever the scheduler
+            // put it, not necessarily on main. Everything below touches the shared peer registries
+            // and the source world's peer state, so marshal here rather than trusting every caller
+            // to. Inline when already on main, so the pump-driven paths are unchanged.
+            if (!NebulaThread.IsMain)
+            {
+                RunOnMainThread(() => MigratePeerToWorld(peer, target));
+                return;
+            }
+
+            if (target.Lifecycle != WorldRunner.WorldLifecycle.Live)
+            {
+                // Callers get a Live world by awaiting CreateWorld, so this is a guard against
+                // holding on to a world across a failure rather than a path anyone takes normally.
+                Debugger.Instance.Log(Debugger.DebugLevel.ERROR,
+                    $"MigratePeerToWorld: target world {target.WorldId} is {target.Lifecycle}, not Live. Refusing to migrate peer {peer.ID}.");
+                return;
+            }
 
             var peerId = GetPeerId(peer);
             if (!PeerWorldMap.TryGetValue(peerId, out var source) || source == null)
@@ -921,41 +1277,160 @@ namespace Nebula
 
         public event Action<WorldRunner> OnWorldCreated;
 
-        public WorldRunner CreateWorld(UUID worldId, PackedScene scene)
+        /// <summary>
+        /// Creates a world from a scene, instantiating it off the main thread.
+        ///
+        /// <para>The returned task completes only once the world is fully built and ready for
+        /// peers, including any <see cref="IAsyncWorldGenerator"/> work its root scene does. Await
+        /// it before migrating anyone in.</para>
+        ///
+        /// <para>Safe to call from a world's tick thread -- which is the normal case, since a
+        /// [NetFunction] like "start an expedition" is dispatched from inside ServerProcessTick.
+        /// Everything that touches the SceneTree is marshalled to the main thread internally.</para>
+        /// </summary>
+        /// <param name="onTreeReady">
+        /// Runs on the main thread once the world is in the tree and network-prepared, but before
+        /// it goes Live. This is where per-world infrastructure a caller wants in place before any
+        /// peer can join belongs -- a PlayerSpawnManager, say. Attaching it after awaiting would be
+        /// a race against the first join.
+        /// </param>
+        public async Task<WorldRunner> CreateWorld(
+            UUID worldId,
+            PackedScene scene,
+            Action<WorldRunner> onTreeReady = null,
+            CancellationToken ct = default)
         {
             if (!IsServer) return null;
-            var node = scene.Instantiate();
+
+            // Off the main thread: instantiating a PackedScene is permitted anywhere, so long as
+            // the result is not added to the tree there (SetupWorldInstance does that on main).
+            //
+            // LongRunning rather than Task.Run deliberately -- it gets a dedicated thread instead of
+            // consuming a ThreadPool worker, and world generation code below this tends to use the
+            // pool itself (Parallel.For, Task.Run), so a pool-bound outer call would sit waiting on
+            // the very pool it is starving.
+            var node = await Task.Factory.StartNew(
+                () => scene.Instantiate(),
+                ct,
+                TaskCreationOptions.LongRunning,
+                TaskScheduler.Default);
+
             if (node is not INetNodeBase netNodeBase)
             {
+                node?.Free();
                 Debugger.Instance.Log(Debugger.DebugLevel.ERROR, $"Failed to create world: root node is not a NetworkController");
                 return null;
             }
-            return SetupWorldInstance(worldId, netNodeBase.Network);
+
+            return await SetupWorldInstance(worldId, netNodeBase.Network, onTreeReady, ct);
         }
 
-        public WorldRunner SetupWorldInstance(UUID worldId, NetworkController node)
+        /// <summary>
+        /// Brings up a world around an already-instantiated root scene -- the restored-world path,
+        /// where the node came from deserialization rather than a PackedScene.
+        /// See <see cref="CreateWorld"/> for the contract.
+        /// </summary>
+        public async Task<WorldRunner> SetupWorldInstance(
+            UUID worldId,
+            NetworkController node,
+            Action<WorldRunner> onTreeReady = null,
+            CancellationToken ct = default)
         {
             if (!IsServer) return null;
+
+            // Everything from here to the end of generation touches the SceneTree and the world
+            // registry, so it belongs on the main thread. Completes inline when already there.
+            await SwitchToMainThread();
+            NebulaThread.AssertMain(nameof(SetupWorldInstance));
             var godotPhysicsWorld = new SubViewport
             {
                 OwnWorld3D = true,
                 World3D = new World3D(),
                 Name = worldId.ToString()
             };
+
+            if (PerWorldThreadGroup)
+            {
+                // The whole world -- its WorldRunner and every node in its scene -- processes on
+                // this group's own thread instead of the main SceneTree walk.
+                godotPhysicsWorld.ProcessThreadGroup = Node.ProcessThreadGroupEnum.SubThread;
+
+                // Order 1 puts every world group strictly after the default main-thread group
+                // (order 0), which is where the NetRunner autoload and therefore the ENet pump
+                // live. Worlds share an order, so they run concurrently with each other.
+                //
+                // This is an ordering convenience, not a synchronization mechanism: the inbound
+                // queue is what actually makes pump/tick overlap safe, because the pump is not the
+                // only thing that touches world state (the World channel completes peer handoffs).
+                godotPhysicsWorld.ProcessThreadGroupOrder = 1;
+
+                // Flush CallDeferredThreadGroup work immediately before this group's
+                // _physics_process, so anything marshalled into the group lands before its tick.
+                godotPhysicsWorld.ProcessThreadMessages = Node.ProcessThreadMessagesEnum.MessagesPhysics;
+            }
+
+            // Nothing in a half-built world may tick: not the WorldRunner, and not the gameplay
+            // nodes underneath it. Disabling the SubViewport is what actually achieves that -- a
+            // Lifecycle check inside WorldRunner._PhysicsProcess would only stop the former.
+            godotPhysicsWorld.ProcessMode = ProcessModeEnum.Disabled;
+
             var worldRunner = new WorldRunner
             {
                 WorldId = worldId,
                 RootScene = node,
+                Lifecycle = WorldRunner.WorldLifecycle.Generating,
             };
+
+            // Registered before the first await below, so two callers racing to create the same
+            // world resolve to one entry instead of each building their own.
             Worlds[worldId] = worldRunner;
-            WorldPeerMap[worldId] = [];
-            godotPhysicsWorld.AddChild(worldRunner);
-            godotPhysicsWorld.AddChild(node.RawNode);
-            GetTree().CurrentScene.AddChild(godotPhysicsWorld);
-            node._NetworkPrepare(worldRunner);
-            node._WorldReady();
+            worldRunner.Debug?.Send("WorldGenerating", worldId.ToString());
+
+            try
+            {
+                godotPhysicsWorld.AddChild(worldRunner);
+                godotPhysicsWorld.AddChild(node.RawNode);
+                GetTree().CurrentScene.AddChild(godotPhysicsWorld);
+                node._NetworkPrepare(worldRunner);
+
+                // Before _WorldReady and before the world can go Live, so callers can install
+                // whatever must exist ahead of the first join.
+                onTreeReady?.Invoke(worldRunner);
+
+                node._WorldReady();
+
+                if (node.RawNode is IAsyncWorldGenerator generator)
+                {
+                    await generator.GenerateWorldAsync(ct);
+                    // Generation is free to hop threads; come back before touching the tree again.
+                    await SwitchToMainThread();
+                }
+
+                ct.ThrowIfCancellationRequested();
+            }
+            catch (Exception)
+            {
+                // Registration and its compensating removal live in the same method, so there is no
+                // path that leaves a half-registered world behind for someone to find later.
+                await SwitchToMainThread();
+                worldRunner.Lifecycle = WorldRunner.WorldLifecycle.Failed;
+                Worlds.Remove(worldId);
+                // Frees the WorldRunner, the world's scene and its World3D along with it.
+                godotPhysicsWorld.QueueFree();
+                throw;
+            }
+
+            worldRunner.Lifecycle = WorldRunner.WorldLifecycle.Live;
+            godotPhysicsWorld.ProcessMode = ProcessModeEnum.Inherit;
+
             worldRunner.Debug?.Send("WorldCreated", worldId.ToString());
+            // Fired only once the world is genuinely usable: subscribers include the autosave hook,
+            // which must never serialize a world that is still being built.
             OnWorldCreated?.Invoke(worldRunner);
+
+            // Anyone who connected while this was still generating can now be let in.
+            AuthenticateWaitingPeers();
+
             return worldRunner;
         }
 
@@ -964,6 +1439,9 @@ namespace Nebula
             Debugger.Instance.Log($"Peer disconnected peerId: {peer.ID}");
             OnPeerDisconnected?.Invoke(peer.ID);
             PeersByNativeId.Remove(peer.ID);
+            // A peer that gave up while waiting for the first world must not be authenticated into
+            // it later.
+            _peersAwaitingWorld.Remove(peer.ID);
         }
     }
 }

--- a/addons/Nebula/Core/NetworkController.cs
+++ b/addons/Nebula/Core/NetworkController.cs
@@ -869,6 +869,122 @@ namespace Nebula
 		}
 
 		/// <summary>
+		/// Resolves the NetArray instance a per-peer array property should expose to the caller,
+		/// forking one for the context peer on first access. Called by generated property getters.
+		///
+		/// Returns <paramref name="baseArray"/> unchanged under the same conditions as
+		/// <see cref="TryReadPerPeer"/> (not the server, no <see cref="ForPeer"/> scope open, the
+		/// owning NetScene root not resolvable yet, or storage absent) — so client-side and
+		/// unscoped server-side access both see the shared base, exactly as before.
+		///
+		/// Inside a scope this returns that peer's own instance, creating it via
+		/// <see cref="NetArray{T}.ForkForPeer"/> if the peer has not diverged yet. Note that an
+		/// array is mutated in place, so this getter cannot distinguish a read from a write: any
+		/// scoped access forks. The fork is content-identical and inherits the peer's sync state,
+		/// so it costs an allocation but no bandwidth.
+		/// </summary>
+		public NetArray<TElem> TryGetPerPeerArray<TElem>(INetNodeBase sourceNode, string propertyName, NetArray<TElem> baseArray, ref int cachedIndex, ref NetworkController cachedRoot) where TElem : struct
+		{
+			var peerId = _contextPeer;
+			if (peerId == default || !PerPeerServerContext)
+			{
+				return baseArray;
+			}
+
+			var root = cachedRoot ?? ResolvePerPeerRoot();
+			if (root == null || root.PerPeerValues == null)
+			{
+				return baseArray;
+			}
+			cachedRoot = root;
+
+			if (cachedIndex < 0)
+			{
+				var staticChildId = sourceNode.Network.StaticChildId;
+				if (!Protocol.LookupPropertyByStaticChildId(root.NetSceneFilePath, staticChildId, propertyName, out var prop))
+				{
+					return baseArray;
+				}
+				cachedIndex = prop.Index;
+			}
+
+			var peerValues = root.PerPeerValues[cachedIndex];
+			if (peerValues == null)
+			{
+				return baseArray;
+			}
+
+			if (peerValues.TryGetValue(peerId, out var existing) && existing.RefValue is NetArray<TElem> forked)
+			{
+				return forked;
+			}
+
+			// A null base cannot be forked; nothing to diverge from yet.
+			if (baseArray == null)
+			{
+				return null;
+			}
+
+			var fork = NetArray<TElem>.ForkForPeer(baseArray, peerId);
+			var cache = new PropertyCache
+			{
+				Type = SerialVariantType.Object,
+				RefValue = fork,
+			};
+			peerValues[peerId] = cache;
+			return fork;
+		}
+
+		/// <summary>
+		/// Writes the context peer's instance for a per-peer reference-typed (object) property —
+		/// the wholesale-assignment counterpart to <see cref="TryWritePerPeer{T}"/>, which is
+		/// constrained to value types and so cannot accept a NetArray.
+		///
+		/// Unlike the primitive path this sets no dirty bit: object properties self-filter every
+		/// tick through their own per-peer sync state rather than through PerPeerDirtyMask. Note
+		/// that assigning a fresh instance discards the peer's sync state along with the old one,
+		/// so the replacement is delivered as a full chunked sync.
+		/// </summary>
+		public bool TryWritePerPeerRef<TObj>(INetNodeBase sourceNode, string propertyName, TObj value, ref int cachedIndex, ref NetworkController cachedRoot) where TObj : class
+		{
+			var peerId = _contextPeer;
+			if (peerId == default || !PerPeerServerContext)
+			{
+				return false;
+			}
+
+			var root = cachedRoot ?? ResolvePerPeerRoot();
+			if (root == null || root.PerPeerValues == null)
+			{
+				return false;
+			}
+			cachedRoot = root;
+
+			if (cachedIndex < 0)
+			{
+				var staticChildId = sourceNode.Network.StaticChildId;
+				if (!Protocol.LookupPropertyByStaticChildId(root.NetSceneFilePath, staticChildId, propertyName, out var prop))
+				{
+					return false;
+				}
+				cachedIndex = prop.Index;
+			}
+
+			var peerValues = root.PerPeerValues[cachedIndex];
+			if (peerValues == null)
+			{
+				return false;
+			}
+
+			peerValues[peerId] = new PropertyCache
+			{
+				Type = SerialVariantType.Object,
+				RefValue = value,
+			};
+			return true;
+		}
+
+		/// <summary>
 		/// Discovers nested NetScenes in the scene tree and populates DynamicNetworkChildren.
 		/// Also sets CachedNodePathIdInParent for spawn serialization.
 		/// Called on server during Setup().

--- a/addons/Nebula/Core/Serialization/NetBuffer.cs
+++ b/addons/Nebula/Core/Serialization/NetBuffer.cs
@@ -15,7 +15,7 @@ namespace Nebula.Serialization
         public const int DefaultCapacity = 1536;
 
         private byte[] _buffer;
-        private readonly int _capacity;
+        private int _capacity; // Not readonly: Attach() re-points wrapper instances at new data.
         private bool _disposed;
         private bool _isPooled;
 
@@ -122,6 +122,29 @@ namespace Nebula.Serialization
             _capacity = data.Length;
             _isPooled = false;
             WritePosition = data.Length;
+            ReadPosition = 0;
+        }
+
+        /// <summary>
+        /// Re-points this instance at existing data for reading, without allocating. The inbound
+        /// packet paths parse one packet after another on a single thread; a long-lived wrapper
+        /// re-attached per packet replaces a per-packet <c>new NetBuffer(byte[])</c>.
+        ///
+        /// Only legal on wrapper instances (created via <see cref="NetBuffer(byte[])"/>): a pooled
+        /// instance would leak its rented storage on the first Attach.
+        /// </summary>
+        /// <param name="data">The array to read from. May be longer than <paramref name="length"/>
+        /// (rented pool arrays are oversized); bytes beyond it are never read.</param>
+        /// <param name="length">The number of valid bytes in <paramref name="data"/>.</param>
+        public void Attach(byte[] data, int length)
+        {
+            if (_isPooled)
+            {
+                throw new InvalidOperationException("Attach is only valid on wrapper NetBuffers (created from an existing array).");
+            }
+            _buffer = data;
+            _capacity = length;
+            WritePosition = length;
             ReadPosition = 0;
         }
 

--- a/addons/Nebula/Core/Serialization/Serializers/NetPropertiesSerializer.cs
+++ b/addons/Nebula/Core/Serialization/Serializers/NetPropertiesSerializer.cs
@@ -1846,7 +1846,9 @@ namespace Nebula.Serialization.Serializers
                 var serializer = Protocol.GetSerializer(classIndex);
                 if (serializer == null) continue;
 
-                ref var cache = ref network.CachedProperties[propIndex];
+                // Per-peer array properties serialize this peer's forked instance; everything else
+                // (and any peer that has not diverged) serializes the shared base.
+                ref var cache = ref ResolveObjectCache(propIndex, peerId);
 
                 // Remember position in case we need to rewind
                 int startPos = buffer.WritePosition;
@@ -2194,6 +2196,29 @@ namespace Nebula.Serialization.Serializers
             }
         }
 
+        /// <summary>
+        /// Resolves the cache slot an object property should serialize for one peer. Per-peer array
+        /// properties (NetProperty.PerPeerState) keep a forked instance per diverged peer in
+        /// PerPeerValues; every other object property, and any peer that has not diverged, uses the
+        /// shared base in CachedProperties. Returns by ref and never allocates.
+        /// </summary>
+        private ref PropertyCache ResolveObjectCache(int propIndex, UUID peerId)
+        {
+            if (_propIsPerPeer[propIndex] && network.PerPeerValues != null)
+            {
+                var peerValues = network.PerPeerValues[propIndex];
+                if (peerValues != null)
+                {
+                    ref var perPeer = ref CollectionsMarshal.GetValueRefOrNullRef(peerValues, peerId);
+                    if (!Unsafe.IsNullRef(ref perPeer) && perPeer.RefValue != null)
+                    {
+                        return ref perPeer;
+                    }
+                }
+            }
+            return ref network.CachedProperties[propIndex];
+        }
+
         public void Cleanup()
         {
             // NOTE: This is called every tick after ExportState(), NOT when the object is destroyed.
@@ -2210,6 +2235,20 @@ namespace Nebula.Serialization.Serializers
                 if (network.CachedProperties[i].RefValue is INetExportAware exportAware)
                 {
                     exportAware.OnExportComplete();
+                }
+
+                // Forked per-peer instances carry their own global dirty set and are invisible to
+                // the base slot above. Skipping them would leave a fork's _dirtyMask set forever,
+                // so it would re-merge the same bits into its pending queue every single tick.
+                if (!_propIsPerPeer[i] || network.PerPeerValues == null) continue;
+                var peerValues = network.PerPeerValues[i];
+                if (peerValues == null) continue;
+                foreach (var entry in peerValues)
+                {
+                    if (entry.Value.RefValue is INetExportAware forkExportAware)
+                    {
+                        forkExportAware.OnExportComplete();
+                    }
                 }
             }
         }
@@ -2258,7 +2297,9 @@ namespace Nebula.Serialization.Serializers
                 var onDisconnected = Protocol.GetOnPeerDisconnected(classIndex);
                 if (onDisconnected == null) continue;
 
-                ref var cache = ref network.CachedProperties[i];
+                // Route to the peer's forked instance when it has one - the base array holds no
+                // state for a diverged peer (ForkForPeer moved it across).
+                ref var cache = ref ResolveObjectCache(i, peerId);
                 if (cache.RefValue != null)
                 {
                     onDisconnected(cache.RefValue, peerId);
@@ -2281,7 +2322,10 @@ namespace Nebula.Serialization.Serializers
                 var onAck = Protocol.GetOnPeerAcknowledge(classIndex);
                 if (onAck == null) continue;
 
-                ref var cache = ref network.CachedProperties[i];
+                // Must resolve per peer: an ack delivered to the base array while this peer is
+                // served by a fork would never clear the fork's pending mask, so it would resend
+                // the same delta forever.
+                ref var cache = ref ResolveObjectCache(i, peerId);
                 if (cache.RefValue != null)
                 {
                     onAck(cache.RefValue, peerId, latestAck);

--- a/addons/Nebula/Core/Serialization/Serializers/SpawnSerializer.cs
+++ b/addons/Nebula/Core/Serialization/Serializers/SpawnSerializer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Godot;
 using Nebula.Utility.Tools;
@@ -27,11 +28,26 @@ namespace Nebula.Serialization.Serializers
             public byte HasInputAuthority;
         }
 
-        // Pre-allocated buffers for nested scene handling (static to avoid per-instance allocation)
-        private static readonly List<NetworkController> _nestedSceneBuffer = new(16);
-        private static readonly NestedSceneData[] _nestedDataBuffer = new NestedSceneData[64];
-        private static int _nestedDataCount;
-        private static readonly List<NetworkController> _allLocalNestedScenes = new(64);
+        // Pre-allocated scratch for nested scene handling, shared across every SpawnSerializer
+        // instance to avoid a per-instance allocation. Each buffer is filled and consumed within a
+        // single Export/Import call chain, so sharing is safe as long as only one such chain runs
+        // at a time.
+        //
+        // [ThreadStatic] is what keeps that true once worlds tick on their own threads (see
+        // NetRunner's per_world_thread_group setting): two worlds exporting concurrently would
+        // otherwise stomp each other's spawn tables, which surfaces as a desync rather than a
+        // crash. Note that [ThreadStatic] and field initializers do NOT mix -- an initializer runs
+        // only on the first thread to touch the type and every other thread silently sees null --
+        // so these are lazily initialized through the properties below and must only ever be
+        // reached that way.
+        [ThreadStatic] private static List<NetworkController> _nestedSceneBuffer;
+        [ThreadStatic] private static NestedSceneData[] _nestedDataBuffer;
+        [ThreadStatic] private static int _nestedDataCount;
+        [ThreadStatic] private static List<NetworkController> _allLocalNestedScenes;
+
+        private static List<NetworkController> NestedSceneBuffer => _nestedSceneBuffer ??= new(16);
+        private static NestedSceneData[] NestedDataBuffer => _nestedDataBuffer ??= new NestedSceneData[64];
+        private static List<NetworkController> AllLocalNestedScenes => _allLocalNestedScenes ??= new(64);
 
         private NetworkController netController;
         private Dictionary<UUID, Tick> setupTicks = new();
@@ -431,14 +447,14 @@ namespace Nebula.Serialization.Serializers
             var peerUUID = NetRunner.Instance.GetPeerId(peer);
 
             // Collect nested NetScenes recursively (entire subtree)
-            _nestedSceneBuffer.Clear();
-            CollectNestedNetScenesRecursive(currentWorld, peer, netController, _nestedSceneBuffer);
+            NestedSceneBuffer.Clear();
+            CollectNestedNetScenesRecursive(currentWorld, peer, netController, NestedSceneBuffer);
 
             // Filter to only include scenes the peer has interest in
             _interestedNestedBuffer.Clear();
-            for (int i = 0; i < _nestedSceneBuffer.Count; i++)
+            for (int i = 0; i < NestedSceneBuffer.Count; i++)
             {
-                var nested = _nestedSceneBuffer[i];
+                var nested = NestedSceneBuffer[i];
                 if (!nested.IsPeerInterested(peer))
                 {
                     continue;
@@ -811,9 +827,9 @@ namespace Nebula.Serialization.Serializers
             CollectAllNestedScenes(nodeOut);
 
             // Match local instances against spawn data
-            for (int i = 0; i < _allLocalNestedScenes.Count; i++)
+            for (int i = 0; i < AllLocalNestedScenes.Count; i++)
             {
-                var local = _allLocalNestedScenes[i];
+                var local = AllLocalNestedScenes[i];
                 var localPathId = local.CachedNodePathIdInParent;
                 var localSceneId = Protocol.PackScene(local.NetSceneFilePath);
 
@@ -821,8 +837,8 @@ namespace Nebula.Serialization.Serializers
                 int matchIndex = -1;
                 for (int j = 0; j < _nestedDataCount; j++)
                 {
-                    if (_nestedDataBuffer[j].NodePathId == localPathId &&
-                        _nestedDataBuffer[j].SceneId == localSceneId)
+                    if (NestedDataBuffer[j].NodePathId == localPathId &&
+                        NestedDataBuffer[j].SceneId == localSceneId)
                     {
                         matchIndex = j;
                         break;
@@ -832,11 +848,11 @@ namespace Nebula.Serialization.Serializers
                 if (matchIndex >= 0)
                 {
                     // Keep local, sync NetId
-                    local.NetId = new NetId(_nestedDataBuffer[matchIndex].NetId);
+                    local.NetId = new NetId(NestedDataBuffer[matchIndex].NetId);
                     local.IsClientSpawn = true;
                     local.CurrentWorld = currentWorld;
                     // Set InputAuthority if this client owns the nested scene
-                    if (_nestedDataBuffer[matchIndex].HasInputAuthority == 1)
+                    if (NestedDataBuffer[matchIndex].HasInputAuthority == 1)
                     {
                         local.InputAuthority = NetRunner.Instance.ServerPeer;
                         currentWorld.MarkOwnedEntitiesDirty();
@@ -851,7 +867,7 @@ namespace Nebula.Serialization.Serializers
                         nestedSpawnSerializer.hasImported = true;
                     }
                     // Mark as processed (use 246 as sentinel, > 245 reserved)
-                    _nestedDataBuffer[matchIndex].SceneId = 246;
+                    NestedDataBuffer[matchIndex].SceneId = 246;
                 }
                 else
                 {
@@ -865,10 +881,10 @@ namespace Nebula.Serialization.Serializers
             // Create any new NetScenes from unmatched spawn data
             for (int i = 0; i < _nestedDataCount; i++)
             {
-                if (_nestedDataBuffer[i].SceneId >= 246 || _nestedDataBuffer[i].SceneId == 0)
+                if (NestedDataBuffer[i].SceneId >= 246 || NestedDataBuffer[i].SceneId == 0)
                     continue;
 
-                var data = _nestedDataBuffer[i];
+                var data = NestedDataBuffer[i];
                 var instance = Protocol.UnpackScene(data.SceneId).Instantiate<INetNodeBase>();
                 instance.Network.NetId = new NetId(data.NetId);
                 instance.Network.IsClientSpawn = true;
@@ -953,7 +969,7 @@ namespace Nebula.Serialization.Serializers
         /// </summary>
         private void CollectAllNestedScenes(NetworkController root)
         {
-            _allLocalNestedScenes.Clear();
+            AllLocalNestedScenes.Clear();
             CollectNestedRecursive(root.RawNode, root.RawNode, root.NetSceneFilePath);
         }
 
@@ -965,7 +981,7 @@ namespace Nebula.Serialization.Serializers
 
                 if (child is INetNodeBase netNode && netNode.Network != null && netNode.Network.IsNetScene())
                 {
-                    _allLocalNestedScenes.Add(netNode.Network);
+                    AllLocalNestedScenes.Add(netNode.Network);
 
                     // Compute and cache the node path ID for matching
                     var relativePath = treeRoot.GetPathTo(child);
@@ -1021,7 +1037,7 @@ namespace Nebula.Serialization.Serializers
         {
             _nestedDataCount = 0;
 
-            for (int i = 0; i < count && i < _nestedDataBuffer.Length; i++)
+            for (int i = 0; i < count && i < NestedDataBuffer.Length; i++)
             {
                 var sceneId = NetReader.ReadByte(buffer);
                 var nodePathId = NetReader.ReadByte(buffer);
@@ -1032,7 +1048,7 @@ namespace Nebula.Serialization.Serializers
                 // Note: sceneId=0 is valid (first registered scene), but netId=0 means no allocation
                 if (netId == 0) continue;
 
-                _nestedDataBuffer[_nestedDataCount++] = new NestedSceneData
+                NestedDataBuffer[_nestedDataCount++] = new NestedSceneData
                 {
                     SceneId = sceneId,
                     NodePathId = nodePathId,

--- a/addons/Nebula/Core/WorldRunner.cs
+++ b/addons/Nebula/Core/WorldRunner.cs
@@ -149,6 +149,34 @@ namespace Nebula
         /// </summary>
         public NetworkController RootScene;
 
+        /// <summary>How far along a world is in coming up. See <see cref="Lifecycle"/>.</summary>
+        public enum WorldLifecycle
+        {
+            /// <summary>Registered and reserving its id, but still being built. Not tickable, not joinable.</summary>
+            Generating,
+
+            /// <summary>Fully built. The only state in which peers may be admitted.</summary>
+            Live,
+
+            /// <summary>Creation threw. The world is being torn down; nothing may reference it.</summary>
+            Failed,
+        }
+
+        /// <summary>
+        /// Where this world is in its creation. A world is registered in
+        /// <see cref="NetRunner.Worlds"/> the instant creation starts -- so that concurrent callers
+        /// resolve to one world rather than racing to build duplicates -- which means "registered"
+        /// no longer implies "ready". This is what distinguishes them.
+        ///
+        /// Ticking is gated separately, by the world SubViewport's ProcessMode, because a
+        /// Lifecycle check inside _PhysicsProcess would still let every gameplay node in a
+        /// half-built world run. This flag is what gates <em>peers</em>: see JoinPeer,
+        /// NetRunner.PeerJoinWorld and NetRunner.MigratePeerToWorld.
+        ///
+        /// Defaults to Generating; creation flips it to Live as its final step.
+        /// </summary>
+        public WorldLifecycle Lifecycle { get; internal set; } = WorldLifecycle.Generating;
+
         internal long networkIdCounter = 1; // Start at 1 because NetId=0 is considered invalid
         private Dictionary<long, NetId> networkIds = [];
         internal Dictionary<NetId, NetworkController> NetScenes = [];
@@ -226,10 +254,6 @@ namespace Nebula
         /// rather than per-world.
         /// </summary>
         public int DebugPort => Hub?.BoundPort ?? 0;
-
-        // Diagnostic counter for RPC calls - remove after debugging
-        public static long TotalRpcCallsProcessed = 0;
-        public static long RpcCallsThisTick = 0;
 
         private List<TickLog> tickLogBuffer = [];
         public void Log(string message, Debugger.DebugLevel level = Debugger.DebugLevel.INFO)
@@ -315,6 +339,7 @@ namespace Nebula
             if (NetRunner.Instance.IsServer)
             {
                 NetRunner.Instance.OnPeerDisconnected -= _onPeerDisconnectedHandler;
+                ReleaseInboundPackets();
             }
         }
 
@@ -732,6 +757,22 @@ namespace Nebula
         }
 
         /// <summary>
+        /// The nodes this client owns. Backed by the same cache prediction uses, and refreshed on
+        /// read when stale — callers outside the prediction loop (a <see cref="Bots.BotBehavior"/>,
+        /// for one) can run before it has rebuilt for this tick and would otherwise see a list that
+        /// is an ownership change behind.
+        /// </summary>
+        public IReadOnlyList<NetworkController> OwnedNodes
+        {
+            get
+            {
+                if (_ownedEntitiesDirty)
+                    RebuildOwnedEntitiesCache();
+                return _ownedEntities;
+            }
+        }
+
+        /// <summary>
         /// Runs one prediction tick for all owned entities.
         /// Called from the independent client tick loop in _PhysicsProcess.
         /// </summary>
@@ -1079,9 +1120,44 @@ namespace Nebula
         }
 
         /// <summary>
+        /// Per-world load instrumentation. Null unless the process was launched with --metrics;
+        /// created on this world's first server tick.
+        /// </summary>
+        private Diagnostics.ServerMetrics _metrics;
+
+        /// <summary>
+        /// Peer count and round-trip spread, for the metrics line. Only called on the tick that
+        /// actually emits, so the scan is once per interval rather than once per tick.
+        /// </summary>
+        private void CollectPeerRtt(out int peers, out double rttMean, out uint rttMax)
+        {
+            peers = 0;
+            rttMax = 0;
+            ulong rttSum = 0;
+            foreach (var peerState in PeerStates.Values)
+            {
+                if (peerState.Status == PeerSyncStatus.DISCONNECTED)
+                    continue;
+                peers++;
+                uint rtt = peerState.Peer.IsSet ? peerState.Peer.RoundTripTime : 0;
+                rttSum += rtt;
+                if (rtt > rttMax) rttMax = rtt;
+            }
+            rttMean = peers > 0 ? rttSum / (double)peers : 0;
+        }
+
+        /// <summary>
         /// Invoked after each network tick completes.
         /// </summary>
         public event Action<Tick> OnAfterNetworkTick;
+
+        /// <summary>
+        /// Client counterpart to <see cref="OnAfterNetworkTick"/>: raised once per network tick,
+        /// immediately before the prediction pass. That placement is the point of it — it is where
+        /// a human's input has just been sampled, so a scripted client acting here produces input
+        /// indistinguishable from a played one.
+        /// </summary>
+        public event Action<Tick> OnClientNetworkTick;
 
         /// <summary>
         /// Invoked when a player joins the world (sync status becomes IN_WORLD).
@@ -1113,7 +1189,7 @@ namespace Nebula
 
             if (peer.State == ENet.PeerState.Connected)
             {
-                peer.Disconnect(0);
+                NetRunner.DisconnectPeer(peer, 0);
             }
 
             // forgetIdentity: true — the peer is leaving for good, so also drop its global
@@ -1153,6 +1229,8 @@ namespace Nebula
         /// </summary>
         private void TeardownPeer(NetPeer peer, UUID peerId, bool forgetIdentity, bool despawnOwnedNodes)
         {
+            // Deliberately NOT asserted main-thread: the ack-timeout sweep calls this from inside
+            // ServerProcessTick. The shared-registry mutations at the end are deferred instead.
             var peerState = PeerStates[peerId];
             foreach (var netController in peerState.OwnedNodes)
             {
@@ -1215,13 +1293,27 @@ namespace Nebula
             _peerPendingAcks.Remove(peerId); // Fix #5: Clean up pending acks tracking
             _peerNetBufferPool.Remove(peerId); // Clean up pooled export buffer
             _peerListDirty = true; // Fix #1: Mark peer list as dirty
-            NetRunner.Instance.WorldPeerMap.Remove(peerId);
-            NetRunner.Instance.PeerWorldMap.Remove(peerId);
-            if (forgetIdentity)
+
+            // Everything above is this world's own state, so it belongs on whichever thread is
+            // running this world. NetRunner's registries are not: the ENet pump reads them every
+            // frame on the main thread, and the ack-timeout sweep reaches here from inside
+            // ServerProcessTick. RunOnMainThread executes inline when already on the main thread,
+            // so with per-world thread groups off this is exactly the previous behavior.
+            //
+            // Deferring by a frame is harmless: a stale PeerWorldMap entry only means the pump
+            // routes one more frame of this peer's packets into this world, where they queue and
+            // then find no PeerState.
+            var nativePeerId = peer.ID;
+            NetRunner.Instance.RunOnMainThread(() =>
             {
-                NetRunner.Instance.Peers.Remove(peerId);
-                NetRunner.Instance.PeerIds.Remove(peer.ID);
-            }
+                NetRunner.Instance.PeerWorldMap.Remove(peerId);
+                if (forgetIdentity)
+                {
+                    NetRunner.Instance.Peers.Remove(peerId);
+                    NetRunner.Instance.PeerIds.Remove(nativePeerId);
+                }
+            });
+
             OnPlayerCleanup?.Invoke(WorldId, peerId);
         }
 
@@ -1258,6 +1350,7 @@ namespace Nebula
                 if (ticksSinceLastAck > ackTimeoutTicks)
                 {
                     Log(Debugger.DebugLevel.WARN, $"[ACK TIMEOUT] Peer {peerId} has not acknowledged for {ticksSinceLastAck} ticks ({ticksSinceLastAck / (float)NetRunner.TPS:F1}s). Force disconnecting.");
+                    _metrics?.RecordAckTimeout();
                     _peersToDisconnect.Add(peerState.Peer);
                 }
             }
@@ -1453,8 +1546,10 @@ namespace Nebula
                         if (rawSize > NetRunner.MTU)
                         {
                             Log(Debugger.DebugLevel.ERROR, $"[MTU EXCEEDED] Peer {peer.ID} tick {CurrentTick}: Uncompressed size {rawSize} exceeds MTU {NetRunner.MTU} (on wire {buffer.Length}) - PACKET MAY BE CORRUPTED!");
+                            _metrics?.RecordMtuExceeded();
                         }
 
+                        _metrics?.RecordPacket(buffer.Length);
                         NetRunner.SendUnreliableSequenced(peer, (byte)NetRunner.ENetChannelId.Tick, buffer);
 
                         // Remember what we sent; it becomes a delta baseline once this peer acks it.
@@ -1678,6 +1773,174 @@ namespace Nebula
             }
         }
 
+        /// <summary>An inbound packet routed to this world, awaiting the world's next physics frame.</summary>
+        private readonly struct InboundPacket
+        {
+            public readonly NetPeer Peer;
+            public readonly byte Channel;
+            /// <summary>Rented from ArrayPool&lt;byte&gt;.Shared and OWNED by this queue from the
+            /// moment of enqueue; returned to the pool on drop, after apply, or at teardown.</summary>
+            public readonly byte[] Payload;
+            /// <summary>Valid byte count -- rented arrays are oversized, only [0, Length) is packet data.</summary>
+            public readonly int Length;
+
+            public InboundPacket(NetPeer peer, byte channel, byte[] payload, int length)
+            {
+                Peer = peer;
+                Channel = channel;
+                Payload = payload;
+                Length = length;
+            }
+        }
+
+        /// <summary>
+        /// Sized for the worst realistic frame: every peer's input plus an ack, with headroom.
+        /// Overflow drops rather than grows -- an unbounded queue turns a burst into a memory
+        /// problem, and this mirrors the pump's existing posture that one misbehaving sender must
+        /// never stall everyone.
+        /// </summary>
+        private const int InboundQueueCapacity = 1024;
+
+        private readonly InboundPacket[] _inboundPackets = new InboundPacket[InboundQueueCapacity];
+        private int _inboundHead;
+        private int _inboundTail;
+        private int _inboundCount;
+        private readonly object _inboundLock = new();
+        private bool _loggedInboundOverflow;
+        private bool _loggedTickThread;
+
+        /// <summary>
+        /// Hands a packet to this world from the ENet pump.
+        ///
+        /// The pump runs on the main thread while this world may be mid-tick on its own thread, so
+        /// packets are queued here instead of being applied inline. Parsing deliberately happens at
+        /// drain time, on the world's thread, so the pump stays a pure router.
+        ///
+        /// Fully allocation-free: <paramref name="payload"/> is RENTED from
+        /// ArrayPool&lt;byte&gt;.Shared by the pump, and this call transfers ownership -- the queue
+        /// returns it to the pool on drop, after apply, or at world teardown. Callers must not
+        /// touch the array after this returns.
+        /// </summary>
+        internal void EnqueueInboundPacket(NetPeer peer, byte channel, byte[] payload, int length)
+        {
+            lock (_inboundLock)
+            {
+                if (_inboundCount == InboundQueueCapacity)
+                {
+                    if (!_loggedInboundOverflow)
+                    {
+                        _loggedInboundOverflow = true;
+                        Log(Debugger.DebugLevel.WARN,
+                            $"Inbound packet queue for world {WorldId} overflowed at {InboundQueueCapacity}; dropping packets. Logged once.");
+                    }
+                    // Dropped, so ownership ends here: the rented payload goes back to the pool.
+                    System.Buffers.ArrayPool<byte>.Shared.Return(payload);
+                    return;
+                }
+
+                _inboundPackets[_inboundTail] = new InboundPacket(peer, channel, payload, length);
+                _inboundTail = (_inboundTail + 1) % InboundQueueCapacity;
+                _inboundCount++;
+            }
+        }
+
+        /// <summary>
+        /// Applies everything queued by <see cref="EnqueueInboundPacket"/>, in arrival order.
+        ///
+        /// Bounded to the count present on entry: the pump can enqueue concurrently, and an
+        /// unbounded loop would let a busy frame of inbound traffic hold this world's thread
+        /// indefinitely.
+        /// </summary>
+        private void DrainInboundPackets()
+        {
+            int pending;
+            lock (_inboundLock)
+            {
+                pending = _inboundCount;
+            }
+
+            while (pending-- > 0)
+            {
+                InboundPacket packet;
+                lock (_inboundLock)
+                {
+                    if (_inboundCount == 0) return;
+                    packet = _inboundPackets[_inboundHead];
+                    // Release the payload reference so a quiet world doesn't pin up to
+                    // InboundQueueCapacity packets until the slot is reused.
+                    _inboundPackets[_inboundHead] = default;
+                    _inboundHead = (_inboundHead + 1) % InboundQueueCapacity;
+                    _inboundCount--;
+                }
+
+                ApplyInboundPacket(packet);
+
+                // Every consumer copies what it keeps (NetReader.ReadBytes materializes copies;
+                // acks are values), so the rented payload can go straight back to the pool.
+                System.Buffers.ArrayPool<byte>.Shared.Return(packet.Payload);
+            }
+        }
+
+        /// <summary>
+        /// Reusable wrapper for parsing queued payloads in place. Re-pointed at each packet via
+        /// <see cref="NetBuffer.Attach"/> -- one long-lived object instead of a NetBuffer
+        /// allocation per packet. Only ever touched by this world's drain (single-threaded).
+        /// </summary>
+        private readonly NetBuffer _inboundParseBuffer = new(System.Array.Empty<byte>());
+
+        private void ApplyInboundPacket(in InboundPacket packet)
+        {
+            // Per-packet catch, matching the pump's original contract: a malformed packet must never
+            // abort the drain and take out every other peer's traffic this frame.
+            try
+            {
+                _inboundParseBuffer.Attach(packet.Payload, packet.Length);
+                switch ((NetRunner.ENetChannelId)packet.Channel)
+                {
+                    case NetRunner.ENetChannelId.Tick:
+                        if (packet.Length == 0) break;
+                        PeerAcknowledge(packet.Peer, NetReader.ReadInt32(_inboundParseBuffer));
+                        break;
+
+                    case NetRunner.ENetChannelId.Input:
+                        ReceiveInput(packet.Peer, _inboundParseBuffer);
+                        break;
+
+                    case NetRunner.ENetChannelId.Function:
+                        ReceiveNetFunction(packet.Peer, _inboundParseBuffer);
+                        break;
+                }
+            }
+            catch (Exception ex)
+            {
+                Log(Debugger.DebugLevel.ERROR,
+                    $"[Nebula][MalformedPacket] Failed to parse packet on channel {packet.Channel} from peer {packet.Peer.ID}: {ex.Message}");
+                NetRunner.DisconnectPeer(packet.Peer, NetRunner.MalformedPacketDisconnectCode);
+            }
+        }
+
+        /// <summary>
+        /// Returns any still-queued rented payloads to the pool. Without this, packets that arrived
+        /// after this world's final drain would leak their pool arrays when the world is freed.
+        /// </summary>
+        private void ReleaseInboundPackets()
+        {
+            lock (_inboundLock)
+            {
+                while (_inboundCount > 0)
+                {
+                    var packet = _inboundPackets[_inboundHead];
+                    _inboundPackets[_inboundHead] = default;
+                    _inboundHead = (_inboundHead + 1) % InboundQueueCapacity;
+                    _inboundCount--;
+                    if (packet.Payload != null)
+                    {
+                        System.Buffers.ArrayPool<byte>.Shared.Return(packet.Payload);
+                    }
+                }
+            }
+        }
+
         public override void _PhysicsProcess(double delta)
         {
             base._PhysicsProcess(delta);
@@ -1686,6 +1949,24 @@ namespace Nebula
 
             if (NetRunner.Instance.IsServer)
             {
+                if (!_loggedTickThread)
+                {
+                    // One line per world, on its first server frame, naming the thread it ticks on.
+                    // Whether per-world thread groups actually took effect is otherwise invisible
+                    // until something goes wrong, and "did the flag do anything?" is the first
+                    // question worth being able to answer from a log.
+                    _loggedTickThread = true;
+                    Log(Debugger.DebugLevel.INFO,
+                        $"World {WorldId} ticking on thread {System.Environment.CurrentManagedThreadId}"
+                        + $" ({(NebulaThread.IsMain ? "main" : "worker")}).");
+                }
+
+                // Drained every physics frame, deliberately ahead of the network-tick gate below.
+                // The ENet pump used to apply acks and inputs inline as it read them, so they landed
+                // on the frame they arrived; draining only on tick frames would add up to
+                // PhysicsTicksPerNetworkTick-1 frames of latency to every one of them.
+                DrainInboundPackets();
+
                 _frameCounter += 1;
                 if (_frameCounter < NetRunner.PhysicsTicksPerNetworkTick)
                     return;
@@ -1702,6 +1983,17 @@ namespace Nebula
                 if (elapsedMs > 15)
                 {
                     Log(Debugger.DebugLevel.WARN, $"ServerProcessTick took {elapsedMs:F2} ms");
+                }
+
+                if (Diagnostics.ServerMetrics.Enabled)
+                {
+                    _metrics ??= new Diagnostics.ServerMetrics();
+                    _metrics.RecordTick(elapsedMs);
+                    if (_metrics.IsDue(out double metricsWindow))
+                    {
+                        CollectPeerRtt(out int metricsPeers, out double rttMean, out uint rttMax);
+                        _metrics.Emit(WorldId, CurrentTick, metricsPeers, rttMean, rttMax, metricsWindow);
+                    }
                 }
 #if DEBUG
                 // stopwatch.Stop();
@@ -1723,6 +2015,10 @@ namespace Nebula
                     {
                         _clientFrameCounter = 0;
                         _eligibleFrameIndex++;
+
+                        // Ahead of prediction, so anything a subscriber does to the input state is
+                        // picked up by this tick rather than the next one.
+                        OnClientNetworkTick?.Invoke(CurrentTick);
 
                         // Adaptive lead slew: steer the predicted timeline toward an
                         // RTT-derived lead instead of free-running (see the slew block
@@ -2236,6 +2532,10 @@ namespace Nebula
         {
             if (NetRunner.Instance.IsClient) return null;
 
+            // Live-tree AddChild plus NetId allocation plus a pass over NetRunner.Instance.Peers --
+            // none of which is safe off the main thread.
+            NebulaThread.AssertMain(nameof(Spawn));
+
             if (!node.Network.IsNetScene())
             {
                 Debugger.Instance.Log(Debugger.DebugLevel.ERROR, $"Only Net Scenes can be spawned (i.e. a scene where the root node is an NetNode). Attempting to spawn node that isn't a Net Scene: {node.Network.RawNode.Name} on {parent.RawNode.Name}/{netNodePath}");
@@ -2312,6 +2612,16 @@ namespace Nebula
 
         internal void JoinPeer(NetPeer peer, string token)
         {
+            // Mutates NetRunner's peer registries, which the ENet pump reads every frame.
+            NebulaThread.AssertMain(nameof(JoinPeer));
+
+            if (Lifecycle != WorldLifecycle.Live)
+            {
+                Log(Debugger.DebugLevel.ERROR,
+                    $"JoinPeer: world {WorldId} is {Lifecycle}, not Live. Refusing to admit peer {peer.ID}.");
+                return;
+            }
+
             var peerId = NetRunner.Instance.GetPeerId(peer);
             NetRunner.Instance.PeerWorldMap[peerId] = this;
             PeerStates[peerId] = new PeerState

--- a/addons/Nebula/Generator/NetPropertyGenerator.cs
+++ b/addons/Nebula/Generator/NetPropertyGenerator.cs
@@ -54,7 +54,7 @@ public class NetPropertyGenerator : IIncrementalGenerator
     private static readonly DiagnosticDescriptor PerPeerInvalidTypeDiagnostic = new(
         id: "NEBULA007",
         title: "Per-peer property type not supported",
-        messageFormat: "Property '{0}' has PerPeerState=true but type '{1}' is not supported. Per-peer properties must be primitive value types (int, bool, long, float, enums, Vector*, UUID, NetId, ...) - reference types, string, INetSerializable and NetArray are not supported",
+        messageFormat: "Property '{0}' has PerPeerState=true but type '{1}' is not supported. Per-peer properties must be primitive value types (int, bool, long, float, enums, Vector*, UUID, NetId, ...) or NetArray<T> - other reference types, string and INetSerializable are not supported",
         category: "Nebula",
         DiagnosticSeverity.Error,
         isEnabledByDefault: true);
@@ -228,10 +228,13 @@ public class NetPropertyGenerator : IIncrementalGenerator
     private static bool EmitsPerPeerImplementation(PropertyInfo prop) =>
         prop.IsPerPeer
         && prop.IsPartial
-        && prop.IsValueType
-        && !prop.ImplementsINetSerializable
         && !prop.Predicted
-        && !prop.Interpolate;
+        && !prop.Interpolate
+        // NetArray is a reference type implementing INetSerializable, but it is the one object
+        // type per-peer state supports: its sync/ack machinery is already keyed by peer, so the
+        // server just hands the peer's forked instance to the existing serializer.
+        && (IsNetArrayType(prop.PropertyType)
+            || (prop.IsValueType && !prop.ImplementsINetSerializable));
 
     /// <summary>
     /// Counts the number of [NetProperty] properties in all base classes of the given type.
@@ -559,7 +562,8 @@ public class NetPropertyGenerator : IIncrementalGenerator
             {
                 if (!prop!.IsPerPeer || prop.PropertyLocation == null) continue;
 
-                if (!prop.IsValueType || prop.ImplementsINetSerializable)
+                // NetArray is the one supported object type - see EmitsPerPeerImplementation.
+                if (!IsNetArrayType(prop.PropertyType) && (!prop.IsValueType || prop.ImplementsINetSerializable))
                 {
                     context.ReportDiagnostic(Diagnostic.Create(
                         PerPeerInvalidTypeDiagnostic,
@@ -609,15 +613,27 @@ public class NetPropertyGenerator : IIncrementalGenerator
 
                 if (EmitsPerPeerImplementation(prop))
                 {
-                    var readExpr = GetCacheReadExpression(prop, "__cache");
+                    bool perPeerIsNetArray = IsNetArrayType(prop.PropertyType);
+
                     sb.AppendLine($"    private {prop.PropertyType} __netBase_{prop.PropertyName};");
                     sb.AppendLine($"    private int __netPerPeerIdx_{prop.PropertyName} = -1;");
                     sb.AppendLine($"    private Nebula.NetworkController __netPerPeerRoot_{prop.PropertyName};");
                     sb.AppendLine();
                     sb.AppendLine("    /// <summary>");
-                    sb.AppendLine("    /// Per-peer property: inside Network.ForPeer(peer) accessors target that peer's");
-                    sb.AppendLine("    /// value; outside any scope they target the base value broadcast to peers without");
-                    sb.AppendLine("    /// an override. See NetProperty.PerPeerState.");
+                    if (perPeerIsNetArray)
+                    {
+                        sb.AppendLine("    /// Per-peer array property: inside Network.ForPeer(peer) the getter returns that");
+                        sb.AppendLine("    /// peer's own instance, forking it from the base on first scoped access; outside any");
+                        sb.AppendLine("    /// scope it returns the base instance shared by peers that have not diverged.");
+                        sb.AppendLine("    /// An array is mutated in place, so ANY scoped access forks - including a read.");
+                        sb.AppendLine("    /// See NetProperty.PerPeerState.");
+                    }
+                    else
+                    {
+                        sb.AppendLine("    /// Per-peer property: inside Network.ForPeer(peer) accessors target that peer's");
+                        sb.AppendLine("    /// value; outside any scope they target the base value broadcast to peers without");
+                        sb.AppendLine("    /// an override. See NetProperty.PerPeerState.");
+                    }
                     sb.AppendLine("    /// </summary>");
                     sb.AppendLine("    [global::PropertyChanged.DoNotNotify]");
                     sb.AppendLine($"    {prop.Accessibility} partial {prop.PropertyType} {prop.PropertyName}");
@@ -625,23 +641,46 @@ public class NetPropertyGenerator : IIncrementalGenerator
                     sb.AppendLine("        get");
                     sb.AppendLine("        {");
                     sb.AppendLine("            // Network is null in the editor (node ctors skip controller creation there)");
-                    sb.AppendLine("            if (Network is not null");
-                    sb.AppendLine($"                && Network.TryReadPerPeer(this, \"{prop.PropertyName}\", ref __netPerPeerIdx_{prop.PropertyName}, ref __netPerPeerRoot_{prop.PropertyName}, out var __cache))");
-                    sb.AppendLine("            {");
-                    sb.AppendLine($"                return {readExpr};");
-                    sb.AppendLine("            }");
+                    if (perPeerIsNetArray)
+                    {
+                        sb.AppendLine("            if (Network is not null)");
+                        sb.AppendLine("            {");
+                        sb.AppendLine($"                return Network.TryGetPerPeerArray(this, \"{prop.PropertyName}\", __netBase_{prop.PropertyName}, ref __netPerPeerIdx_{prop.PropertyName}, ref __netPerPeerRoot_{prop.PropertyName});");
+                        sb.AppendLine("            }");
+                    }
+                    else
+                    {
+                        sb.AppendLine("            if (Network is not null");
+                        sb.AppendLine($"                && Network.TryReadPerPeer(this, \"{prop.PropertyName}\", ref __netPerPeerIdx_{prop.PropertyName}, ref __netPerPeerRoot_{prop.PropertyName}, out var __cache))");
+                        sb.AppendLine("            {");
+                        sb.AppendLine($"                return {GetCacheReadExpression(prop, "__cache")};");
+                        sb.AppendLine("            }");
+                    }
                     sb.AppendLine($"            return __netBase_{prop.PropertyName};");
                     sb.AppendLine("        }");
                     sb.AppendLine("        set");
                     sb.AppendLine("        {");
                     sb.AppendLine("            // Per-peer route first: a write inside ForPeer must not touch the base value");
-                    sb.AppendLine("            if (Network is not null");
-                    sb.AppendLine($"                && Network.TryWritePerPeer(this, \"{prop.PropertyName}\", value, ref __netPerPeerIdx_{prop.PropertyName}, ref __netPerPeerRoot_{prop.PropertyName}))");
-                    sb.AppendLine("            {");
-                    sb.AppendLine("                return;");
-                    sb.AppendLine("            }");
-                    sb.AppendLine($"            __netBase_{prop.PropertyName} = value;");
-                    sb.AppendLine($"            Network?.MarkDirty(this, \"{prop.PropertyName}\", value);");
+                    if (perPeerIsNetArray)
+                    {
+                        sb.AppendLine("            if (Network is not null");
+                        sb.AppendLine($"                && Network.TryWritePerPeerRef(this, \"{prop.PropertyName}\", value, ref __netPerPeerIdx_{prop.PropertyName}, ref __netPerPeerRoot_{prop.PropertyName}))");
+                        sb.AppendLine("            {");
+                        sb.AppendLine("                return;");
+                        sb.AppendLine("            }");
+                        sb.AppendLine($"            __netBase_{prop.PropertyName} = value;");
+                        sb.AppendLine($"            Network?.MarkDirtyRef(this, \"{prop.PropertyName}\", value);");
+                    }
+                    else
+                    {
+                        sb.AppendLine("            if (Network is not null");
+                        sb.AppendLine($"                && Network.TryWritePerPeer(this, \"{prop.PropertyName}\", value, ref __netPerPeerIdx_{prop.PropertyName}, ref __netPerPeerRoot_{prop.PropertyName}))");
+                        sb.AppendLine("            {");
+                        sb.AppendLine("                return;");
+                        sb.AppendLine("            }");
+                        sb.AppendLine($"            __netBase_{prop.PropertyName} = value;");
+                        sb.AppendLine($"            Network?.MarkDirty(this, \"{prop.PropertyName}\", value);");
+                    }
                     sb.AppendLine("        }");
                     sb.AppendLine("    }");
                     sb.AppendLine();

--- a/addons/Nebula/Testing/Unit/InboundPacketQueueTests.cs
+++ b/addons/Nebula/Testing/Unit/InboundPacketQueueTests.cs
@@ -1,0 +1,306 @@
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Nebula.Testing.Unit;
+
+/// <summary>
+/// Covers the per-world inbound packet queue.
+///
+/// The ENet pump runs on the main thread and used to apply acks, inputs and net functions to a
+/// world inline as it read them. That is only sound while worlds also tick on the main thread; with
+/// per-world thread groups the pump can be writing into a world that is simultaneously mid-tick on
+/// its own thread. So the pump became a pure router: it queues here, and the world drains on its own
+/// thread at the top of its next physics frame.
+///
+/// These tests pin the queue's mechanics -- FIFO order, the bounded-drain contract, overflow
+/// behavior, and the fact that drained slots release their payload -- without needing a live world,
+/// since applying a packet requires peer state the unit harness has no way to build.
+/// </summary>
+[NebulaUnitTest]
+public class InboundPacketQueueTests
+{
+    private const BindingFlags Hidden = BindingFlags.NonPublic | BindingFlags.Instance;
+
+    /// <summary>
+    /// Channel 4 is the World channel, which ApplyInboundPacket deliberately has no case for. That
+    /// lets a drain exercise the ring's bookkeeping without touching peer state that cannot be
+    /// constructed here.
+    /// </summary>
+    private const byte InertChannel = 4;
+
+    private static int Capacity =>
+        (int)typeof(WorldRunner)
+            .GetField("InboundQueueCapacity", BindingFlags.NonPublic | BindingFlags.Static)
+            .GetRawConstantValue();
+
+    private static int CountOf(WorldRunner world) =>
+        (int)typeof(WorldRunner).GetField("_inboundCount", Hidden).GetValue(world);
+
+    private static void Drain(WorldRunner world) =>
+        typeof(WorldRunner).GetMethod("DrainInboundPackets", Hidden).Invoke(world, null);
+
+    private static WorldRunner NewWorld() => new() { WorldId = new UUID() };
+
+    /// <summary>
+    /// Rents a payload and enqueues it, matching the pump's ownership contract: every payload
+    /// handed to the queue MUST come from ArrayPool&lt;byte&gt;.Shared, because the queue returns
+    /// it there on drop, after apply, or at teardown.
+    /// </summary>
+    private static void Enqueue(WorldRunner world, byte fill = 1, int length = 1)
+    {
+        var payload = System.Buffers.ArrayPool<byte>.Shared.Rent(length);
+        payload[0] = fill;
+        world.EnqueueInboundPacket(default, InertChannel, payload, length);
+    }
+
+    [NebulaUnitTest]
+    public void TestEnqueueThenDrainEmptiesTheQueue()
+    {
+        var world = NewWorld();
+        try
+        {
+            for (int i = 0; i < 8; i++)
+            {
+                Enqueue(world, fill: (byte)i);
+            }
+            Assert.Equal(8, CountOf(world));
+
+            Drain(world);
+            Assert.Equal(0, CountOf(world));
+        }
+        finally { world.Free(); }
+    }
+
+    [NebulaUnitTest]
+    public void TestDrainedSlotsReleaseTheirPayload()
+    {
+        var world = NewWorld();
+        try
+        {
+            Enqueue(world, length: 64);
+            Drain(world);
+
+            // A drained slot must not keep holding its payload: a world that goes quiet after a
+            // burst would otherwise pin up to a full ring of packets until those slots are reused.
+            var ring = (System.Array)typeof(WorldRunner).GetField("_inboundPackets", Hidden).GetValue(world);
+            var slot = ring.GetValue(0);
+            var payload = slot.GetType().GetField("Payload").GetValue(slot);
+            Assert.Null(payload);
+        }
+        finally { world.Free(); }
+    }
+
+    [NebulaUnitTest]
+    public void TestOverflowDropsRatherThanGrowing()
+    {
+        var world = NewWorld();
+        try
+        {
+            // Deliberately overshoot: an unbounded queue would turn a traffic burst into a memory
+            // problem, so the contract is drop-and-warn at the cap.
+            for (int i = 0; i < Capacity + 50; i++)
+            {
+                Enqueue(world);
+            }
+
+            Assert.Equal(Capacity, CountOf(world));
+
+            Drain(world);
+            Assert.Equal(0, CountOf(world));
+        }
+        finally { world.Free(); }
+    }
+
+    [NebulaUnitTest]
+    public void TestRingWrapsAroundCorrectly()
+    {
+        var world = NewWorld();
+        try
+        {
+            // Push the head/tail past the end of the backing array several times over. A modulo
+            // slip here would silently reorder or duplicate packets rather than fail outright.
+            for (int round = 0; round < 3; round++)
+            {
+                int batch = (Capacity * 2) / 3;
+                for (int i = 0; i < batch; i++)
+                {
+                    Enqueue(world, fill: (byte)i);
+                }
+                Assert.Equal(batch, CountOf(world));
+                Drain(world);
+                Assert.Equal(0, CountOf(world));
+            }
+        }
+        finally { world.Free(); }
+    }
+
+    [NebulaUnitTest]
+    public void TestSteadyStateEnqueueDrainAllocatesNothing()
+    {
+        var world = NewWorld();
+        try
+        {
+            // Reflection Invoke allocates, so bind the drain once as a delegate for the
+            // measured loop.
+            var drain = (System.Action)System.Delegate.CreateDelegate(
+                typeof(System.Action), world,
+                typeof(WorldRunner).GetMethod("DrainInboundPackets", Hidden));
+
+            // Warm up: first rents populate the pool's thread-local buckets, lazy statics run.
+            for (int i = 0; i < 8; i++) Enqueue(world);
+            drain();
+
+            long before = System.GC.GetAllocatedBytesForCurrentThread();
+            for (int round = 0; round < 32; round++)
+            {
+                for (int i = 0; i < 8; i++) Enqueue(world);
+                drain();
+            }
+            long allocated = System.GC.GetAllocatedBytesForCurrentThread() - before;
+
+            // The whole point of pooling the payloads and re-attaching one parse wrapper: a busy
+            // server's inbound path must produce zero garbage per packet.
+            Assert.True(allocated == 0, $"steady-state enqueue/drain allocated {allocated} bytes");
+        }
+        finally { world.Free(); }
+    }
+
+    [NebulaUnitTest]
+    public void TestConcurrentEnqueuesAreNotLost()
+    {
+        var world = NewWorld();
+        try
+        {
+            // The pump enqueues from the main thread while, in principle, other producers exist;
+            // the lock has to account every packet exactly once.
+            const int threads = 4;
+            const int perThread = 100;
+
+            var workers = new List<Thread>();
+            using var start = new ManualResetEventSlim(false);
+            for (int t = 0; t < threads; t++)
+            {
+                var thread = new Thread(() =>
+                {
+                    start.Wait();
+                    for (int i = 0; i < perThread; i++)
+                    {
+                        Enqueue(world);
+                    }
+                });
+                thread.Start();
+                workers.Add(thread);
+            }
+
+            start.Set();
+            foreach (var thread in workers)
+            {
+                Assert.True(thread.Join(10_000), "producer thread did not finish");
+            }
+
+            Assert.Equal(threads * perThread, CountOf(world));
+        }
+        finally { world.Free(); }
+    }
+}
+
+/// <summary>
+/// Covers NetRunner's main-thread marshalling queue: the mechanism by which work that originates on
+/// a world's tick thread (peer registry teardown, and world creation once it is async) gets back
+/// onto the main thread, where the SceneTree and the shared peer registries can be touched safely.
+/// </summary>
+[NebulaUnitTest]
+public class MainThreadWorkQueueTests
+{
+    private static void Drain() =>
+        typeof(NetRunner)
+            .GetMethod("DrainMainThreadWork", BindingFlags.NonPublic | BindingFlags.Instance)
+            .Invoke(NetRunner.Instance, null);
+
+    [NebulaUnitTest]
+    public void TestRunsInlineWhenAlreadyOnMainThread()
+    {
+        // Callers on the main thread must not be deferred by a frame -- that would add latency to
+        // every peer join and leave for no reason, and would change behavior with the thread-group
+        // flag off.
+        bool ran = false;
+        NetRunner.Instance.RunOnMainThread(() => ran = true);
+        Assert.True(ran);
+    }
+
+    [NebulaUnitTest]
+    public void TestDefersWorkQueuedFromAnotherThread()
+    {
+        bool ran = false;
+
+        var worker = new Thread(() => NetRunner.Instance.RunOnMainThread(() => ran = true));
+        worker.Start();
+        Assert.True(worker.Join(10_000), "worker thread did not finish");
+
+        // Queued, not executed: the whole point is that it waits for a main-thread turn.
+        Assert.False(ran);
+
+        Drain();
+        Assert.True(ran);
+    }
+
+    [NebulaUnitTest]
+    public void TestAThrowingItemDoesNotStopTheRest()
+    {
+        // One bad deferred item must not strand every other peer's teardown behind it.
+        bool laterRan = false;
+
+        var worker = new Thread(() =>
+        {
+            NetRunner.Instance.RunOnMainThread(() => throw new System.InvalidOperationException("boom"));
+            NetRunner.Instance.RunOnMainThread(() => laterRan = true);
+        });
+        worker.Start();
+        Assert.True(worker.Join(10_000), "worker thread did not finish");
+
+        Drain();
+        Assert.True(laterRan);
+    }
+
+    private static async Task HopAndRecordThread(System.Action<int> record)
+    {
+        await NetRunner.Instance.SwitchToMainThread();
+        record(System.Environment.CurrentManagedThreadId);
+    }
+
+    [NebulaUnitTest]
+    public void TestSwitchToMainThreadCompletesInlineOnMainThread()
+    {
+        Assert.True(NetRunner.Instance.SwitchToMainThread().GetAwaiter().IsCompleted);
+
+        // And therefore an await runs straight through with no drain needed.
+        bool ran = false;
+        var hop = HopAndRecordThread(_ => ran = true);
+        Assert.True(ran);
+        Assert.True(hop.IsCompletedSuccessfully);
+    }
+
+    [NebulaUnitTest]
+    public void TestSwitchToMainThreadResumesOnMainThreadAtDrain()
+    {
+        int resumedOnThread = 0;
+        Task hop = null;
+        var worker = new Thread(() => hop = HopAndRecordThread(id => resumedOnThread = id));
+        worker.Start();
+        Assert.True(worker.Join(10_000), "worker thread did not finish");
+
+        Assert.False(hop.IsCompleted);
+
+        Drain();
+        Assert.True(hop.Wait(10_000), "hop did not complete after a main-thread drain");
+
+        // The regression this pins: a TaskCompletionSource-based hop completed *after* main
+        // signalled but resumed on the ThreadPool, because a world thread has no
+        // SynchronizationContext for the continuation to come back through. The awaitable must
+        // resume the caller ON the draining thread itself.
+        Assert.Equal(System.Environment.CurrentManagedThreadId, resumedOnThread);
+    }
+}

--- a/addons/Nebula/Testing/Unit/InboundPacketQueueTests.cs.uid
+++ b/addons/Nebula/Testing/Unit/InboundPacketQueueTests.cs.uid
@@ -1,0 +1,1 @@
+uid://bie3wh86ip0h

--- a/addons/Nebula/Testing/Unit/NetArraySyncTests.cs
+++ b/addons/Nebula/Testing/Unit/NetArraySyncTests.cs
@@ -563,4 +563,205 @@ public class NetArraySyncTests
         for (int i = 0; i < arr.Length; i++)
             Assert.Equal(arr[i], restored[i]);
     }
+
+    // ------------------------------------------------------------------------------------------------
+    // Per-peer forking (NetProperty.PerPeerState on a NetArray). The server keeps one instance per
+    // diverged peer; ForkForPeer clones the contents AND MOVES that peer's PeerSyncState across, so a
+    // peer that forks without mutating is already fully synced and sends nothing. Skipping the move
+    // would leave the fork with InitialSyncComplete == false and re-chunk the entire array to a client
+    // that already holds identical bytes.
+    // ------------------------------------------------------------------------------------------------
+
+    private static bool AnyPendingBits(in PeerSyncState s)
+    {
+        if (s.PendingDirty == null) return false;
+        for (int i = 0; i < s.PendingDirty.Length; i++) if (s.PendingDirty[i] != 0) return true;
+        return false;
+    }
+
+    // F1. THE regression test for the sync-state transplant: fork after a completed sync, change
+    //     nothing, and the fork must have nothing to say.
+    [NebulaUnitTest]
+    public void Fork_AfterInitialSync_SendsNothing()
+    {
+        var server = new NetArray<byte>(1024, 1024);
+        for (int i = 0; i < 1024; i++) server[i] = (byte)((i % 250) + 1);
+
+        var peerId = UUID.NewUUID();
+        var client = new NetArray<byte>(1024);
+        int tick = 1;
+        DrainInitialSync(server, ref client, peerId, ref tick);
+        server.OnExportComplete(); // end-of-tick global clear
+        AssertArraysEqual(server, client);
+
+        var fork = NetArray<byte>.ForkForPeer(server, peerId);
+
+        ref var forkState = ref fork.GetOrCreatePeerState(peerId);
+        Assert.True(forkState.InitialSyncComplete,
+            "fork lost the peer's sync state -> the whole array would be re-chunked to a client that already has it");
+        Assert.False(AnyPendingBits(forkState), "fork has pending elements despite no mutation");
+
+        // And the base no longer tracks a peer it no longer serves.
+        Assert.False(server.HasPeerStateForTests(peerId));
+    }
+
+    // F2. Fork then mutate one element -> an ordinary delta carrying that element, NOT a full resync,
+    //     and the client reconstructs it exactly.
+    [NebulaUnitTest]
+    public void Fork_ThenMutate_SendsDeltaNotResync()
+    {
+        var server = new NetArray<byte>(1024, 1024);
+        for (int i = 0; i < 1024; i++) server[i] = (byte)((i % 250) + 1);
+
+        var peerId = UUID.NewUUID();
+        var client = new NetArray<byte>(1024);
+        int tick = 1;
+        DrainInitialSync(server, ref client, peerId, ref tick);
+        server.OnExportComplete();
+
+        var fork = NetArray<byte>.ForkForPeer(server, peerId);
+        fork[7] = 200; // this peer's secret
+
+        var buf = new NetBuffer(8192, usePool: false);
+        {
+            ref var st = ref fork.GetOrCreatePeerState(peerId);
+            fork.MergeDirtyIntoPending(ref st, tick);
+            Assert.True(st.InitialSyncComplete, "fork fell back to chunked sync");
+            NetArray<byte>.WriteDeltaSync(fork, buf, ref st, tick);
+        }
+
+        // A full 1024-element resync could not fit in a delta this small.
+        Assert.True(buf.Length < 64, $"expected a single-element delta, got {buf.Length} bytes");
+
+        buf.ResetRead();
+        client = NetArray<byte>.NetworkDeserialize(null, default, buf, client);
+        Assert.Equal((byte)200, client[7]);
+        AssertArraysEqual(fork, client);
+    }
+
+    // F3. Two peers forked from the same base diverge independently and each client reconstructs only
+    //     its own view.
+    [NebulaUnitTest]
+    public void Fork_TwoPeers_ReconstructDifferentArrays()
+    {
+        var server = new NetArray<byte>(256, 256);
+        for (int i = 0; i < 256; i++) server[i] = 1;
+
+        var peerA = UUID.NewUUID();
+        var peerB = UUID.NewUUID();
+        var clientA = new NetArray<byte>(256);
+        var clientB = new NetArray<byte>(256);
+        int tickA = 1, tickB = 1;
+        DrainInitialSync(server, ref clientA, peerA, ref tickA);
+        DrainInitialSync(server, ref clientB, peerB, ref tickB);
+        server.OnExportComplete();
+
+        var forkA = NetArray<byte>.ForkForPeer(server, peerA);
+        var forkB = NetArray<byte>.ForkForPeer(server, peerB);
+        forkA[3] = 111;
+        forkB[3] = 222;
+
+        SendDelta(forkA, peerA, ref clientA, tickA);
+        SendDelta(forkB, peerB, ref clientB, tickB);
+
+        Assert.Equal((byte)111, clientA[3]);
+        Assert.Equal((byte)222, clientB[3]);
+        Assert.Equal((byte)1, server[3]); // base untouched by either fork
+    }
+
+    // F4. Acks must land on the fork: routed to the base instead, the fork's pending mask never clears
+    //     and it resends the same delta forever (the NetPropertiesSerializer.Acknowledge routing).
+    [NebulaUnitTest]
+    public void Fork_AckClearsForkPendingMask()
+    {
+        var server = new NetArray<byte>(256, 256);
+        var peerId = UUID.NewUUID();
+        CompleteInitialSync(server, peerId);
+
+        var fork = NetArray<byte>.ForkForPeer(server, peerId);
+        fork[9] = 77;
+
+        {
+            ref var st = ref fork.GetOrCreatePeerState(peerId);
+            fork.MergeDirtyIntoPending(ref st, 5);
+            NetArray<byte>.WriteDeltaSync(fork, new NetBuffer(512, usePool: false), ref st, 5);
+            Assert.True(AnyPendingBits(st));
+        }
+        fork.OnExportComplete();
+
+        NetArray<byte>.OnPeerAcknowledge(fork, peerId, 5);
+
+        Assert.False(AnyPendingBits(fork.GetOrCreatePeerState(peerId)),
+            "ack did not clear the fork's pending mask -> perpetual delta resend");
+    }
+
+    // F5. Bool takes the separate bit-packed path (_bits, not _data), so the clone must carry it.
+    [NebulaUnitTest]
+    public void Fork_Bool_ClonesBitPackedContents()
+    {
+        var server = new NetArray<bool>(256, 256);
+        server[0] = true; server[63] = true; server[64] = true; server[255] = true;
+
+        var peerId = UUID.NewUUID();
+        var fork = NetArray<bool>.ForkForPeer(server, peerId);
+
+        Assert.Equal(server.Length, fork.Length);
+        for (int i = 0; i < server.Length; i++)
+            Assert.Equal(server[i], fork[i]);
+
+        // Diverging the fork leaves the base alone.
+        fork[1] = true;
+        Assert.True(fork[1]);
+        Assert.False(server[1]);
+    }
+
+    // F6. A base mutation made BEFORE the fork (same tick, not yet exported) must survive the fork -
+    //     it is in the copied contents but the peer has not received it, so its dirty bit has to come
+    //     along. (Base mutations AFTER the fork deliberately never reach this peer - see F7.)
+    [NebulaUnitTest]
+    public void Fork_CarriesUnexportedBaseMutation()
+    {
+        var server = new NetArray<byte>(256, 256);
+        var peerId = UUID.NewUUID();
+        CompleteInitialSync(server, peerId);
+        var client = new NetArray<byte>(256, 256);
+
+        server[12] = 55;                 // dirtied this tick, not exported yet
+        var fork = NetArray<byte>.ForkForPeer(server, peerId);
+
+        SendDelta(fork, peerId, ref client, 3);
+        Assert.Equal((byte)55, client[12]);
+    }
+
+    // F7. Once forked, the peer is divorced from the base: later base mutations never reach it.
+    //     This pins the documented contract that differs from per-peer primitives.
+    [NebulaUnitTest]
+    public void Fork_IsDivorcedFromLaterBaseMutations()
+    {
+        var server = new NetArray<byte>(256, 256);
+        var peerId = UUID.NewUUID();
+        CompleteInitialSync(server, peerId);
+        var client = new NetArray<byte>(256, 256);
+
+        var fork = NetArray<byte>.ForkForPeer(server, peerId);
+        server[20] = 99; // base changes AFTER the fork
+
+        SendDelta(fork, peerId, ref client, 3);
+        Assert.Equal((byte)0, client[20]);
+        Assert.Equal((byte)0, fork[20]);
+    }
+
+    // Exports one delta from `arr` for `peerId` into `client`.
+    private static void SendDelta<T>(NetArray<T> arr, UUID peerId, ref NetArray<T> client, int tick) where T : struct
+    {
+        var buf = new NetBuffer(8192, usePool: false);
+        {
+            ref var st = ref arr.GetOrCreatePeerState(peerId);
+            arr.MergeDirtyIntoPending(ref st, tick);
+            NetArray<T>.WriteDeltaSync(arr, buf, ref st, tick);
+        }
+        arr.OnExportComplete();
+        buf.ResetRead();
+        client = NetArray<T>.NetworkDeserialize(null, default, buf, client);
+    }
 }

--- a/addons/Nebula/Testing/Unit/PerPeerStateTests.cs
+++ b/addons/Nebula/Testing/Unit/PerPeerStateTests.cs
@@ -267,4 +267,192 @@ public class PerPeerStateTests
         nodeA.Free();
         nodeB.Free();
     }
+
+    // ----------------------------------------------------------------------------------------
+    // Per-peer NetArray properties. Unlike a primitive, an array is mutated in place, so the
+    // generated getter routes through TryGetPerPeerArray and forks on any scoped access. All of
+    // this is server-side: the client holds one plain NetArray written by the normal import path.
+    // ----------------------------------------------------------------------------------------
+
+    /// <summary>Creates a node whose controller has one per-peer object (NetArray) prop at index 0.</summary>
+    private static NetNode CreateNodeWithPerPeerArrayStorage()
+    {
+        var node = new NetNode();
+        node.Network.InitializePerPeerStorageForTests(
+            [true],
+            [SerialVariantType.Object]);
+        return node;
+    }
+
+    // A1. Two peers fork from the same base and diverge; the base is untouched by either.
+    [NebulaUnitTest]
+    public void PerPeerArray_TwoPeersDiverge()
+    {
+        var node = CreateNodeWithPerPeerArrayStorage();
+        var net = node.Network;
+        var a = UUID.NewUUID();
+        var b = UUID.NewUUID();
+        var baseArray = new NetArray<byte>(64, 8);
+        for (int i = 0; i < 8; i++) baseArray[i] = 1;
+
+        NetworkController.ForcePerPeerServerContextForTests = true;
+        try
+        {
+            int idx = 0;
+            NetworkController root = null;
+
+            using (net.ForPeer(a))
+                net.TryGetPerPeerArray(node, "Arr", baseArray, ref idx, ref root)[2] = 111;
+            using (net.ForPeer(b))
+                net.TryGetPerPeerArray(node, "Arr", baseArray, ref idx, ref root)[2] = 222;
+
+            using (net.ForPeer(a))
+                Assert.Equal((byte)111, net.TryGetPerPeerArray(node, "Arr", baseArray, ref idx, ref root)[2]);
+            using (net.ForPeer(b))
+                Assert.Equal((byte)222, net.TryGetPerPeerArray(node, "Arr", baseArray, ref idx, ref root)[2]);
+
+            Assert.Equal((byte)1, baseArray[2]);
+            Assert.True(net.PerPeerValues[0].ContainsKey(a));
+            Assert.True(net.PerPeerValues[0].ContainsKey(b));
+        }
+        finally
+        {
+            NetworkController.ForcePerPeerServerContextForTests = false;
+        }
+        node.Free();
+    }
+
+    // A2. With no scope open the getter hands back the base instance itself and allocates nothing -
+    //     this is also the client-side path, where per-peer state must never engage.
+    [NebulaUnitTest]
+    public void PerPeerArray_NoScope_ReturnsBaseAndDoesNotFork()
+    {
+        var node = CreateNodeWithPerPeerArrayStorage();
+        var net = node.Network;
+        var baseArray = new NetArray<byte>(64, 8);
+
+        NetworkController.ForcePerPeerServerContextForTests = true;
+        try
+        {
+            int idx = 0;
+            NetworkController root = null;
+
+            Assert.Same(baseArray, net.TryGetPerPeerArray(node, "Arr", baseArray, ref idx, ref root));
+            Assert.Empty(net.PerPeerValues[0]);
+
+            // Storage absent (plain node) -> base even inside a scope
+            var bare = new NetNode();
+            int bareIdx = 0;
+            NetworkController bareRoot = null;
+            using (net.ForPeer(UUID.NewUUID()))
+                Assert.Same(baseArray, bare.Network.TryGetPerPeerArray(bare, "Arr", baseArray, ref bareIdx, ref bareRoot));
+            bare.Free();
+        }
+        finally
+        {
+            NetworkController.ForcePerPeerServerContextForTests = false;
+        }
+        node.Free();
+    }
+
+    // A3. Repeated scoped access returns the SAME forked instance - forking happens once per peer.
+    [NebulaUnitTest]
+    public void PerPeerArray_ForksOncePerPeer()
+    {
+        var node = CreateNodeWithPerPeerArrayStorage();
+        var net = node.Network;
+        var peer = UUID.NewUUID();
+        var baseArray = new NetArray<byte>(64, 8);
+
+        NetworkController.ForcePerPeerServerContextForTests = true;
+        try
+        {
+            int idx = 0;
+            NetworkController root = null;
+
+            NetArray<byte> first, second;
+            using (net.ForPeer(peer))
+                first = net.TryGetPerPeerArray(node, "Arr", baseArray, ref idx, ref root);
+            using (net.ForPeer(peer))
+                second = net.TryGetPerPeerArray(node, "Arr", baseArray, ref idx, ref root);
+
+            Assert.NotSame(baseArray, first);
+            Assert.Same(first, second);
+        }
+        finally
+        {
+            NetworkController.ForcePerPeerServerContextForTests = false;
+        }
+        node.Free();
+    }
+
+    // A4. Disconnect cleanup drops exactly the departing peer's forked instance.
+    [NebulaUnitTest]
+    public void PerPeerArray_CleanupPeerState_EvictsOnlyThatPeer()
+    {
+        var node = CreateNodeWithPerPeerArrayStorage();
+        var net = node.Network;
+        var a = UUID.NewUUID();
+        var b = UUID.NewUUID();
+        var baseArray = new NetArray<byte>(64, 8);
+
+        NetworkController.ForcePerPeerServerContextForTests = true;
+        try
+        {
+            int idx = 0;
+            NetworkController root = null;
+            using (net.ForPeer(a))
+                net.TryGetPerPeerArray(node, "Arr", baseArray, ref idx, ref root)[0] = 7;
+            using (net.ForPeer(b))
+                net.TryGetPerPeerArray(node, "Arr", baseArray, ref idx, ref root)[0] = 8;
+
+            net.CleanupPeerState(a);
+
+            Assert.False(net.PerPeerValues[0].ContainsKey(a));
+            Assert.True(net.PerPeerValues[0].ContainsKey(b));
+            Assert.Equal((byte)8, ((NetArray<byte>)net.PerPeerValues[0][b].RefValue)[0]);
+        }
+        finally
+        {
+            NetworkController.ForcePerPeerServerContextForTests = false;
+        }
+        node.Free();
+    }
+
+    // A5. Wholesale assignment inside a scope replaces only that peer's instance (the
+    //     TryWritePerPeerRef path - TryWritePerPeer<T> is constrained to value types).
+    [NebulaUnitTest]
+    public void PerPeerArray_WholesaleAssignment_TargetsOnlyThatPeer()
+    {
+        var node = CreateNodeWithPerPeerArrayStorage();
+        var net = node.Network;
+        var a = UUID.NewUUID();
+        var b = UUID.NewUUID();
+        var baseArray = new NetArray<byte>(64, 8);
+        var replacement = new NetArray<byte>(64, 8);
+        replacement[0] = 42;
+
+        NetworkController.ForcePerPeerServerContextForTests = true;
+        try
+        {
+            int idx = 0;
+            NetworkController root = null;
+
+            using (net.ForPeer(a))
+                Assert.True(net.TryWritePerPeerRef(node, "Arr", replacement, ref idx, ref root));
+
+            using (net.ForPeer(a))
+                Assert.Same(replacement, net.TryGetPerPeerArray(node, "Arr", baseArray, ref idx, ref root));
+            using (net.ForPeer(b))
+                Assert.NotSame(replacement, net.TryGetPerPeerArray(node, "Arr", baseArray, ref idx, ref root));
+
+            // No scope open -> refused, base assignment is the caller's job
+            Assert.False(net.TryWritePerPeerRef(node, "Arr", replacement, ref idx, ref root));
+        }
+        finally
+        {
+            NetworkController.ForcePerPeerServerContextForTests = false;
+        }
+        node.Free();
+    }
 }

--- a/addons/Nebula/Testing/Unit/PerPeerTestNode.cs
+++ b/addons/Nebula/Testing/Unit/PerPeerTestNode.cs
@@ -1,4 +1,5 @@
 using Nebula;
+using Nebula.Serialization;
 
 namespace Nebula.Testing.Unit;
 
@@ -14,11 +15,21 @@ public partial class PerPeerTestNode : NetNode
     [NetProperty(PerPeerState = true)]
     public partial int PerPeerValue { get; set; }
 
+    /// <summary>
+    /// Per-peer NetArray: compiles the generator's object-typed per-peer branch (getter routed
+    /// through TryGetPerPeerArray, setter through TryWritePerPeerRef). A partial property cannot
+    /// carry an initializer, so the base instance is created in the constructor - which is exactly
+    /// the sequence NEBULA006's message tells users to follow.
+    /// </summary>
+    [NetProperty(PerPeerState = true)]
+    public partial NetArray<byte> PerPeerArray { get; set; }
+
     [NetProperty]
     public int BroadcastValue { get; set; }
 
     public PerPeerTestNode()
     {
         PerPeerValue = -1;
+        PerPeerArray = new NetArray<byte>(64, 8);
     }
 }

--- a/addons/Nebula/Testing/Unit/SpawnSerializerThreadScratchTests.cs
+++ b/addons/Nebula/Testing/Unit/SpawnSerializerThreadScratchTests.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using Nebula.Serialization.Serializers;
+using Xunit;
+
+namespace Nebula.Testing.Unit;
+
+/// <summary>
+/// Pins the thread-locality of SpawnSerializer's shared spawn-table scratch.
+///
+/// Those buffers are static so that every SpawnSerializer instance can share one allocation, and
+/// each is filled and consumed within a single Export/Import call chain. That is only sound while
+/// one such chain runs at a time -- which stopped being guaranteed when worlds gained the option to
+/// tick on their own threads. Two worlds exporting concurrently would otherwise interleave writes
+/// into one spawn table, and the symptom is a client desync well downstream of the actual fault,
+/// not a crash at the scene of it.
+///
+/// The specific regression guarded here is subtle enough to be worth a test rather than a comment:
+/// [ThreadStatic] silently does not combine with a field initializer. An initializer runs only on
+/// the first thread to touch the type, so every *other* thread sees null -- converting these fields
+/// back to `[ThreadStatic] private static List&lt;T&gt; _x = new()` would look correct, compile, and
+/// pass every single-threaded test. Hence the lazy-init properties, and hence these assertions run
+/// on threads that have provably never touched the type before.
+/// </summary>
+[NebulaUnitTest]
+public class SpawnSerializerThreadScratchTests
+{
+    private const BindingFlags Scratch = BindingFlags.NonPublic | BindingFlags.Static;
+
+    private static object GetScratch(string propertyName)
+    {
+        var property = typeof(SpawnSerializer).GetProperty(propertyName, Scratch);
+        Assert.NotNull(property);
+        return property.GetValue(null);
+    }
+
+    /// <summary>Runs <paramref name="body"/> on a brand-new thread and returns its result.</summary>
+    private static T OnFreshThread<T>(Func<T> body)
+    {
+        T result = default;
+        Exception failure = null;
+        var thread = new Thread(() =>
+        {
+            try { result = body(); }
+            catch (Exception e) { failure = e; }
+        });
+        thread.Start();
+        Assert.True(thread.Join(TimeSpan.FromSeconds(10)), "worker thread did not finish");
+        if (failure != null) throw failure;
+        return result;
+    }
+
+    [NebulaUnitTest]
+    public void TestScratchIsNonNullOnAThreadThatNeverTouchedTheType()
+    {
+        foreach (var name in new[] { "NestedSceneBuffer", "NestedDataBuffer", "AllLocalNestedScenes" })
+        {
+            // Touch the type here first, deliberately. Under the field-initializer trap the FIRST
+            // thread to reach the type does run the initializer and gets a valid buffer -- it is
+            // every subsequent thread that silently sees null. Without this line the test would
+            // pass or fail purely on whether it happened to run before any other consumer.
+            Assert.NotNull(GetScratch(name));
+
+            var onWorker = OnFreshThread(() => GetScratch(name));
+            Assert.NotNull(onWorker);
+        }
+    }
+
+    [NebulaUnitTest]
+    public void TestEachThreadGetsItsOwnScratchInstance()
+    {
+        foreach (var name in new[] { "NestedSceneBuffer", "NestedDataBuffer", "AllLocalNestedScenes" })
+        {
+            var a = OnFreshThread(() => GetScratch(name));
+            var b = OnFreshThread(() => GetScratch(name));
+
+            Assert.NotNull(a);
+            Assert.NotNull(b);
+            // Reference inequality is the whole point: two concurrent exports must not be able to
+            // reach the same buffer.
+            Assert.False(ReferenceEquals(a, b), $"{name} was shared between two threads");
+        }
+    }
+
+    [NebulaUnitTest]
+    public void TestScratchWritesDoNotLeakAcrossThreads()
+    {
+        // The list buffers: a write on one thread must be invisible to another.
+        var countSeenByFreshThread = OnFreshThread(() =>
+        {
+            var mine = (List<NetworkController>)GetScratch("NestedSceneBuffer");
+            mine.Add(null);          // element value is irrelevant; only the count is observed
+            return mine.Count;
+        });
+        Assert.Equal(1, countSeenByFreshThread);
+
+        // A second thread must start from its own empty buffer, not inherit the entry above.
+        var countOnNextThread = OnFreshThread(() =>
+            ((List<NetworkController>)GetScratch("NestedSceneBuffer")).Count);
+        Assert.Equal(0, countOnNextThread);
+    }
+
+    [NebulaUnitTest]
+    public void TestNestedDataCountIsPerThread()
+    {
+        // _nestedDataCount is a bare [ThreadStatic] int rather than a lazy property (default 0 is
+        // already the correct per-thread initial value), so it is checked separately: it pairs with
+        // NestedDataBuffer and would desynchronize the table if it ever became genuinely shared.
+        var field = typeof(SpawnSerializer).GetField("_nestedDataCount", Scratch);
+        Assert.NotNull(field);
+
+        OnFreshThread<object>(() => { field.SetValue(null, 7); return null; });
+
+        var onAnotherThread = OnFreshThread(() => (int)field.GetValue(null));
+        Assert.Equal(0, onAnotherThread);
+    }
+}

--- a/addons/Nebula/Testing/Unit/SpawnSerializerThreadScratchTests.cs.uid
+++ b/addons/Nebula/Testing/Unit/SpawnSerializerThreadScratchTests.cs.uid
@@ -1,0 +1,1 @@
+uid://cbc758fhn1afb

--- a/addons/Nebula/Testing/Unit/TestRunnerNode.cs
+++ b/addons/Nebula/Testing/Unit/TestRunnerNode.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Threading.Tasks;
 
 namespace Nebula.Testing.Unit;
 
@@ -33,10 +34,31 @@ public partial class TestRunnerNode : Node
         if (_discoverOnly)
         {
             DiscoverTests();
+            GetTree().Quit(0);
+            return;
         }
-        else
+
+        RunAllTestsThenQuit();
+    }
+
+    /// <summary>
+    /// async void, deliberately: _Ready cannot await, and the suite must be able to span engine
+    /// frames. Async tests resume on the main thread via Godot's SynchronizationContext between
+    /// frames -- which is also what lets a test run work on a worker thread: synchronous
+    /// RenderingServer/ResourceLoader calls made from a worker are serviced only when the main
+    /// thread pumps, so a runner that blocked the main thread waiting on such a test would
+    /// deadlock the whole suite.
+    /// </summary>
+    private async void RunAllTestsThenQuit()
+    {
+        try
         {
-            RunAllTests();
+            await RunAllTests();
+        }
+        catch (Exception ex)
+        {
+            GD.Print($"[FAIL] TestRunnerNode: runner crashed: {ex.Message}");
+            _failed++;
         }
 
         // Exit with appropriate code
@@ -67,7 +89,7 @@ public partial class TestRunnerNode : Node
         GD.Print("[DISCOVER_END]");
     }
 
-    private void RunAllTests()
+    private async Task RunAllTests()
     {
         GD.Print("[RUN_START]");
 
@@ -81,14 +103,14 @@ public partial class TestRunnerNode : Node
 
         foreach (var testClass in testClasses)
         {
-            RunTestClass(testClass);
+            await RunTestClass(testClass);
         }
 
         GD.Print("[RUN_END]");
         GD.Print($"[SUMMARY] Passed: {_passed}, Failed: {_failed}");
     }
 
-    private void RunTestClass(Type testClass)
+    private async Task RunTestClass(Type testClass)
     {
         // Find all methods with [NebulaUnitTest] attribute
         var testMethods = testClass.GetMethods(BindingFlags.Public | BindingFlags.Instance)
@@ -116,7 +138,7 @@ public partial class TestRunnerNode : Node
 
         foreach (var method in testMethods)
         {
-            RunTestMethod(testClass, instance!, method);
+            await RunTestMethod(testClass, instance!, method);
         }
 
         // Dispose if IDisposable
@@ -126,13 +148,37 @@ public partial class TestRunnerNode : Node
         }
     }
 
-    private void RunTestMethod(Type testClass, object instance, MethodInfo method)
+    /// <summary>
+    /// Ceiling for a single Task-returning test. Generous because async tests exist precisely for
+    /// work that spans frames (worker-thread generation, multi-frame settling); its job is only to
+    /// turn a wedged test into a [FAIL] instead of a suite that never prints a summary.
+    /// </summary>
+    private static readonly TimeSpan AsyncTestTimeout = TimeSpan.FromSeconds(120);
+
+    private async Task RunTestMethod(Type testClass, object instance, MethodInfo method)
     {
         var testName = $"{testClass.Name}.{method.Name}";
 
         try
         {
-            method.Invoke(instance, null);
+            var result = method.Invoke(instance, null);
+
+            // A Task-returning test is awaited here on the main thread, which keeps pumping engine
+            // frames between continuations. Do NOT be tempted to .Wait()/.GetResult() it: a test
+            // whose worker thread makes a synchronous RenderingServer/ResourceLoader call needs a
+            // live main thread to service that call, and blocking here deadlocks the suite.
+            if (result is Task task)
+            {
+                var finished = await Task.WhenAny(task, Task.Delay(AsyncTestTimeout));
+                if (finished != task)
+                {
+                    GD.Print($"[FAIL] {testName}: timed out after {AsyncTestTimeout.TotalSeconds:0}s");
+                    _failed++;
+                    return;
+                }
+                await task; // Propagate the test's exception, if any.
+            }
+
             GD.Print($"[PASS] {testName}");
             _passed++;
         }

--- a/addons/Nebula/Testing/Unit/WorldLifecycleTests.cs
+++ b/addons/Nebula/Testing/Unit/WorldLifecycleTests.cs
@@ -1,0 +1,123 @@
+using System.Collections.Generic;
+using System.Reflection;
+using Xunit;
+
+namespace Nebula.Testing.Unit;
+
+/// <summary>
+/// Covers the world lifecycle gate on peer admission.
+///
+/// World creation registers a world in <see cref="NetRunner.Worlds"/> before it has been built --
+/// that is what stops two callers racing to create the same world from each building their own.
+/// The consequence is that "findable in Worlds" stopped implying "ready for players", and
+/// <see cref="WorldRunner.Lifecycle"/> is what distinguishes them. Without the gate, a peer admitted
+/// during generation would be streamed a world that is still assembling itself.
+///
+/// Ticking is gated separately, by the world SubViewport's ProcessMode, which needs a real
+/// SceneTree and so belongs to the integration harness rather than here.
+/// </summary>
+[NebulaUnitTest]
+public class WorldLifecycleTests
+{
+    private const BindingFlags Hidden = BindingFlags.NonPublic | BindingFlags.Instance;
+
+    private static int PeerStateCount(WorldRunner world)
+    {
+        var states = typeof(WorldRunner).GetField("PeerStates", Hidden).GetValue(world);
+        return (int)states.GetType().GetProperty("Count").GetValue(states);
+    }
+
+    /// <summary>Registers a world, runs the body, then unregisters it and everything it touched.</summary>
+    private static void WithRegisteredWorld(WorldRunner.WorldLifecycle lifecycle, System.Action<WorldRunner, UUID> body)
+    {
+        var worldId = new UUID();
+        var world = new WorldRunner { WorldId = worldId, Lifecycle = lifecycle };
+        NetRunner.Instance.Worlds[worldId] = world;
+        try
+        {
+            body(world, worldId);
+        }
+        finally
+        {
+            NetRunner.Instance.Worlds.Remove(worldId);
+            foreach (var peerId in new List<UUID>(NetRunner.Instance.PeerWorldMap.Keys))
+            {
+                if (NetRunner.Instance.PeerWorldMap[peerId] == world)
+                {
+                    NetRunner.Instance.PeerWorldMap.Remove(peerId);
+                }
+            }
+            world.Free();
+        }
+    }
+
+    [NebulaUnitTest]
+    public void TestAWorldStartsOutGenerating()
+    {
+        var world = new WorldRunner();
+        try
+        {
+            // The default matters: a world is reachable through Worlds from the instant creation
+            // begins, so the safe assumption for a world nobody has finished building is "not yet".
+            Assert.Equal(WorldRunner.WorldLifecycle.Generating, world.Lifecycle);
+        }
+        finally { world.Free(); }
+    }
+
+    [NebulaUnitTest]
+    public void TestJoinPeerRefusesAGeneratingWorld()
+    {
+        WithRegisteredWorld(WorldRunner.WorldLifecycle.Generating, (world, _) =>
+        {
+            world.JoinPeer(default, "token");
+            Assert.Equal(0, PeerStateCount(world));
+        });
+    }
+
+    [NebulaUnitTest]
+    public void TestJoinPeerRefusesAFailedWorld()
+    {
+        WithRegisteredWorld(WorldRunner.WorldLifecycle.Failed, (world, _) =>
+        {
+            world.JoinPeer(default, "token");
+            Assert.Equal(0, PeerStateCount(world));
+        });
+    }
+
+    [NebulaUnitTest]
+    public void TestJoinPeerAdmitsALiveWorld()
+    {
+        // The counterpart to the refusals above: without this, a gate that rejected everything
+        // would look just as green.
+        WithRegisteredWorld(WorldRunner.WorldLifecycle.Live, (world, _) =>
+        {
+            world.JoinPeer(default, "token");
+            Assert.Equal(1, PeerStateCount(world));
+        });
+    }
+
+    [NebulaUnitTest]
+    public void TestPeerJoinWorldRefusesAGeneratingWorld()
+    {
+        int peersBefore = NetRunner.Instance.Peers.Count;
+
+        WithRegisteredWorld(WorldRunner.WorldLifecycle.Generating, (world, worldId) =>
+        {
+            NetRunner.Instance.PeerJoinWorld(default, worldId, "token");
+
+            // Refused before the peer identity is minted, so nothing is left half-registered.
+            Assert.Equal(peersBefore, NetRunner.Instance.Peers.Count);
+            Assert.Equal(0, PeerStateCount(world));
+        });
+    }
+
+    [NebulaUnitTest]
+    public void TestPeerJoinWorldHandlesAnUnknownWorld()
+    {
+        // Previously an unknown id indexed straight into Worlds and threw a KeyNotFoundException
+        // out of the ENet pump.
+        int peersBefore = NetRunner.Instance.Peers.Count;
+        NetRunner.Instance.PeerJoinWorld(default, new UUID(), "token");
+        Assert.Equal(peersBefore, NetRunner.Instance.Peers.Count);
+    }
+}

--- a/addons/Nebula/Testing/Unit/WorldLifecycleTests.cs.uid
+++ b/addons/Nebula/Testing/Unit/WorldLifecycleTests.cs.uid
@@ -1,0 +1,1 @@
+uid://dodtnotpxlptt

--- a/addons/Nebula/Tools/Main.cs
+++ b/addons/Nebula/Tools/Main.cs
@@ -416,6 +416,30 @@ public partial class Main : EditorPlugin
             });
         }
 
+        // Bots are ordinary client instances with a behavior attached, so they ride the same
+        // orchestrator list rather than needing a launch path of their own. Their clientId
+        // continues the client numbering, keeping debug labels unique across the whole session.
+        for (int i = 0; i < config.BotCount; i++)
+        {
+            int botDebugPort = ReserveLoopbackPort();
+            debugPorts.Add(botDebugPort);
+
+            var botArgs = new List<string>
+            {
+                "--path", projectPath,
+                "--remote-debug", debugUri,
+                $"--debugPort={botDebugPort}",
+                $"--clientId={config.ClientCount + i}",
+                Nebula.Bots.BotRunner.BotArg,
+                $"{Nebula.Bots.BotRunner.BotIdArg}{i}",
+                $"{Nebula.Bots.BotRunner.BotBehaviorArg}{config.BotBehavior}",
+            };
+            if (config.BotsHeadless)
+                botArgs.Add("--headless");
+
+            clientArgsList.Add(botArgs.ToArray());
+        }
+
         GetOrchestrator(createIfMissing: true).Call("launch",
             DEBUG_SESSION_SCENE, exe, serverArgs, clientArgsList, config.Name,
             debugPorts.ToArray());

--- a/addons/Nebula/Tools/MainScreen/NebulaConfigDialog.cs
+++ b/addons/Nebula/Tools/MainScreen/NebulaConfigDialog.cs
@@ -34,6 +34,14 @@ public partial class NebulaConfigDialog : AcceptDialog
     // Add/Edit form
     private ConfirmationDialog formDialog;
     private SpinBox clientCountSpin;
+    private SpinBox botCountSpin;
+    private OptionButton botBehaviorPicker;
+    private CheckBox botsHeadlessCheck;
+    /// <summary>
+    /// Behavior type names in <see cref="botBehaviorPicker"/> order, index 0 being "(none)".
+    /// Kept alongside the control because OptionButton only carries the display text.
+    /// </summary>
+    private readonly List<string> botBehaviorNames = new();
     /// <summary>Index being edited, or -1 when the form is adding a new entry.</summary>
     private int editingIndex = -1;
 
@@ -93,7 +101,10 @@ public partial class NebulaConfigDialog : AcceptDialog
         list.Clear();
         foreach (var config in configurations)
         {
-            list.AddItem($"{config.Name}\n    headless server + {config.ClientCount} client instance(s)");
+            string detail = $"    headless server + {config.ClientCount} client instance(s)";
+            if (config.BotCount > 0)
+                detail += $" + {config.BotCount} bot(s) running {BotBehaviorLabel(config.BotBehavior)}";
+            list.AddItem($"{config.Name}\n{detail}");
         }
 
         if (previous >= 0 && previous < configurations.Count)
@@ -154,20 +165,72 @@ public partial class NebulaConfigDialog : AcceptDialog
         EnsureFormDialog();
         editingIndex = index;
 
+        // Rebuilt on every open: the game assembly reloads while the editor is running, so a
+        // behavior added since the dialog was last shown has to appear without an editor restart.
+        RefreshBotBehaviorPicker();
+
         if (index >= 0 && index < configurations.Count)
         {
+            var config = configurations[index];
             formDialog.Title = "Edit Configuration";
-            clientCountSpin.Value = configurations[index].ClientCount;
+            clientCountSpin.Value = config.ClientCount;
+            botCountSpin.Value = config.BotCount;
+            botsHeadlessCheck.ButtonPressed = config.BotsHeadless;
+            SelectBotBehavior(config.BotBehavior);
         }
         else
         {
             formDialog.Title = "Add Configuration";
             clientCountSpin.Value = 1;
+            botCountSpin.Value = 0;
+            botsHeadlessCheck.ButtonPressed = true;
+            botBehaviorPicker.Selected = 0;
         }
 
-        formDialog.PopupCentered(new Vector2I(360, 0));
+        formDialog.PopupCentered(new Vector2I(420, 0));
         clientCountSpin.GrabFocus();
     }
+
+    /// <summary>
+    /// Fills the picker from the BotBehavior subclasses that actually exist, so a configuration
+    /// cannot name one that was never written. A configured behavior that has since been removed
+    /// or renamed is re-added as a "(missing)" entry rather than silently reset to none.
+    /// </summary>
+    private void RefreshBotBehaviorPicker()
+    {
+        botBehaviorPicker.Clear();
+        botBehaviorNames.Clear();
+
+        botBehaviorPicker.AddItem("(none)");
+        botBehaviorNames.Add("");
+
+        foreach (var type in Nebula.Bots.BotRunner.DiscoverBehaviorTypes())
+        {
+            botBehaviorPicker.AddItem(type.Name);
+            botBehaviorNames.Add(type.Name);
+        }
+    }
+
+    private void SelectBotBehavior(string behaviorName)
+    {
+        if (string.IsNullOrEmpty(behaviorName))
+        {
+            botBehaviorPicker.Selected = 0;
+            return;
+        }
+
+        int index = botBehaviorNames.IndexOf(behaviorName);
+        if (index < 0)
+        {
+            botBehaviorPicker.AddItem($"{behaviorName}  (missing)");
+            botBehaviorNames.Add(behaviorName);
+            index = botBehaviorNames.Count - 1;
+        }
+        botBehaviorPicker.Selected = index;
+    }
+
+    private static string BotBehaviorLabel(string behaviorName) =>
+        string.IsNullOrEmpty(behaviorName) ? "no behavior" : behaviorName;
 
     private void EnsureFormDialog()
     {
@@ -197,6 +260,36 @@ public partial class NebulaConfigDialog : AcceptDialog
         };
         grid.AddChild(clientCountSpin);
 
+        grid.AddChild(new Label { Text = "Bot count" });
+        botCountSpin = new SpinBox
+        {
+            MinValue = 0,
+            MaxValue = 64,
+            Value = 0,
+            Rounded = true,
+            CustomMinimumSize = new Vector2(120, 0),
+            TooltipText = "Scripted bot instances launched alongside the clients. Each is a full "
+                + "client process driven by a BotBehavior instead of a keyboard.",
+        };
+        grid.AddChild(botCountSpin);
+
+        grid.AddChild(new Label { Text = "Bot behavior" });
+        botBehaviorPicker = new OptionButton
+        {
+            CustomMinimumSize = new Vector2(220, 0),
+            TooltipText = "The BotBehavior subclass the bots run. Write one in your game project; "
+                + "it is discovered automatically.",
+        };
+        grid.AddChild(botBehaviorPicker);
+
+        grid.AddChild(new Label { Text = "Bots headless" });
+        botsHeadlessCheck = new CheckBox
+        {
+            ButtonPressed = true,
+            TooltipText = "Run bot instances without a window. Turn off to watch a bot directly.",
+        };
+        grid.AddChild(botsHeadlessCheck);
+
         formDialog.Connect(ConfirmationDialog.SignalName.Confirmed, new Callable(this, MethodName.OnFormConfirmed));
         AddChild(formDialog);
     }
@@ -204,11 +297,25 @@ public partial class NebulaConfigDialog : AcceptDialog
     private void OnFormConfirmed()
     {
         int clientCount = (int)clientCountSpin.Value;
+        int botCount = (int)botCountSpin.Value;
+
+        int behaviorIndex = botBehaviorPicker.Selected;
+        string botBehavior = behaviorIndex >= 0 && behaviorIndex < botBehaviorNames.Count
+            ? botBehaviorNames[behaviorIndex]
+            : "";
+        // Bots with no behavior would connect and stand there, which reads as a broken session
+        // rather than a misconfiguration. Treat it as "no bots" instead.
+        if (string.IsNullOrEmpty(botBehavior))
+            botCount = 0;
+
         var edited = new NebulaPlayConfiguration
         {
-            // The client count is the whole configuration, so it is also the name.
-            Name = NebulaPlayConfiguration.DisplayName(clientCount),
+            // The instance counts are the whole configuration, so they are also the name.
+            Name = NebulaPlayConfiguration.DisplayName(clientCount, botCount),
             ClientCount = clientCount,
+            BotCount = botCount,
+            BotBehavior = botBehavior,
+            BotsHeadless = botsHeadlessCheck.ButtonPressed,
         };
 
         if (editingIndex >= 0 && editingIndex < configurations.Count)

--- a/addons/Nebula/Tools/MainScreen/NebulaPlayConfigStore.cs
+++ b/addons/Nebula/Tools/MainScreen/NebulaPlayConfigStore.cs
@@ -17,15 +17,46 @@ public sealed class NebulaPlayConfiguration
     public string Name = "";
     public int ClientCount = 1;
 
+    /// <summary>
+    /// Scripted bot instances launched alongside the real clients. Each is a full client process
+    /// driven by <see cref="Nebula.Bots.BotBehavior"/> rather than a keyboard.
+    /// </summary>
+    public int BotCount = 0;
+
+    /// <summary>
+    /// Name of the <see cref="Nebula.Bots.BotBehavior"/> subclass the bots run. Stored as a type
+    /// name rather than a script path — see BotRunner for why. Empty means "no bots", regardless
+    /// of <see cref="BotCount"/>.
+    /// </summary>
+    public string BotBehavior = "";
+
+    /// <summary>
+    /// Whether bot instances get <c>--headless</c>. On by default: bots are usually there to
+    /// populate a world rather than to be watched, and rendering ten of them is pure cost.
+    /// </summary>
+    public bool BotsHeadless = true;
+
     public NebulaPlayConfiguration Clone() => new()
     {
         Name = Name,
         ClientCount = ClientCount,
+        BotCount = BotCount,
+        BotBehavior = BotBehavior,
+        BotsHeadless = BotsHeadless,
     };
 
-    /// <summary>The configuration is just a client count, so name it after one.</summary>
-    public static string DisplayName(int clientCount) =>
-        clientCount == 1 ? "1 client" : $"{clientCount} clients";
+    /// <summary>
+    /// The configuration is just its instance counts, so name it after them. Bots have to appear
+    /// here: the selected target is stored by name, so two configurations differing only in bot
+    /// count would otherwise be indistinguishable.
+    /// </summary>
+    public static string DisplayName(int clientCount, int botCount)
+    {
+        string clients = clientCount == 1 ? "1 client" : $"{clientCount} clients";
+        if (botCount <= 0)
+            return clients;
+        return botCount == 1 ? $"{clients} + 1 bot" : $"{clients} + {botCount} bots";
+    }
 }
 
 /// <summary>
@@ -60,11 +91,17 @@ public static class NebulaPlayConfigStore
                 if (!section.StartsWith(CONFIG_SECTION_PREFIX))
                     continue;
                 int clientCount = file.GetValue(section, "client_count", DEFAULT_CLIENT_COUNT).AsInt32();
+                // Absent bot keys default to "no bots", so files written before bots existed load
+                // unchanged and keep behaving exactly as they did.
+                int botCount = file.GetValue(section, "bot_count", 0).AsInt32();
                 configurations.Add(new NebulaPlayConfiguration
                 {
                     // Older files predate client_count and carried a free-text name.
-                    Name = file.GetValue(section, "name", NebulaPlayConfiguration.DisplayName(clientCount)).AsString(),
+                    Name = file.GetValue(section, "name", NebulaPlayConfiguration.DisplayName(clientCount, botCount)).AsString(),
                     ClientCount = clientCount,
+                    BotCount = botCount,
+                    BotBehavior = file.GetValue(section, "bot_behavior", "").AsString(),
+                    BotsHeadless = file.GetValue(section, "bots_headless", true).AsBool(),
                 });
             }
         }
@@ -73,7 +110,7 @@ public static class NebulaPlayConfigStore
         {
             configurations.Add(new NebulaPlayConfiguration
             {
-                Name = NebulaPlayConfiguration.DisplayName(DEFAULT_CLIENT_COUNT),
+                Name = NebulaPlayConfiguration.DisplayName(DEFAULT_CLIENT_COUNT, 0),
                 ClientCount = DEFAULT_CLIENT_COUNT,
             });
             Save(configurations);
@@ -97,6 +134,9 @@ public static class NebulaPlayConfigStore
             string section = CONFIG_SECTION_PREFIX + i;
             file.SetValue(section, "name", config.Name);
             file.SetValue(section, "client_count", config.ClientCount);
+            file.SetValue(section, "bot_count", config.BotCount);
+            file.SetValue(section, "bot_behavior", config.BotBehavior);
+            file.SetValue(section, "bots_headless", config.BotsHeadless);
         }
         if (selected.Length > 0)
             file.SetValue(META_SECTION, SELECTED_KEY, selected);

--- a/addons/Nebula/Tools/ProjectSettingsController.cs
+++ b/addons/Nebula/Tools/ProjectSettingsController.cs
@@ -192,6 +192,23 @@ public partial class ProjectSettingsController : Node
             {"type", (int)Variant.Type.Bool},
         });
 
+        // ── Threading ────────────────────────────────────────────────────
+        // Give every server world's SubViewport its own ProcessThreadGroup, so worlds run their
+        // ticks concurrently instead of being walked one after another on the main thread.
+        //
+        // Note this parallelizes _process/_physics_process callbacks only. It does NOT parallelize
+        // physics simulation: PhysicsServer3D steps every active space sequentially, so per-world
+        // World3Ds still simulate serially either way. The gain is ServerProcessTick (dominated by
+        // state serialization) and gameplay scripts.
+        //
+        // Off by default. Everything it depends on is written to be correct in both modes, so this
+        // changes timing rather than behavior -- but it does move all gameplay code in a world onto
+        // a worker thread, so anything reaching across worlds or into a mutable autoload needs to
+        // have been audited first. Read once at startup.
+        Register("Nebula/config/threading/per_world_thread_group", false, new(){
+            {"type", (int)Variant.Type.Bool},
+        });
+
         // ── Editor ───────────────────────────────────────────────────────
         // Editor: master switch for the Nebula editor tooling (main-screen tab,
         // play target button, run-bar hiding, headless run-instances config).

--- a/addons/Nebula/Utils/Debugger/Debugger.cs
+++ b/addons/Nebula/Utils/Debugger/Debugger.cs
@@ -106,6 +106,16 @@ namespace Nebula.Utility.Tools
             return level <= (DebugLevel)ProjectSettings.GetSetting("Nebula/config/debug/log_level", 0).AsInt16();
         }
 
+        /// <summary>
+        /// Callable from any thread, including world tick threads once per-world thread groups are
+        /// enabled. That holds only because this method touches no Node state: ProjectSettings,
+        /// OS.HasFeature, Env's start args (read-only after startup) and GD.Print/PushError/
+        /// PushWarning are all safe off the main thread.
+        ///
+        /// Keep it that way -- Debugger is an autoload and therefore outside every world's thread
+        /// group, so reaching into any node from here would be a cross-group access from the
+        /// callers that need it most.
+        /// </summary>
         public void Log(string msg, DebugLevel level = DebugLevel.INFO)
         {
             if (!IsEnabled(level))

--- a/addons/Nebula/Utils/Env/Env.cs
+++ b/addons/Nebula/Utils/Env/Env.cs
@@ -12,6 +12,9 @@ namespace Nebula.Utility.Tools
         private string initializedFilename = null;
         private Dictionary<string, string> env = new Dictionary<string, string>();
 
+        /// <summary>Guards <see cref="env"/> and <see cref="initializedFilename"/>. See GetValue.</summary>
+        private readonly object _parseLock = new();
+
         public Dictionary<string, string> StartArgs = [];
 
         public enum DevelopmentModeType {
@@ -106,23 +109,16 @@ namespace Nebula.Utility.Tools
                 return OS.GetEnvironment(valuename);
             }
 
-            Dictionary<string, string> parsedEnv;
-
-            if (HasServerFeatures)
+            // The lock spans the lookup, not just the parse: Parse hands back the shared `env`
+            // dictionary, so reading it outside the lock could observe another thread's Clear()
+            // partway through a reparse. Callers reach this from worker threads (world generation,
+            // and any world tick once per-world thread groups are enabled), and it is contended
+            // only on the first access per file -- afterwards Parse returns on its first line.
+            lock (_parseLock)
             {
-                parsedEnv = Parse("res://.env.server");
+                var parsedEnv = Parse(HasServerFeatures ? "res://.env.server" : "res://.env.client");
+                return parsedEnv.TryGetValue(valuename, out var value) ? value : "";
             }
-            else
-            {
-                parsedEnv = Parse("res://.env.client");
-            }
-
-            if (parsedEnv.ContainsKey(valuename))
-            {
-                return parsedEnv[valuename];
-            }
-
-            return "";
         }
 
         public string InitialWorldScene { get; private set; }

--- a/addons/Nebula/Utils/ServerClientConnector/ServerClientConnector.cs
+++ b/addons/Nebula/Utils/ServerClientConnector/ServerClientConnector.cs
@@ -19,7 +19,7 @@ namespace Nebula.Utility.Tools
 			}
 		}
 
-		private void prepareServer()
+		private async void prepareServer()
 		{
 			NetRunner.Instance.StartServer();
 			if (Env.Instance.InitialWorldScene != null)
@@ -27,7 +27,7 @@ namespace Nebula.Utility.Tools
 				Debugger.Instance.Log("Loading initial world scene: " + Env.Instance.InitialWorldScene);
 				Debugger.Instance.Log("No existing World data found. Create fresh World instance.");
 				var InitialWorldScene = GD.Load<PackedScene>(Env.Instance.InitialWorldScene);
-				NetRunner.Instance.CreateWorld(Env.Instance.InitialWorldId, InitialWorldScene);
+				await NetRunner.Instance.CreateWorld(Env.Instance.InitialWorldId, InitialWorldScene);
 				Debugger.Instance.Log("Server ready");
 			}
 			else


### PR DESCRIPTION
World creation is now asynchronous end to end. CreateWorld/SetupWorldInstance return Task<WorldRunner>, instantiate the scene off the main thread, and only complete once the world is fully built — including any IAsyncWorldGenerator work its root scene does. A WorldLifecycle (Generating/Live/Failed) makes "registered" no longer imply "joinable": the world is registered before the first await so racing callers resolve to one instance, its SubViewport is process-disabled while it builds, and creation failure deregisters and tears it down. Peers that connect before the first world is ready are held and authenticated the moment one goes Live, instead of the pump throwing "Sequence contains no elements" out of DefaultAuthenticator.

On top of that, worlds can optionally tick concurrently via Nebula/config/threading/per_world_thread_group (off by default), which gives each world's SubViewport its own ProcessThreadGroup. Everything it depends on is written to be correct in both modes, so the flag changes timing rather than behavior:

- All ENet host access (send, disconnect, service/check) goes through a single lock, held around the native call only; the pump releases it before dispatch.
- Inbound Tick/Input/Function packets are queued per world by the pump and parsed on the world's own thread, in arrival order, drained every physics frame so latency is unchanged.
- Peer registry mutations and SceneTree work reached from a world thread are marshalled to the main thread (RunOnMainThread / SwitchToMainThread awaitable, drained at the top of _PhysicsProcess). Inline when already on main.
- SpawnSerializer's shared nested-scene scratch is [ThreadStatic], Env's parse is locked, and NebulaThread adds DEBUG-only thread-affinity assertions on the paths that assume main.

Per-peer NetProperty state now supports NetArray<T>. The getter forks a content-identical instance for the peer on first scoped access — carrying over the peer's sync state and the base's un-exported dirty bits, so a fork costs an allocation but no bandwidth — and export, ack and disconnect all route through the peer's fork rather than the base. Note a forked peer is divorced from the base from then on; the attribute docs and NEBULA007 spell that out.

Also:

- Bots: --bot launches an ordinary client with a reflection-resolved BotBehavior attached, acting through input actions so it takes the same prediction and reconciliation path a human does. Wired into the editor play config (bot count, behavior, headless).
- --metrics emits one JSON line per interval per world (tick time percentiles, packet volume, RTT spread) to stdout, allocation-free on the recording path.
- Per-tick inbound payloads rent from ArrayPool instead of allocating a byte[] per packet, with NetBuffer.Attach re-pointing a long-lived wrapper at each.
- Tests for the inbound queue, world lifecycle, per-peer arrays and the thread-static spawn scratch.