### PR TITLE
Budget tick payloads to the MTU, speed up NebulaPack, add tick telemetry

### DIFF
--- a/Nebula.csproj
+++ b/Nebula.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Godot.NET.Sdk/4.5.0-dev.3">
+<Project Sdk="Godot.NET.Sdk/4.7.1">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <EnableDynamicLoading>true</EnableDynamicLoading>

--- a/addons/Nebula/Core/Debug/DebugHub.cs
+++ b/addons/Nebula/Core/Debug/DebugHub.cs
@@ -84,6 +84,24 @@ namespace Nebula
         private readonly List<WorldRunner> _worlds = new();
 
         private readonly Queue<QueuedFrame> _queue = new();
+
+        /// <summary>
+        /// Low-rate telemetry that must not queue behind the tick flood. The main queue
+        /// carries hundreds of frames per second on a busy world (one PAYLOADS frame per
+        /// peer per tick), and past the hard backstop it drops from the front - which is
+        /// exactly where accumulated reliable frames sit. A once-a-second frame parked
+        /// there is starved precisely when the numbers matter. The writer drains this
+        /// first, and it is bounded by its own tiny cap rather than by the trim.
+        /// </summary>
+        private readonly Queue<QueuedFrame> _priorityQueue = new();
+
+        /// <summary>
+        /// Cap on the priority queue. Sized for seconds of buffered telemetry, not
+        /// throughput: anything that produces enough volume to hit this does not belong
+        /// in the priority lane.
+        /// </summary>
+        private const int MaxPriorityFrames = 64;
+
         /// <summary>Reused staging queue for <see cref="TrimLossyFrames"/>. Guarded by <see cref="_queueLock"/>.</summary>
         private readonly Queue<QueuedFrame> _trimScratch = new();
         private readonly object _queueLock = new();
@@ -104,6 +122,19 @@ namespace Nebula
 
         /// <summary>The port actually bound, or 0 when not running.</summary>
         public int BoundPort { get; private set; }
+
+        /// <summary>
+        /// Whether debug-class frames (tick state, per-peer payloads, world exports,
+        /// logs, calls, world announcements) are produced at all.
+        ///
+        /// <para>The socket is a shared transport for two independently switchable
+        /// features: the debugger (<c>NEBULA_DEBUG</c>) and metrics reporting
+        /// (<c>NEBULA_PERFORMANCE</c>). With this false the channel carries metrics
+        /// only — the listener exists, but none of the expensive per-tick debug work
+        /// runs. Emitters check it BEFORE building a frame, so "off" costs nothing
+        /// beyond this property read.</para>
+        /// </summary>
+        public bool DebugFramesEnabled { get; init; } = true;
 
         public bool IsRunning => _listener != null;
 
@@ -187,6 +218,8 @@ namespace Nebula
             {
                 while (_queue.Count > 0)
                     ReturnFrame(_queue.Dequeue());
+                while (_priorityQueue.Count > 0)
+                    ReturnFrame(_priorityQueue.Dequeue());
                 foreach (var frame in _pendingFrames)
                     ReturnFrame(frame);
                 _pendingFrames.Clear();
@@ -236,8 +269,15 @@ namespace Nebula
             // on these sockets. A client that attaches later therefore re-sends
             // announcements to everyone; readers treat a repeat announcement
             // for a known world as a no-op.
-            foreach (var world in _worlds)
-                EnqueueWorldAnnounce(world);
+            //
+            // Skipped entirely on a metrics-only channel: an announcement is what
+            // makes the editor build a debugger panel, and here it would only ever
+            // sit empty (same reasoning as RegisterWorld).
+            if (DebugFramesEnabled)
+            {
+                foreach (var world in _worlds)
+                    EnqueueWorldAnnounce(world);
+            }
 
             FlushPendingFrames();
         }
@@ -284,7 +324,10 @@ namespace Nebula
             if (world == null || _worlds.Contains(world))
                 return;
             _worlds.Add(world);
-            if (HasClients)
+            // Announcements are what make the editor build a debugger panel for a
+            // world. On a metrics-only channel that panel would sit permanently empty,
+            // so the world stays unannounced and the Debugger tab honestly shows none.
+            if (HasClients && DebugFramesEnabled)
                 EnqueueWorldAnnounce(world);
         }
 
@@ -295,7 +338,7 @@ namespace Nebula
         /// </summary>
         public void ReannounceWorld(WorldRunner world, UUID previousId)
         {
-            if (world == null || !_worlds.Contains(world) || !HasClients)
+            if (world == null || !_worlds.Contains(world) || !HasClients || !DebugFramesEnabled)
                 return;
 
             if (!previousId.IsEmpty)
@@ -311,7 +354,7 @@ namespace Nebula
         {
             if (world == null || !_worlds.Remove(world))
                 return;
-            if (!HasClients)
+            if (!HasClients || !DebugFramesEnabled)
                 return;
 
             using var payload = new NetBuffer(16, usePool: false);
@@ -338,7 +381,8 @@ namespace Nebula
         /// dropped oldest-first when the queue backs up; everything else is
         /// guaranteed, in order.
         /// </summary>
-        public void Enqueue(UUID worldId, WorldRunner.DebugDataType type, NetBuffer payload, bool lossy)
+        public void Enqueue(UUID worldId, WorldRunner.DebugDataType type, NetBuffer payload, bool lossy,
+            bool priority = false)
         {
             if (_listener == null)
                 return;
@@ -354,6 +398,20 @@ namespace Nebula
             if (!HasClients)
             {
                 BufferUntilFirstClient(frame);
+                return;
+            }
+
+            if (priority)
+            {
+                lock (_queueLock)
+                {
+                    // Oldest-first eviction: a stalled reader should see the most recent
+                    // telemetry, not a minute-old backlog of it.
+                    while (_priorityQueue.Count >= MaxPriorityFrames)
+                        ReturnFrame(_priorityQueue.Dequeue());
+                    _priorityQueue.Enqueue(frame);
+                }
+                _queueSignal.Set();
                 return;
             }
 
@@ -473,9 +531,20 @@ namespace Nebula
                     QueuedFrame frame;
                     lock (_queueLock)
                     {
-                        if (_queue.Count == 0)
+                        // Priority lane first: its frames are rare and must not wait
+                        // behind a backlog of tick frames.
+                        if (_priorityQueue.Count > 0)
+                        {
+                            frame = _priorityQueue.Dequeue();
+                        }
+                        else if (_queue.Count > 0)
+                        {
+                            frame = _queue.Dequeue();
+                        }
+                        else
+                        {
                             break;
-                        frame = _queue.Dequeue();
+                        }
                     }
 
                     try

--- a/addons/Nebula/Core/Diagnostics/ServerMetrics.cs
+++ b/addons/Nebula/Core/Diagnostics/ServerMetrics.cs
@@ -22,6 +22,18 @@ namespace Nebula.Diagnostics
         public const string EnableArg = "--metrics";
         public const string IntervalArg = "--metricsInterval=";
 
+        /// <summary>
+        /// Environment variable that enables metrics like <see cref="EnableArg"/> does.
+        /// Read through the Env autoload, so it works both as a real process variable
+        /// (spawned processes inherit the editor's environment) and as an entry in the
+        /// process's .env file (res://.env.server for servers). This gates the SERVER
+        /// only - collection and reporting cost nothing unless it is set, so production
+        /// instances leave it off. The editor's Performance tab always exists and simply
+        /// stays empty when no server is reporting.
+        /// </summary>
+        public const string EnableEnvVar = "NEBULA_PERFORMANCE";
+
+
         /// <summary>Prefix on every emitted line, so a run can be filtered out of a noisy log.</summary>
         public const string LinePrefix = "NEBULA_METRICS ";
 
@@ -55,6 +67,10 @@ namespace Nebula.Diagnostics
             if (_parsed) return;
             _parsed = true;
 
+            // Process environment first, then the process's .env file, so both
+            // configuration styles work (see Env.TryGetFlag).
+            Nebula.Utility.Tools.Env.TryGetFlag(EnableEnvVar, out _enabled);
+
             foreach (var argument in OS.GetCmdlineArgs())
             {
                 if (argument == EnableArg)
@@ -80,6 +96,18 @@ namespace Nebula.Diagnostics
         private long _packetsOut;
         private int _mtuExceeded;
         private int _ackTimeouts;
+
+        // Budgeted serialization (MTU splitting).
+        //
+        // Per-peer payload sizes are sampled, not just summed: one saturated peer says
+        // nothing about the other 21, and a mean alone reads as "plenty of headroom"
+        // while individual packets sit against the cap. Percentiles show the spread.
+        private readonly double[] _payloadBytes = new double[SampleCapacity];
+        private int _payloadCount;
+        private int _budgetBytes;
+        private int _spawnSectionsDeferred;
+        private int _propsSectionsDeferred;
+        private int _spawnBacklogMax;
 
         private readonly double[] _sortScratch = new double[SampleCapacity];
         private readonly StringBuilder _line = new(512);
@@ -114,6 +142,28 @@ namespace Nebula.Diagnostics
 
         public void RecordAckTimeout() => _ackTimeouts++;
 
+        /// <summary>Records one per-peer tick payload against its byte budget. Hot path.</summary>
+        public void RecordTickBudget(int usedBytes, int budgetBytes)
+        {
+            _budgetBytes = budgetBytes; // constant within a window; carried for context
+            if (_payloadCount < SampleCapacity)
+                _payloadBytes[_payloadCount++] = usedBytes;
+        }
+
+        /// <summary>Records sections dropped or deferred for budget in one per-peer export. Hot path.</summary>
+        public void RecordDeferredSections(int spawnDeferred, int propsDeferred)
+        {
+            _spawnSectionsDeferred += spawnDeferred;
+            _propsSectionsDeferred += propsDeferred;
+        }
+
+        /// <summary>Records a peer's count of in-flight (Spawning) spawn records. Hot path.</summary>
+        public void RecordSpawnBacklog(int spawningCount)
+        {
+            if (spawningCount > _spawnBacklogMax)
+                _spawnBacklogMax = spawningCount;
+        }
+
         /// <summary>
         /// Whether the interval has elapsed. Separate from <see cref="Emit"/> so the caller only
         /// pays for a peer scan on the tick that actually reports.
@@ -143,12 +193,26 @@ namespace Nebula.Diagnostics
 
         /// <summary>
         /// Writes one line and resets the window. Peer figures are supplied by the caller, which
-        /// owns the peer table.
+        /// owns the peer table. Returns the JSON body (without <see cref="LinePrefix"/>) so the
+        /// caller can also ship it over the debug channel to the editor's Performance tab.
         /// </summary>
-        public void Emit(UUID worldId, Tick tick, int peers, double rttMean, uint rttMax, double elapsedSeconds)
+        public string Emit(UUID worldId, Tick tick, int peers, double rttMean, uint rttMax, double elapsedSeconds)
         {
+            // Percentiles are computed up front, not inline: both sets share _sortScratch,
+            // so the second sort would otherwise invalidate the first set's reads.
             Array.Copy(_tickMs, _sortScratch, _tickCount);
             Array.Sort(_sortScratch, 0, _tickCount);
+            double tickP50 = Percentile(_tickCount, 0.50);
+            double tickP95 = Percentile(_tickCount, 0.95);
+            double tickP99 = Percentile(_tickCount, 0.99);
+            double tickMax = Percentile(_tickCount, 1.0);
+
+            Array.Copy(_payloadBytes, _sortScratch, _payloadCount);
+            Array.Sort(_sortScratch, 0, _payloadCount);
+            double payloadP50 = Percentile(_payloadCount, 0.50);
+            double payloadP95 = Percentile(_payloadCount, 0.95);
+            double payloadP99 = Percentile(_payloadCount, 0.99);
+            double payloadMax = Percentile(_payloadCount, 1.0);
 
             _line.Clear();
             _line.Append(LinePrefix);
@@ -158,10 +222,10 @@ namespace Nebula.Diagnostics
             _line.Append(",\"peers\":").Append(peers);
             _line.Append(",\"ticks\":").Append(_ticksThisWindow);
             _line.Append(",\"tick_ms\":{");
-            _line.Append("\"p50\":").Append(Percentile(0.50).ToString("F3", Inv));
-            _line.Append(",\"p95\":").Append(Percentile(0.95).ToString("F3", Inv));
-            _line.Append(",\"p99\":").Append(Percentile(0.99).ToString("F3", Inv));
-            _line.Append(",\"max\":").Append(Percentile(1.0).ToString("F3", Inv));
+            _line.Append("\"p50\":").Append(tickP50.ToString("F3", Inv));
+            _line.Append(",\"p95\":").Append(tickP95.ToString("F3", Inv));
+            _line.Append(",\"p99\":").Append(tickP99.ToString("F3", Inv));
+            _line.Append(",\"max\":").Append(tickMax.ToString("F3", Inv));
             _line.Append('}');
             _line.Append(",\"bytes_out\":").Append(_bytesOut);
             _line.Append(",\"packets_out\":").Append(_packetsOut);
@@ -178,9 +242,22 @@ namespace Nebula.Diagnostics
                  .Append(GC.CollectionCount(2) - _gc2).Append(']');
             _line.Append(",\"mtu_exceeded\":").Append(_mtuExceeded);
             _line.Append(",\"ack_timeouts\":").Append(_ackTimeouts);
+            // One sample per peer per tick, in PRE-pack bytes - the size the splitting
+            // logic bounds. What actually goes on the wire is this minus NebulaPack's
+            // delta compression, so these run larger than bytes_out/packets_out.
+            _line.Append(",\"payload\":{\"p50\":").Append(payloadP50.ToString("F0", Inv));
+            _line.Append(",\"p95\":").Append(payloadP95.ToString("F0", Inv));
+            _line.Append(",\"p99\":").Append(payloadP99.ToString("F0", Inv));
+            _line.Append(",\"max\":").Append(payloadMax.ToString("F0", Inv));
+            _line.Append(",\"cap\":").Append(_budgetBytes);
+            _line.Append('}');
+            _line.Append(",\"budget\":{\"spawn_deferred\":").Append(_spawnSectionsDeferred);
+            _line.Append(",\"props_deferred\":").Append(_propsSectionsDeferred);
+            _line.Append(",\"spawn_backlog_max\":").Append(_spawnBacklogMax).Append('}');
             _line.Append('}');
 
             GD.Print(_line.ToString());
+            string json = _line.ToString(LinePrefix.Length, _line.Length - LinePrefix.Length);
 
             _windowStartUsec = Time.GetTicksUsec();
             _tickCount = 0;
@@ -189,19 +266,26 @@ namespace Nebula.Diagnostics
             _packetsOut = 0;
             _mtuExceeded = 0;
             _ackTimeouts = 0;
+            _payloadCount = 0;
+            _spawnSectionsDeferred = 0;
+            _propsSectionsDeferred = 0;
+            _spawnBacklogMax = 0;
             CaptureGcBaseline();
+
+            return json;
         }
 
         /// <summary>
-        /// Nearest-rank percentile over the sorted scratch. Returns 0 with no samples, which reads
-        /// correctly as "this world did not tick during the window".
+        /// Nearest-rank percentile over the first <paramref name="count"/> entries of the sorted
+        /// scratch. Returns 0 with no samples, which reads correctly as "this world did not tick
+        /// during the window".
         /// </summary>
-        private double Percentile(double fraction)
+        private double Percentile(int count, double fraction)
         {
-            if (_tickCount == 0) return 0;
-            int index = (int)Math.Ceiling(fraction * _tickCount) - 1;
+            if (count == 0) return 0;
+            int index = (int)Math.Ceiling(fraction * count) - 1;
             if (index < 0) index = 0;
-            if (index >= _tickCount) index = _tickCount - 1;
+            if (index >= count) index = count - 1;
             return _sortScratch[index];
         }
     }

--- a/addons/Nebula/Core/Diagnostics/TickProfiler.cs
+++ b/addons/Nebula/Core/Diagnostics/TickProfiler.cs
@@ -1,0 +1,343 @@
+using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.Text;
+
+namespace Nebula.Diagnostics
+{
+    /// <summary>
+    /// Per-phase timing of the server tick, measured in-process on the untraced server.
+    ///
+    /// <para>This exists because sampling profilers cannot answer "where does the tick go?" for
+    /// this server. Attaching <c>dotnet-trace</c>'s SampleProfiler takes tick p50 from ~14.5 ms to
+    /// ~31 ms and drops the server from 30 to ~25 TPS, and its two largest frames
+    /// (<c>Thread.PollGCWorker</c> ~29%, <c>Monitor.Enter_Slowpath</c> ~23%) are thread-suspension
+    /// artifacts rather than real cost. That was established by a controlled experiment: rewriting
+    /// the inbound drain from one lock acquisition per packet to a single batched acquisition made
+    /// its <c>Enter_Slowpath</c> share go <em>up</em>. Three separate optimizations the profile
+    /// called large measured exactly zero in wall-clock A/B tests.</para>
+    ///
+    /// <para>So: real <see cref="Stopwatch"/> timestamps, on the real workload, with the profiler
+    /// nowhere near it. Percentiles rather than means, because a mean hides the tail that actually
+    /// costs a tick its deadline.</para>
+    ///
+    /// <para>Cost when disabled is one static bool test per phase boundary — <see cref="Now"/>
+    /// returns 0 without reading the clock, and the world never allocates a profiler at all.
+    /// Allocation-free when enabled: fixed arrays, a reused StringBuilder, no LINQ.</para>
+    /// </summary>
+    public sealed class TickProfiler
+    {
+        /// <summary>
+        /// Enables phase timing. Read through the Env autoload, so it works as a real process
+        /// variable or as an entry in res://.env.server. Deliberately separate from
+        /// <see cref="ServerMetrics.EnableEnvVar"/>: this is a diagnostic you turn on to answer a
+        /// question, not something a production instance should carry.
+        /// </summary>
+        public const string EnableEnvVar = "NEBULA_PROFILE";
+
+        /// <summary>Prefix on every emitted line, so a run can be filtered out of a noisy log.</summary>
+        public const string LinePrefix = "NEBULA_PHASES ";
+
+        private const int SampleCapacity = 2048;
+
+        private static bool _parsed;
+        private static bool _enabled;
+
+        public static bool Enabled
+        {
+            get
+            {
+                if (!_parsed)
+                {
+                    _parsed = true;
+                    Nebula.Utility.Tools.Env.TryGetFlag(EnableEnvVar, out _enabled);
+                }
+                return _enabled;
+            }
+        }
+
+        /// <summary>
+        /// Phases of one server tick, in execution order.
+        ///
+        /// <para>Some are nested and the report says so rather than pretending otherwise:
+        /// <see cref="Gameplay"/> runs inside <see cref="SceneScan"/>, and the five Export* phases
+        /// run inside <see cref="Export"/>. Reporting them flat with honest labels beats
+        /// subtracting, which quietly hides whatever is in the parent but in no child.</para>
+        /// </summary>
+        public enum Phase
+        {
+            /// <summary>Applying queued inbound packets. Runs every physics frame, not just tick frames.</summary>
+            Inbound,
+            /// <summary>Tick-aligned player-join callbacks.</summary>
+            Joins,
+            /// <summary>Ack-timeout sweep plus disconnecting whoever it found.</summary>
+            AckSweep,
+            /// <summary>The pass over NetScenes: validity, interest, auto-despawn. Contains Gameplay.</summary>
+            SceneScan,
+            /// <summary>Game code: _NetworkProcess on every networked node. Nested in SceneScan.</summary>
+            Gameplay,
+            /// <summary>Dispatching queued net functions.</summary>
+            NetFunctions,
+            /// <summary>Whole serialization pass. Contains the four Export* phases below.</summary>
+            Export,
+            /// <summary>Export phase 1: spawn/despawn records.</summary>
+            ExportSpawn,
+            /// <summary>Export phase 2: property sections, round-robin across nodes.</summary>
+            ExportProps,
+            /// <summary>Export phase 3: interest resync.</summary>
+            ExportResync,
+            /// <summary>Per-tick serializer Cleanup across every node. Nested in Export.</summary>
+            ExportCleanup,
+            /// <summary>NebulaPack compression plus handing each peer's packet to the transport.</summary>
+            PackSend,
+            /// <summary>NebulaPack.WritePacket: baseline pick, delta measure, encode. Nested in PackSend.</summary>
+            PackCompress,
+            /// <summary>Searching the acked window for the baseline that compresses best. Nested in PackCompress.</summary>
+            PackPick,
+            /// <summary>Encoding the delta against the chosen baseline. Nested in PackCompress.</summary>
+            PackEncode,
+            /// <summary>Copying the payload uncompressed, when no baseline won. Nested in PackCompress.</summary>
+            PackRaw,
+            /// <summary>Payload checksum. Nested in PackCompress.</summary>
+            PackChecksum,
+            /// <summary>Handing the finished packet to ENet. Nested in PackSend.</summary>
+            PackTransmit,
+            /// <summary>Recording the payload as a future delta baseline. Nested in PackSend.</summary>
+            PackBaseline,
+            /// <summary>Despawn bookkeeping and deleting fully-acked nodes.</summary>
+            Despawn,
+
+            Count,
+        }
+
+        private static readonly string[] PhaseNames =
+        {
+            "inbound", "joins", "ack_sweep", "scene_scan", "gameplay", "netfunctions",
+            "export", "exp_spawn", "exp_props", "exp_resync", "exp_cleanup",
+            "pack_send", "pack_compress", "pk_pick", "pk_encode", "pk_raw", "pk_checksum",
+            "pack_transmit", "pack_baseline", "despawn",
+        };
+
+        private const int PhaseCount = (int)Phase.Count;
+
+        /// <summary>Accumulated Stopwatch ticks for each phase within the tick being measured.</summary>
+        private readonly long[] _currentPhase = new long[PhaseCount];
+
+        /// <summary>Per-phase millisecond samples for the current window.</summary>
+        private readonly double[][] _samples = NewSamples();
+
+        private readonly int[] _sampleCounts = new int[PhaseCount];
+
+        /// <summary>Whole-tick samples, so each phase can be reported as a share of the tick.</summary>
+        private readonly double[] _tickMs = new double[SampleCapacity];
+        private int _tickCount;
+
+        private readonly double[] _sortScratch = new double[SampleCapacity];
+        private readonly StringBuilder _line = new(1024);
+
+        private static double[][] NewSamples()
+        {
+            var samples = new double[PhaseCount][];
+            for (int i = 0; i < PhaseCount; i++) samples[i] = new double[SampleCapacity];
+            return samples;
+        }
+
+        private static readonly CultureInfo Inv = CultureInfo.InvariantCulture;
+        private static readonly double MsPerTick = 1000.0 / Stopwatch.Frequency;
+
+        /// <summary>
+        /// The profiler for the world ticking on THIS thread, so library code reached from the tick
+        /// (NebulaPack, serializers) can report without every signature growing a profiler
+        /// parameter. Thread-static because worlds tick on their own threads when per-world thread
+        /// groups are on — a plain static would interleave two worlds' numbers into one bucket.
+        /// Null whenever profiling is off, or on any thread that is not mid-tick.
+        /// </summary>
+        [ThreadStatic] private static TickProfiler _current;
+
+        public static TickProfiler Current => _current;
+
+        /// <summary>Binds this profiler to the calling thread for the duration of its tick.</summary>
+        public void MakeCurrent() => _current = this;
+
+        /// <summary>Things worth counting rather than timing.</summary>
+        public enum Counter
+        {
+            /// <summary>Baselines measured by PickBaseline. Distinguishes a wide search from a slow one.</summary>
+            PackCandidates,
+            /// <summary>Payload bytes fed to a measuring pass, i.e. the search's real workload.</summary>
+            PackBytesMeasured,
+            /// <summary>Packets where a baseline was chosen, i.e. the denominator for the two below.</summary>
+            PackDeltasChosen,
+            /// <summary>Sum of chosen baseline ages. Mean age says how far back the winner tends to be.</summary>
+            PackChosenAgeSum,
+            /// <summary>Bytes in literal (differing) runs — the half scanned one byte at a time.</summary>
+
+            /// <summary>Candidates that reached an exact measurement, after digest ranking.</summary>
+            PackMeasured,
+            Count,
+        }
+
+        private static readonly string[] CounterNames =
+        {
+            "pk_candidates", "pk_bytes_measured", "pk_deltas_chosen",
+            "pk_chosen_age_sum", "pk_measured",
+        };
+        private const int CounterCount = (int)Counter.Count;
+
+        private readonly long[] _counterCurrent = new long[CounterCount];
+        private readonly long[] _counterWindow = new long[CounterCount];
+
+        /// <summary>Adds to a per-tick counter. No-op when profiling is off.</summary>
+        public void Add(Counter counter, long amount) => _counterCurrent[(int)counter] += amount;
+
+        /// <summary>
+        /// Timestamp for a phase about to start, or 0 when profiling is off. Pair with
+        /// <see cref="Record"/>; a 0 start is ignored there, so callers need no null checks.
+        /// </summary>
+        public static long Now() => _enabled ? Stopwatch.GetTimestamp() : 0L;
+
+        /// <summary>
+        /// Charges the elapsed time since <paramref name="startTimestamp"/> to a phase. Additive:
+        /// a phase entered many times in one tick (Gameplay, once per node) accumulates.
+        /// </summary>
+        public void Record(Phase phase, long startTimestamp)
+        {
+            if (startTimestamp == 0L) return;
+            _currentPhase[(int)phase] += Stopwatch.GetTimestamp() - startTimestamp;
+        }
+
+        /// <summary>
+        /// Closes the tick: converts this tick's accumulators into samples and resets them.
+        /// <paramref name="tickMs"/> is the whole ServerProcessTick duration the caller already
+        /// measures, so shares are against the real tick rather than the sum of the parts.
+        /// </summary>
+        public void EndTick(double tickMs)
+        {
+            if (_tickCount < SampleCapacity) _tickMs[_tickCount++] = tickMs;
+
+            for (int i = 0; i < PhaseCount; i++)
+            {
+                if (_sampleCounts[i] < SampleCapacity)
+                {
+                    _samples[i][_sampleCounts[i]++] = _currentPhase[i] * MsPerTick;
+                }
+                _currentPhase[i] = 0;
+            }
+
+            for (int i = 0; i < CounterCount; i++)
+            {
+                _counterWindow[i] += _counterCurrent[i];
+                _counterCurrent[i] = 0;
+            }
+        }
+
+        private long _windowStartTs;
+        private bool _started;
+
+        /// <summary>
+        /// True once a reporting window has elapsed. Kept independent of
+        /// <see cref="ServerMetrics.IsDue"/> so phase timing can be switched on by itself, without
+        /// also turning on the metrics channel.
+        /// </summary>
+        public bool IsDue(out double elapsedSeconds)
+        {
+            long now = Stopwatch.GetTimestamp();
+            if (!_started)
+            {
+                _started = true;
+                _windowStartTs = now;
+                elapsedSeconds = 0;
+                return false;
+            }
+
+            elapsedSeconds = (now - _windowStartTs) / (double)Stopwatch.Frequency;
+            if (elapsedSeconds < IntervalSeconds) return false;
+            _windowStartTs = now;
+            return true;
+        }
+
+        /// <summary>Reporting cadence. Matches ServerMetrics' default so lines interleave readably.</summary>
+        public static double IntervalSeconds => 1.0;
+
+        /// <summary>
+        /// Prints the report line and clears the window. Printing rather than returning, because
+        /// unlike ServerMetrics this has no editor-side consumer -- it is read from the log.
+        /// </summary>
+        public string Emit(UUID worldId, Tick tick, int peers, double elapsedSeconds)
+        {
+            double tickP50 = PercentileOf(_tickMs, _tickCount, 0.50);
+            double tickMean = MeanOf(_tickMs, _tickCount);
+
+            _line.Clear();
+            _line.Append(LinePrefix);
+            _line.Append("{\"world\":\"").Append(worldId.ToString()).Append('"');
+            _line.Append(",\"tick\":").Append(tick.ToString(Inv));
+            _line.Append(",\"window_s\":").Append(elapsedSeconds.ToString("F2", Inv));
+            _line.Append(",\"peers\":").Append(peers.ToString(Inv));
+            _line.Append(",\"ticks\":").Append(_tickCount.ToString(Inv));
+            _line.Append(",\"tick_ms\":{\"p50\":").Append(tickP50.ToString("F3", Inv));
+            _line.Append(",\"mean\":").Append(tickMean.ToString("F3", Inv)).Append('}');
+
+            _line.Append(",\"phases\":{");
+            for (int i = 0; i < PhaseCount; i++)
+            {
+                if (i > 0) _line.Append(',');
+                int count = _sampleCounts[i];
+                double mean = MeanOf(_samples[i], count);
+                _line.Append('"').Append(PhaseNames[i]).Append("\":{");
+                _line.Append("\"mean\":").Append(mean.ToString("F3", Inv));
+                _line.Append(",\"p50\":").Append(PercentileOf(_samples[i], count, 0.50).ToString("F3", Inv));
+                _line.Append(",\"p95\":").Append(PercentileOf(_samples[i], count, 0.95).ToString("F3", Inv));
+                _line.Append(",\"max\":").Append(PercentileOf(_samples[i], count, 1.0).ToString("F3", Inv));
+                // Share of the mean tick, not of the summed phases: the difference between the two
+                // is the tick time no phase claims, which is itself worth seeing.
+                double share = tickMean > 0 ? mean / tickMean * 100.0 : 0;
+                _line.Append(",\"pct\":").Append(share.ToString("F1", Inv));
+                _line.Append('}');
+            }
+            _line.Append('}');
+
+            // Per tick, so "30 candidates measured" reads directly rather than needing division.
+            _line.Append(",\"counters_per_tick\":{");
+            int ticks = _tickCount > 0 ? _tickCount : 1;
+            for (int i = 0; i < CounterCount; i++)
+            {
+                if (i > 0) _line.Append(',');
+                _line.Append('"').Append(CounterNames[i]).Append("\":")
+                     .Append((_counterWindow[i] / (double)ticks).ToString("F1", Inv));
+            }
+            _line.Append('}');
+
+
+            _line.Append('}');
+
+            for (int i = 0; i < CounterCount; i++) _counterWindow[i] = 0;
+            _tickCount = 0;
+            for (int i = 0; i < PhaseCount; i++) _sampleCounts[i] = 0;
+
+            var report = _line.ToString();
+            Godot.GD.Print(report);
+            return report;
+        }
+
+        private double MeanOf(double[] values, int count)
+        {
+            if (count == 0) return 0;
+            double total = 0;
+            for (int i = 0; i < count; i++) total += values[i];
+            return total / count;
+        }
+
+        /// <summary>Nearest-rank percentile. Sorts into scratch so the sample order survives.</summary>
+        private double PercentileOf(double[] values, int count, double fraction)
+        {
+            if (count == 0) return 0;
+            Array.Copy(values, _sortScratch, count);
+            Array.Sort(_sortScratch, 0, count);
+            int index = (int)Math.Ceiling(fraction * count) - 1;
+            if (index < 0) index = 0;
+            if (index >= count) index = count - 1;
+            return _sortScratch[index];
+        }
+    }
+}

--- a/addons/Nebula/Core/Diagnostics/TickProfiler.cs.uid
+++ b/addons/Nebula/Core/Diagnostics/TickProfiler.cs.uid
@@ -1,0 +1,1 @@
+uid://b55nhgqtlkdpb

--- a/addons/Nebula/Core/NetRunner.cs
+++ b/addons/Nebula/Core/NetRunner.cs
@@ -193,8 +193,9 @@ namespace Nebula
 
         public override void _Ready()
         {
+            _ = MTU;
             // Protocol is fully static - no initialization needed
-            StartDebugHub();
+            StartTelemetryHub();
 
             // No-op unless this process was launched with --bot. Created here rather than added as
             // an autoload so that adopting Nebula's bots costs a project no project.godot changes,
@@ -234,25 +235,44 @@ namespace Nebula
         /// Cached on first read, so toggling it takes effect on the next run.
         /// </summary>
         public static bool DebugServerEnabled =>
-            _debugServerEnabled ??= ProjectSettings.GetSetting(DEBUG_SERVER_SETTING, true).AsBool();
+            _debugServerEnabled ??= ResolveDebugServerEnabled();
 
         private static bool? _debugServerEnabled;
+
+        /// <summary>
+        /// Environment/.env switch for <see cref="DebugServerEnabled"/>, checked before
+        /// the project setting so a deployment can turn the channel off per process kind
+        /// (<c>.env.server</c> vs <c>.env.client</c>) without editing project.godot.
+        /// Off means fully inert: no listener, no frames built, no per-tick debug work.
+        /// </summary>
+        public const string DEBUG_SERVER_ENV_VAR = "NEBULA_DEBUG";
+
+        private static bool ResolveDebugServerEnabled()
+            => Env.TryGetFlag(DEBUG_SERVER_ENV_VAR, out bool fromEnv)
+                ? fromEnv
+                : ProjectSettings.GetSetting(DEBUG_SERVER_SETTING, true).AsBool();
 
         /// <summary>Project setting key for <see cref="DebugServerEnabled"/>.</summary>
         public const string DEBUG_SERVER_SETTING = "Nebula/config/debug/enable_debug_server";
 
         /// <summary>
-        /// Opt-in via <c>--debugPort=N</c>, and gated by
-        /// <see cref="DebugServerEnabled"/>. The editor's Play button assigns a port
-        /// per launched instance and the integration harness passes it explicitly;
-        /// the port is used verbatim, never fallen back.
+        /// Opt-in via <c>--debugPort=N</c>. The editor's Play button assigns a port per
+        /// launched instance and the integration harness passes it explicitly; the port
+        /// is used verbatim, never fallen back.
+        ///
+        /// <para>The socket carries two independently switchable features, so it starts
+        /// when EITHER wants it: the debugger (<see cref="DebugServerEnabled"/>) and
+        /// metrics reporting (<see cref="Diagnostics.ServerMetrics.Enabled"/>). Turning
+        /// the debugger off while metrics are on leaves the listener up but suppresses
+        /// every debug-class frame — see <see cref="DebugHub.DebugFramesEnabled"/>.</para>
         ///
         /// Parsed here rather than in WorldRunner, where it used to live: that
         /// ran once per world, so multiple worlds fought over the same port.
         /// </summary>
-        private void StartDebugHub()
+        private void StartTelemetryHub()
         {
-            if (!DebugServerEnabled)
+            bool debugFrames = DebugServerEnabled;
+            if (!debugFrames && !Diagnostics.ServerMetrics.Enabled)
                 return;
 
             int explicitPort = 0;
@@ -268,7 +288,7 @@ namespace Nebula
             if (explicitPort <= 0)
                 return;
 
-            var hub = new DebugHub();
+            var hub = new DebugHub { DebugFramesEnabled = debugFrames };
             if (hub.Start(explicitPort))
                 DebugHub = hub;
         }
@@ -409,7 +429,7 @@ namespace Nebula
             Debugger.Instance.Log($"Started on port {Port}");
 
             // The debug channel is not started here: it is process-wide (see
-            // StartDebugHub) so that clients get one too, and so it is already
+            // StartTelemetryHub) so that clients get one too, and so it is already
             // listening before the network starts.
         }
 
@@ -506,7 +526,65 @@ namespace Nebula
         /// Maximum Transferrable Unit. The maximum number of bytes that should be sent in a single ENet UDP Packet (i.e. a single tick)
         /// Not a hard limit.
         /// </summary>
-        public static int MTU => ProjectSettings.GetSetting("Nebula/config/network/mtu", 1400).AsInt32();
+        public const string MTU_SETTING = "Nebula/config/network/mtu";
+        public const int DefaultMTU = 1400;
+        private static int _mtu;
+        public static int MTU
+        {
+            get
+            {
+                var cached = _mtu;
+                if (cached != 0) return cached;
+                return _mtu = ProjectSettings.GetSetting(MTU_SETTING, DefaultMTU).AsInt32();
+            }
+        }
+
+        public const string ACK_TIMEOUT_SETTING = "Nebula/config/network/ack_timeout_seconds";
+        public const string JOIN_ACK_TIMEOUT_SETTING = "Nebula/config/network/join_ack_timeout_seconds";
+        public const float DefaultAckTimeoutSeconds = 5.0f;
+        public const float DefaultJoinAckTimeoutSeconds = 30.0f;
+
+        /// <summary>
+        /// Seconds an IN-WORLD peer may go without acknowledging a tick before the server
+        /// force-disconnects it. A healthy peer acks continuously (piggybacked on input or
+        /// standalone), so this is a pure liveness cutoff.
+        /// </summary>
+        public static float AckTimeoutSeconds =>
+            (float)ProjectSettings.GetSetting(ACK_TIMEOUT_SETTING, DefaultAckTimeoutSeconds).AsDouble();
+
+        /// <summary>
+        /// Seconds a JOINING peer (INITIAL status - never acked yet) gets before the same
+        /// cutoff. A client's first ack only follows a successfully imported tick, which is
+        /// after process boot, world-scene load, and spatial-mirror build - easily past the
+        /// in-world cutoff on a loaded machine, so joins need their own, longer window.
+        /// </summary>
+        public static float JoinAckTimeoutSeconds =>
+            (float)ProjectSettings.GetSetting(JOIN_ACK_TIMEOUT_SETTING, DefaultJoinAckTimeoutSeconds).AsDouble();
+
+        /// <summary>Tick-channel packet header: the int32 tick number.</summary>
+        private const int TickHeaderBytes = sizeof(int);
+
+        /// <summary>NebulaPack framing: the flags byte (see NebulaPack.WritePacket).</summary>
+        private const int PackFlagsBytes = 1;
+
+        /// <summary>NebulaPack framing: the optional uint16 checksum, budgeted worst-case.</summary>
+        private const int PackChecksumBytes = sizeof(ushort);
+
+        /// <summary>
+        /// Headroom subtracted from the tick payload budget to absorb small framing
+        /// variations (NebulaPack baseline-age byte, future flags).
+        /// </summary>
+        public const int TickBudgetHeadroom = 16;
+
+        /// <summary>
+        /// Per-peer byte budget for one tick's serialized payload (the ExportState output),
+        /// derived from the MTU: MTU minus the tick header, pack flags, checksum worst
+        /// case, and <see cref="TickBudgetHeadroom"/>. The export path keeps every peer
+        /// payload within this so the packet never exceeds the MTU and the client's decode
+        /// ceiling (MTU + 64) is unreachable.
+        /// </summary>
+        public static int TickPayloadBudget(int mtu)
+            => mtu - TickHeaderBytes - PackFlagsBytes - PackChecksumBytes - TickBudgetHeadroom;
 
         private static bool? _logTickPayloads;
         /// <summary>

--- a/addons/Nebula/Core/Serialization/BsonWriteBuffer.cs
+++ b/addons/Nebula/Core/Serialization/BsonWriteBuffer.cs
@@ -1,0 +1,205 @@
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.IO;
+using MongoDB.Bson;
+using MongoDB.Bson.IO;
+using MongoDB.Bson.Serialization;
+
+namespace Nebula.Serialization
+{
+    /// <summary>
+    /// Serializes a <see cref="BsonValue"/> into a buffer that is REUSED across calls, so a
+    /// periodic large save stops churning the large object heap.
+    ///
+    /// <para>The problem this exists for, measured on the server with dotnet-trace: every
+    /// <c>BsonDocument.ToBson()</c> grew an internal MemoryStream by doubling
+    /// (131 KB → 262 KB → 524 KB → 1 MB of pure garbage), produced a right-sized ~786 KB copy,
+    /// and the caller then copied that AGAIN into a protobuf ByteString — 3.5 MB of large-object
+    /// traffic to ship 786 KB, every 5 seconds. The LOH is only reclaimed by a gen2 collection,
+    /// so that alone drove a gen2 roughly every 10 seconds.</para>
+    ///
+    /// <para>A MemoryStream never shrinks its backing array, so resetting it between writes and
+    /// slicing <see cref="WrittenMemory"/> to the byte count reaches a high-water mark after a
+    /// few saves and then allocates nothing at all.</para>
+    ///
+    /// <para><b>Ownership.</b> <see cref="WrittenMemory"/> ALIASES the internal buffer — nothing
+    /// is copied. A consumer that hands it to an async API (protobuf's
+    /// <c>UnsafeByteOperations.UnsafeWrap</c>, then a fire-and-forget gRPC call) keeps reading it
+    /// after the call returns, so the buffer must not be reused until that consumer is finished.
+    /// Rent with <see cref="Rent"/> and <see cref="Return"/> exactly once per rent, from the
+    /// point where the consumer is provably done (for an RPC: its response continuation, in a
+    /// <c>finally</c>). Note this type is deliberately NOT IDisposable: a <c>using</c> would
+    /// release the buffer at the end of the synchronous block, which is precisely the bug.</para>
+    ///
+    /// <para>Known, accepted leak mode: if the consumer never signals completion (an RPC with no
+    /// deadline against a hung server), that buffer never returns to the pool. This degrades
+    /// gracefully — <see cref="Rent"/> simply allocates a fresh one — rather than corrupting.</para>
+    /// </summary>
+    public sealed class BsonWriteBuffer
+    {
+        /// <summary>
+        /// Starting capacity. Deliberately under the 85,000-byte large-object threshold so even a
+        /// brand-new buffer starts on the normal heap; it grows to the payload's high-water mark
+        /// within the first few writes and stays there.
+        /// </summary>
+        public const int DefaultCapacity = 64 * 1024;
+
+        /// <summary>Buffers kept for reuse. Beyond this, <see cref="Return"/> drops them for the GC.</summary>
+        private const int MaxPooledBuffers = 32;
+
+        /// <summary>
+        /// A buffer grown past this is dropped rather than pooled, so one pathological document
+        /// cannot permanently pin memory in every pool slot.
+        /// </summary>
+        private const int MaxRetainedCapacity = 8 * 1024 * 1024;
+
+        // Rent happens on the save thread and Return on an RPC continuation thread, i.e. reliably
+        // different threads - the worst case for ConcurrentBag's thread-local bias. A plain locked
+        // Stack is both simpler and LIFO, so the warmest buffer is reused. Contention is a handful
+        // of operations every few seconds.
+        private static readonly Stack<BsonWriteBuffer> _pool = new();
+        private static readonly object _poolLock = new();
+
+        private readonly MemoryStream _stream;
+        private int _length;
+
+        /// <summary>Guards against a double <see cref="Return"/>. Read/written under <see cref="_poolLock"/>.</summary>
+        private bool _pooled;
+
+        private BsonWriteBuffer()
+        {
+            // The int-capacity constructor produces an expandable, exposable stream, which is what
+            // makes GetBuffer() legal below.
+            _stream = new MemoryStream(DefaultCapacity);
+        }
+
+        /// <summary>Bytes written by the last <see cref="Write"/>.</summary>
+        public int Length => _length;
+
+        /// <summary>Current backing-array size. Only grows, and only up to the largest payload seen.</summary>
+        public int Capacity => _stream.Capacity;
+
+        /// <summary>
+        /// The bytes written by the last <see cref="Write"/>, as a view over the internal buffer —
+        /// no copy. The slice is what makes stale bytes from a previous, longer write unreachable;
+        /// the buffer is never cleared, because zeroing ~800 KB per save would buy nothing.
+        /// Valid until this buffer is reused or returned to the pool.
+        /// </summary>
+        public ReadOnlyMemory<byte> WrittenMemory => new(_stream.GetBuffer(), 0, _length);
+
+        /// <summary>
+        /// Serializes <paramref name="value"/> into the buffer, replacing any previous contents.
+        /// </summary>
+        public void Write(BsonValue value)
+        {
+            ArgumentNullException.ThrowIfNull(value);
+
+            _length = 0;
+            _stream.Position = 0;
+            _stream.SetLength(0);
+
+            // A fresh writer per document: after a top-level WriteEndDocument the writer's state is
+            // Done, so it cannot be reused. It is a small short-lived object and the whole point of
+            // this class is the large buffer underneath - do not "optimise" this into a cached
+            // writer. BsonBinaryWriter does not own or dispose the stream (documented on its ctor).
+            //
+            // Nominal type BsonValue, NOT BsonDocument: the callers' documents are held in
+            // BsonValue-typed variables, so the ToBson() this replaces passed BsonValue. Changing
+            // the nominal type risks silently changing the bytes that get persisted.
+            using (var writer = new BsonBinaryWriter(_stream))
+            {
+                BsonSerializer.Serialize(writer, typeof(BsonValue), value);
+            }
+
+            // Read the length AFTER the writer is closed, and from Length rather than Position:
+            // writing a C-string reserves worst-case UTF-8 bytes, so intermediate positions and the
+            // capacity both overstate the payload.
+            _length = (int)_stream.Length;
+
+            // A BSON document opens with its own total length as a little-endian int32. Comparing it
+            // to what we measured is four bytes of work that turns a stale-trailing-bytes or
+            // over-reserve bug into an exception here, instead of a corrupt record discovered later
+            // in a database.
+            if (value is BsonDocument && _length >= sizeof(int))
+            {
+                var declared = BinaryPrimitives.ReadInt32LittleEndian(WrittenMemory.Span);
+                if (declared != _length)
+                {
+                    throw new InvalidOperationException(
+                        $"BSON length mismatch: document declares {declared} bytes, buffer holds {_length}.");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Takes a buffer from the pool, or creates one when the pool is empty. Never blocks and
+        /// never throws: a save must not stall waiting for a buffer.
+        /// </summary>
+        public static BsonWriteBuffer Rent()
+        {
+            lock (_poolLock)
+            {
+                if (_pool.Count > 0)
+                {
+                    var pooled = _pool.Pop();
+                    pooled._pooled = false;
+                    return pooled;
+                }
+            }
+            return new BsonWriteBuffer();
+        }
+
+        /// <summary>
+        /// Returns a buffer for reuse. Must be called exactly once per <see cref="Rent"/>, and only
+        /// once every consumer of <see cref="WrittenMemory"/> is finished with it.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// The buffer was already returned. This is worth throwing over rather than tolerating: a
+        /// double return hands the same array to two callers, so two live payloads alias one buffer
+        /// and one of them silently ships corrupted bytes.
+        /// </exception>
+        public static void Return(BsonWriteBuffer buffer)
+        {
+            if (buffer == null)
+            {
+                return;
+            }
+
+            lock (_poolLock)
+            {
+                if (buffer._pooled)
+                {
+                    throw new InvalidOperationException(
+                        "BsonWriteBuffer returned twice; its buffer may be aliased by another payload.");
+                }
+
+                if (_pool.Count >= MaxPooledBuffers || buffer.Capacity > MaxRetainedCapacity)
+                {
+                    // Dropped, not pooled. Still mark it so a later double return is caught.
+                    buffer._pooled = true;
+                    return;
+                }
+
+                buffer._pooled = true;
+                buffer._length = 0;
+                _pool.Push(buffer);
+            }
+        }
+
+        /// <summary>Test seam: empties the pool so a test starts from a known state.</summary>
+        internal static void ClearPoolForTests()
+        {
+            lock (_poolLock)
+            {
+                _pool.Clear();
+            }
+        }
+
+        /// <summary>Test seam: how many buffers are currently pooled.</summary>
+        internal static int PooledCountForTests
+        {
+            get { lock (_poolLock) { return _pool.Count; } }
+        }
+    }
+}

--- a/addons/Nebula/Core/Serialization/BsonWriteBuffer.cs.uid
+++ b/addons/Nebula/Core/Serialization/BsonWriteBuffer.cs.uid
@@ -1,0 +1,1 @@
+uid://dd6q5p80bwh6p

--- a/addons/Nebula/Core/Serialization/ExportRotation.cs
+++ b/addons/Nebula/Core/Serialization/ExportRotation.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+
+namespace Nebula.Serialization
+{
+    /// <summary>
+    /// Start-index selection for the round-robin property phase of ExportState. The
+    /// per-peer cursor stores the NetId of the next node owed service; the node list is
+    /// world iteration order (insertion order, not sorted), so resolution is by identity
+    /// first, then the closest id at-or-above the cursor for a node that despawned, then
+    /// wrap to 0. Selection order only — wire order stays ascending peer-local node id.
+    /// </summary>
+    internal static class ExportRotation
+    {
+        public static int FindStartIndex(List<NetworkController> nodes, long cursorNetId)
+        {
+            if (nodes.Count == 0 || cursorNetId <= 0)
+            {
+                return 0;
+            }
+            var bestAbove = -1;
+            long bestAboveId = long.MaxValue;
+            for (var i = 0; i < nodes.Count; i++)
+            {
+                var id = nodes[i].NetId.Value;
+                if (id == cursorNetId)
+                {
+                    return i;
+                }
+                if (id > cursorNetId && id < bestAboveId)
+                {
+                    bestAboveId = id;
+                    bestAbove = i;
+                }
+            }
+            return bestAbove >= 0 ? bestAbove : 0;
+        }
+    }
+}

--- a/addons/Nebula/Core/Serialization/ExportRotation.cs.uid
+++ b/addons/Nebula/Core/Serialization/ExportRotation.cs.uid
@@ -1,0 +1,1 @@
+uid://ec8nhbir2hso

--- a/addons/Nebula/Core/Serialization/NebulaPack.cs
+++ b/addons/Nebula/Core/Serialization/NebulaPack.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace Nebula.Serialization
 {
@@ -121,6 +124,70 @@ namespace Nebula.Serialization
 
     public static class NebulaPack
     {
+        /// <summary>
+        /// Bytes per block digest. 32 gives ~28 digests for a typical payload — fine enough that a
+        /// differing-block count tracks literal volume closely, coarse enough that ranking is a few
+        /// dozen word compares.
+        /// </summary>
+        public const int DigestBlockBytes = 32;
+
+        /// <summary>
+        /// How many of the digest-ranked candidates get an exact measurement. Ranking is a proxy, so
+        /// measuring only the single best would inherit every ranking error; measuring the top few
+        /// recovers most of that for one extra scan each, and the exact sizes still decide the
+        /// winner.
+        /// </summary>
+        private const int TopCandidatesToMeasure = 3;
+
+        /// <summary>
+        /// Digest slots kept on the stack for the outgoing payload. Sized past the MTU-capped
+        /// payload so the heap path is unreachable in practice but still correct if a project
+        /// raises the MTU.
+        /// </summary>
+        private const int MaxStackDigests = 128;
+
+        /// <summary>Digest blocks a payload of this length occupies.</summary>
+        public static int BlockCount(int length)
+            => (length + DigestBlockBytes - 1) / DigestBlockBytes;
+
+        /// <summary>
+        /// Fills <paramref name="into"/> with one digest per block of <paramref name="payload"/>.
+        ///
+        /// <para>Multiply-and-rotate rather than an XOR fold: XOR cancels, so two different blocks
+        /// that happen to contain the same bytes in a different order would collide constantly, and
+        /// ranking would treat unrelated baselines as identical. This is not a hash anyone attacks —
+        /// it only has to separate blocks that differ, and a collision costs a slightly worse
+        /// baseline, never a wrong delta.</para>
+        /// </summary>
+        public static void ComputeDigests(ReadOnlySpan<byte> payload, Span<ulong> into)
+        {
+            const ulong Basis = 0xcbf29ce484222325UL;
+            const ulong Prime = 0x100000001b3UL;
+
+            int blocks = BlockCount(payload.Length);
+            for (int b = 0; b < blocks; b++)
+            {
+                int start = b * DigestBlockBytes;
+                int length = Math.Min(DigestBlockBytes, payload.Length - start);
+                var block = payload.Slice(start, length);
+
+                ulong h = Basis;
+                int offset = 0;
+                while (offset + sizeof(ulong) <= length)
+                {
+                    ulong word = MemoryMarshal.Read<ulong>(block.Slice(offset, sizeof(ulong)));
+                    h = System.Numerics.BitOperations.RotateLeft((h ^ word) * Prime, 31);
+                    offset += sizeof(ulong);
+                }
+                // Tail of a short final block, folded in a byte at a time.
+                for (; offset < length; offset++)
+                {
+                    h = System.Numerics.BitOperations.RotateLeft((h ^ block[offset]) * Prime, 31);
+                }
+                into[b] = h;
+            }
+        }
+
         /// <summary>Body is a delta, not a raw payload.</summary>
         public const byte FlagDelta = 0x01;
 
@@ -150,9 +217,12 @@ namespace Nebula.Serialization
             bool allowDelta,
             bool addChecksum)
         {
+            var profiler = Diagnostics.TickProfiler.Current;
+            var pickTs = Diagnostics.TickProfiler.Now();
             int age = allowDelta
                 ? PickBaseline(payload, window, currentTick, out int deltaSize)
                 : 0;
+            profiler?.Record(Diagnostics.TickProfiler.Phase.PackPick, pickTs);
 
             byte flags = 0;
             if (age > 0) flags |= FlagDelta;
@@ -165,7 +235,9 @@ namespace Nebula.Serialization
             if (age > 0 && window.TryGetAcked(currentTick - age, out var baseline))
             {
                 NetWriter.WriteByte(destination, (byte)age);
+                var encodeTs = Diagnostics.TickProfiler.Now();
                 int written = EncodeDelta(payload, baseline, destination.GetWriteSpan(payload.Length));
+                profiler?.Record(Diagnostics.TickProfiler.Phase.PackEncode, encodeTs);
                 if (written > 0)
                 {
                     destination.AdvanceWrite(written);
@@ -182,10 +254,17 @@ namespace Nebula.Serialization
             if (!wroteDelta)
             {
                 age = 0;
+                var rawTs = Diagnostics.TickProfiler.Now();
                 NetWriter.WriteBytes(destination, payload);
+                profiler?.Record(Diagnostics.TickProfiler.Phase.PackRaw, rawTs);
             }
 
-            if (addChecksum) NetWriter.WriteUInt16(destination, Checksum(payload));
+            if (addChecksum)
+            {
+                var checksumTs = Diagnostics.TickProfiler.Now();
+                NetWriter.WriteUInt16(destination, Checksum(payload));
+                profiler?.Record(Diagnostics.TickProfiler.Phase.PackChecksum, checksumTs);
+            }
 
             return age;
         }
@@ -194,8 +273,20 @@ namespace Nebula.Serialization
         /// Finds the acknowledged baseline that compresses <paramref name="payload"/> smallest.
         /// Returns its age in ticks, or 0 if none beats sending raw.
         ///
-        /// Measuring doesn't write anything, so trying every candidate costs only a few byte
-        /// comparisons each.
+        /// <para>Two-stage, because measuring every candidate exactly was the single most expensive
+        /// thing the server did: ~29 acked baselines each cost a full encode pass over a ~870-byte
+        /// payload, which measured 26% of the entire world tick.</para>
+        ///
+        /// <para><b>Rank</b> every candidate by how many 32-byte blocks differ, comparing digests
+        /// the ring computed once when each payload was stored. Differing-block count tracks literal
+        /// volume closely enough to order candidates, and costs ~28 word compares instead of ~870
+        /// byte comparisons. <b>Then measure</b> only the few best exactly, each bounded by the best
+        /// size found so far so a candidate that cannot win stops partway.</para>
+        ///
+        /// <para>Ranking is a heuristic and may pass over the true optimum, so this can pick a
+        /// slightly larger delta than an exhaustive search would. It cannot pick a WRONG one: the
+        /// winner is always measured exactly before anything is encoded, and any acked baseline is
+        /// legal on the wire regardless.</para>
         /// </summary>
         private static int PickBaseline(
             ReadOnlySpan<byte> payload,
@@ -207,19 +298,81 @@ namespace Nebula.Serialization
             int bestAge = 0;
             if (window == null) return 0;
 
+            var profiler = Diagnostics.TickProfiler.Current;
+
+            // ---- stage 1: rank by differing blocks -------------------------------------------
+            int blocks = BlockCount(payload.Length);
+            Span<ulong> payloadDigests = blocks <= MaxStackDigests
+                ? stackalloc ulong[MaxStackDigests].Slice(0, blocks)
+                : new ulong[blocks];
+            ComputeDigests(payload, payloadDigests);
+
+            // Top-K by differing-block count, kept as a tiny insertion-sorted list. K is 3, so a
+            // heap would be more code than it saves.
+            Span<int> topAges = stackalloc int[TopCandidatesToMeasure];
+            Span<int> topScores = stackalloc int[TopCandidatesToMeasure];
+            int topCount = 0;
+
             for (int age = 1; age <= NebulaPackWindow.MaxPackAge; age++)
             {
                 Tick candidate = currentTick - age;
                 if (candidate < 0) break;
                 // TryGetAcked, not TryGet: only a tick this peer specifically acknowledged.
-                if (!window.TryGetAcked(candidate, out var baseline)) continue;
+                if (!window.TryGetAckedDigests(candidate, out var baselineDigests)) continue;
 
-                int size = MeasureDelta(payload, baseline);
-                if (size < payload.Length && (bestSize < 0 || size < bestSize))
+                if (profiler != null) profiler.Add(Diagnostics.TickProfiler.Counter.PackCandidates, 1);
+
+                // Blocks the baseline does not reach count as differing, which is what a delta would
+                // have to spell out literally anyway.
+                int shared = Math.Min(blocks, baselineDigests.Length);
+                int differing = blocks - shared;
+                for (int b = 0; b < shared; b++)
                 {
-                    bestSize = size;
-                    bestAge = age;
+                    if (payloadDigests[b] != baselineDigests[b]) differing++;
                 }
+
+                for (int slot = 0; slot < TopCandidatesToMeasure; slot++)
+                {
+                    if (slot < topCount && differing >= topScores[slot]) continue;
+                    for (int shift = Math.Min(topCount, TopCandidatesToMeasure - 1); shift > slot; shift--)
+                    {
+                        topAges[shift] = topAges[shift - 1];
+                        topScores[shift] = topScores[shift - 1];
+                    }
+                    topAges[slot] = age;
+                    topScores[slot] = differing;
+                    if (topCount < TopCandidatesToMeasure) topCount++;
+                    break;
+                }
+            }
+
+            // ---- stage 2: measure the finalists exactly --------------------------------------
+            // Bound starts at the raw length, since a delta at or above that is unusable anyway,
+            // and tightens with every candidate that beats it.
+            int bound = payload.Length;
+            for (int i = 0; i < topCount; i++)
+            {
+                if (!window.TryGetAcked(currentTick - topAges[i], out var baseline)) continue;
+
+                if (profiler != null)
+                {
+                    profiler.Add(Diagnostics.TickProfiler.Counter.PackMeasured, 1);
+                    profiler.Add(Diagnostics.TickProfiler.Counter.PackBytesMeasured, payload.Length);
+                }
+
+                int size = MeasureDeltaBounded(payload, baseline, bound);
+                if (size < bound)
+                {
+                    bound = size;
+                    bestSize = size;
+                    bestAge = topAges[i];
+                }
+            }
+
+            if (profiler != null && bestAge > 0)
+            {
+                profiler.Add(Diagnostics.TickProfiler.Counter.PackDeltasChosen, 1);
+                profiler.Add(Diagnostics.TickProfiler.Counter.PackChosenAgeSum, bestAge);
             }
 
             return bestAge;
@@ -304,6 +457,18 @@ namespace Nebula.Serialization
             => Encode(input, window, default, measureOnly: true);
 
         /// <summary>
+        /// <see cref="MeasureDelta"/> that gives up as soon as the delta is provably no better than
+        /// <paramref name="abortAtOrAbove"/>, returning that bound rather than the true size.
+        ///
+        /// <para>Exact, not approximate: the running size only ever grows, so once it reaches the
+        /// bound the finished size cannot come in under it. Feeding the best size found so far as
+        /// the bound therefore preserves the same global minimum an unbounded search would find,
+        /// while letting hopeless candidates stop partway.</para>
+        /// </summary>
+        public static int MeasureDeltaBounded(ReadOnlySpan<byte> input, ReadOnlySpan<byte> window, int abortAtOrAbove)
+            => Encode(input, window, default, measureOnly: true, abortAtOrAbove);
+
+        /// <summary>
         /// Writes the run list. Returns bytes written, or -1 if <paramref name="output"/> is too
         /// small. Note a delta can legitimately be larger than the input when nothing matches —
         /// deciding whether it is worth sending is the caller's job.
@@ -375,7 +540,9 @@ namespace Nebula.Serialization
         /// Each loop consumes at least one input byte: if the skip run is empty then the bytes
         /// differ, which means the literal run that follows is not empty. So it always terminates.
         /// </summary>
-        private static int Encode(ReadOnlySpan<byte> input, ReadOnlySpan<byte> window, Span<byte> output, bool measureOnly)
+        private static int Encode(
+            ReadOnlySpan<byte> input, ReadOnlySpan<byte> window, Span<byte> output, bool measureOnly,
+            int abortAtOrAbove = int.MaxValue)
         {
             int inputLen = input.Length;
             int windowLen = window.Length;
@@ -384,25 +551,69 @@ namespace Nebula.Serialization
             int pos = 0;
             if (!measureOnly && !TryWriteVarint(output, ref pos, (uint)inputLen)) return -1;
 
+            // Past either end there is nothing to compare, so word stepping stops here and the
+            // remainder is literal by definition.
+            int compareLimit = Math.Min(inputLen, windowLen);
+            ref byte inputRef = ref MemoryMarshal.GetReference(input);
+            ref byte windowRef = ref MemoryMarshal.GetReference(window);
+
             int i = 0;
             while (i < inputLen)
             {
-                // How many bytes match the baseline from here? CommonPrefixLength is SIMD-accelerated.
+                // How many bytes match the baseline from here? Compared a machine word at a time:
+                // XOR is zero exactly while the eight bytes agree, and when it isn't, the index of
+                // the first differing byte falls straight out of the trailing-zero count.
+                //
+                // This used to call CommonPrefixLength, whose vectorization is real but is charged
+                // a fixed setup cost. Measured against live traffic the matching runs average under
+                // two bytes, so that setup was the entire cost and the SIMD never had length to
+                // work with.
                 int skipStart = i;
-                if (i < windowLen)
+                while (i + sizeof(ulong) <= compareLimit)
                 {
-                    int compareLen = Math.Min(inputLen - i, windowLen - i);
-                    i += input.Slice(i, compareLen).CommonPrefixLength(window.Slice(i, compareLen));
+                    ulong difference = Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref inputRef, i))
+                                     ^ Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref windowRef, i));
+                    if (difference != 0)
+                    {
+                        i += FirstDifferingByte(difference);
+                        break;
+                    }
+                    i += sizeof(ulong);
                 }
+                while (i < compareLimit && Unsafe.Add(ref inputRef, i) == Unsafe.Add(ref windowRef, i)) i++;
                 int skip = i - skipStart;
 
                 // How many differ before they line up again? Anything past the end of the baseline
                 // counts as differing, so a payload longer than its baseline needs no special case.
+                //
+                // Same word trick inverted: step eight bytes whenever none of them match, which is
+                // the common case here (differing runs average ~15 bytes). HasZeroByte can report a
+                // false positive, never a false negative, so a hit only drops us to the byte loop
+                // rather than ever ending a run early.
                 int literalStart = i;
-                while (i < inputLen && (i >= windowLen || input[i] != window[i])) i++;
+                while (true)
+                {
+                    if (i + sizeof(ulong) <= compareLimit)
+                    {
+                        ulong difference = Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref inputRef, i))
+                                         ^ Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref windowRef, i));
+                        if (!HasZeroByte(difference)) { i += sizeof(ulong); continue; }
+                    }
+                    if (i < inputLen && (i >= windowLen || Unsafe.Add(ref inputRef, i) != Unsafe.Add(ref windowRef, i)))
+                    {
+                        i++;
+                        continue;
+                    }
+                    break;
+                }
                 int literals = i - literalStart;
 
                 size += VarintSize((uint)skip) + VarintSize((uint)literals) + literals;
+
+                // Hopeless already. size only grows, so the finished delta cannot come in under the
+                // bound and the remaining bytes would be scanned for nothing. Measuring only --
+                // a real encode has to write every run.
+                if (measureOnly && size >= abortAtOrAbove) return abortAtOrAbove;
 
                 if (!measureOnly)
                 {
@@ -414,8 +625,39 @@ namespace Nebula.Serialization
                 }
             }
 
+
             return measureOnly ? size : pos;
         }
+
+        /// <summary>
+        /// Index of the first byte (in memory order) set in <paramref name="difference"/>, which for
+        /// an XOR of two words is the first byte at which they disagree. Exact, not a heuristic:
+        /// XOR has no carries between bytes.
+        ///
+        /// <para>Memory order is what matters, so the bit scan direction follows endianness — on a
+        /// little-endian machine the first byte is the least significant. The check folds away at
+        /// JIT time.</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int FirstDifferingByte(ulong difference)
+            // Fully qualified: Nebula has its own internal BitOperations (NetArray.cs) which would
+            // otherwise win name resolution here and does not carry these members.
+            => BitConverter.IsLittleEndian
+                ? System.Numerics.BitOperations.TrailingZeroCount(difference) >> 3
+                : System.Numerics.BitOperations.LeadingZeroCount(difference) >> 3;
+
+        /// <summary>
+        /// True if any byte of <paramref name="value"/> is zero — i.e. for an XOR, whether the two
+        /// words agree anywhere.
+        ///
+        /// <para>The subtraction borrows across byte boundaries, so this can answer true when the
+        /// only zero byte is one the borrow manufactured. That is why callers treat a hit as "look
+        /// closer" rather than "a match starts here": it has no false negatives, so a run is never
+        /// ended early, and a false positive costs at most eight byte comparisons.</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool HasZeroByte(ulong value)
+            => ((value - 0x0101010101010101UL) & ~value & 0x8080808080808080UL) != 0;
 
         // ---------------------------------------------------------------- varints
 
@@ -497,6 +739,23 @@ namespace Nebula.Serialization
         private readonly Tick[] _ticks = new Tick[RingSize];
         private readonly bool[] _acked = new bool[RingSize];
 
+        /// <summary>
+        /// One 64-bit digest per fixed-size block of each stored payload, computed when the payload
+        /// is recorded.
+        ///
+        /// <para>This is what lets baseline selection stop scanning whole payloads. Counting blocks
+        /// whose digests differ is a good proxy for how many literal bytes a delta would carry, and
+        /// it costs ~28 word compares instead of ~872 byte comparisons. Crucially the digest work
+        /// amortizes: it happens once per payload STORED, not once per candidate per packet, so the
+        /// ~29-way search stops multiplying it.</para>
+        ///
+        /// <para>Digests are only a ranking signal — a collision or a weak mix costs a slightly
+        /// worse baseline choice, never a wrong delta, because the winner is still measured exactly
+        /// before anything is encoded.</para>
+        /// </summary>
+        private readonly ulong[][] _digests = new ulong[RingSize][];
+        private readonly int[] _digestCounts = new int[RingSize];
+
         public NebulaPackWindow() => Reset();
 
         /// <summary>
@@ -517,6 +776,31 @@ namespace Nebula.Serialization
             _lengths[idx] = payload.Length;
             _ticks[idx] = tick;
             _acked[idx] = false;
+
+            int blocks = NebulaPack.BlockCount(payload.Length);
+            var digests = _digests[idx];
+            if (digests == null || digests.Length < blocks)
+            {
+                _digests[idx] = digests = new ulong[Math.Max(blocks, 64)];
+            }
+            NebulaPack.ComputeDigests(payload, digests);
+            _digestCounts[idx] = blocks;
+        }
+
+        /// <summary>
+        /// The block digests for an acknowledged tick. Pairs with <see cref="TryGetAcked"/>; kept
+        /// separate so ranking can run without touching the payload bytes at all.
+        /// </summary>
+        internal bool TryGetAckedDigests(Tick tick, out ReadOnlySpan<ulong> digests)
+        {
+            digests = default;
+            if (tick < 0) return false;
+            int idx = tick % RingSize;
+            if (_ticks[idx] != tick || !_acked[idx]) return false;
+            var stored = _digests[idx];
+            if (stored == null) return false;
+            digests = stored.AsSpan(0, _digestCounts[idx]);
+            return true;
         }
 
         /// <summary>

--- a/addons/Nebula/Core/Serialization/SendWindow.cs
+++ b/addons/Nebula/Core/Serialization/SendWindow.cs
@@ -1,0 +1,38 @@
+namespace Nebula.Serialization
+{
+    /// <summary>
+    /// Tracks the contiguous run of ticks on which a resend-until-acked record
+    /// (spawn/despawn marker) actually rode a packet to one peer. The ack commit rule is
+    /// <see cref="Covers"/>: an acked tick proves delivery only if the record was in that
+    /// tick's packet, and with budget splitting a record can be deferred on any tick.
+    /// <see cref="RecordSend"/> therefore restarts the window whenever a gap appears —
+    /// an ack for a pre-gap send then simply doesn't commit (one extra resend round),
+    /// which is always safe; a false commit never is.
+    /// Ticks start at 1, so First == 0 means "never sent".
+    /// </summary>
+    internal struct SendWindow
+    {
+        public Tick First;
+        public Tick Last;
+
+        /// <summary>
+        /// Records that the record rode the packet exported at <paramref name="tick"/>.
+        /// Consecutive sends extend the window; any skipped tick restarts it.
+        /// </summary>
+        public void RecordSend(Tick tick)
+        {
+            if (First == 0 || tick > Last + 1)
+            {
+                First = tick;
+            }
+            Last = tick;
+        }
+
+        /// <summary>
+        /// True if the record was provably included in the packet exported at
+        /// <paramref name="ackedTick"/>.
+        /// </summary>
+        public readonly bool Covers(Tick ackedTick)
+            => First != 0 && ackedTick >= First && ackedTick <= Last;
+    }
+}

--- a/addons/Nebula/Core/Serialization/SendWindow.cs.uid
+++ b/addons/Nebula/Core/Serialization/SendWindow.cs.uid
@@ -1,0 +1,1 @@
+uid://b7qlaww1ugwxj

--- a/addons/Nebula/Core/Serialization/Serializers/IStateSerializer.cs
+++ b/addons/Nebula/Core/Serialization/Serializers/IStateSerializer.cs
@@ -1,7 +1,30 @@
 namespace Nebula.Serialization.Serializers
 {
     /// <summary>
-    /// Defines an object which the server utilizes to serialize and send data to the client, 
+    /// Result of a server-side <see cref="IStateSerializer.Export"/> call.
+    /// </summary>
+    public enum ExportResult : byte
+    {
+        /// <summary>Nothing was written.</summary>
+        None,
+
+        /// <summary>
+        /// Everything the serializer wanted to send was written. A self-limiting
+        /// serializer guarantees the section is within maxBytes; an atomic serializer
+        /// may have exceeded it, in which case the host drops the bytes and never calls
+        /// CommitExport.
+        /// </summary>
+        Written,
+
+        /// <summary>
+        /// The serializer self-limited to maxBytes and has more data queued for this
+        /// peer. The host uses this to place the round-robin cursor.
+        /// </summary>
+        Partial,
+    }
+
+    /// <summary>
+    /// Defines an object which the server utilizes to serialize and send data to the client,
     /// and the client can then receive and deserialize from the server.
     /// </summary>
     public interface IStateSerializer
@@ -26,11 +49,37 @@ namespace Nebula.Serialization.Serializers
         /// <summary>
         /// Server-side only. Serialize and write data to the provided buffer.
         /// Writes nothing if there's no data to export.
+        ///
+        /// Budget contract: <paramref name="maxBytes"/> is the byte budget for this
+        /// section. maxBytes &lt;= 0 means "deferred this tick": write NOTHING, but
+        /// preserve any would-be-sent data for a later tick (e.g. merge dirty bits into
+        /// a pending mask) and still run delivery-independent state transitions.
+        ///
+        /// Side-effect contract: packet-coupled state — anything asserting "these bytes
+        /// rode this tick's packet" (send-tick windows, sent-history records, dirty-bit
+        /// clears) — must NOT be stamped here. It belongs in <see cref="CommitExport"/>,
+        /// which the host calls iff the bytes from the immediately preceding Export on
+        /// this instance were committed to the packet. An atomic serializer (one that
+        /// cannot split its record) may write more than maxBytes; the host then discards
+        /// the bytes and never calls CommitExport — sound only because of this rule.
+        /// A self-limiting serializer must never exceed maxBytes; the host always
+        /// commits what it wrote.
         /// </summary>
         /// <param name="currentWorld">The current world runner</param>
         /// <param name="peer">The target peer</param>
         /// <param name="buffer">Buffer to write serialized data into</param>
-        public void Export(WorldRunner currentWorld, NetPeer peer, NetBuffer buffer);
+        /// <param name="maxBytes">Byte budget for this section (see contract above)</param>
+        public ExportResult Export(WorldRunner currentWorld, NetPeer peer, NetBuffer buffer, int maxBytes);
+
+        /// <summary>
+        /// Server-side only. The bytes written by the immediately preceding
+        /// <see cref="Export"/> on this instance were committed to the tick packet being
+        /// assembled — stamp packet-coupled state here (send windows, sent history).
+        /// Temporal contract: the host calls this before any other Export on the same
+        /// instance, on the same world tick thread, so instance scratch captured during
+        /// Export is still valid.
+        /// </summary>
+        public void CommitExport(WorldRunner currentWorld, NetPeer peer, Tick tick) { }
 
         /// <summary>
         /// Server-side only. Called when a peer acknowledges the packet exported at

--- a/addons/Nebula/Core/Serialization/Serializers/InterestResyncSerializer.cs
+++ b/addons/Nebula/Core/Serialization/Serializers/InterestResyncSerializer.cs
@@ -27,23 +27,31 @@ namespace Nebula.Serialization.Serializers
         public void CleanupPeer(UUID peerId) { }
         public bool Acknowledge(WorldRunner currentWorld, NetPeer peer, Tick latestAck) => false;
 
-        public void Export(WorldRunner currentWorld, NetPeer peer, NetBuffer buffer)
+        public ExportResult Export(WorldRunner currentWorld, NetPeer peer, NetBuffer buffer, int maxBytes)
         {
+            // Self-limiting: the section is exactly 1 byte, and a deferred tick is
+            // harmless - there is no ack tracking, the next stagger slot resyncs.
+            if (maxBytes < 1)
+            {
+                return ExportResult.None;
+            }
+
             // Only sync after the node has been spawned for this peer
             if (!currentWorld.HasSpawnedForClient(network.NetId, peer))
             {
-                return;
+                return ExportResult.None;
             }
 
             // Stagger by node ID so not all nodes sync on same tick
             int tickOffset = (int)(network.NetId.Value % SYNC_INTERVAL);
             if ((currentWorld.CurrentTick + tickOffset) % SYNC_INTERVAL != 0)
             {
-                return;
+                return ExportResult.None;
             }
 
             bool isInterested = network.IsPeerInterested(peer);
             NetWriter.WriteByte(buffer, isInterested ? (byte)1 : (byte)0);
+            return ExportResult.Written;
         }
 
         public bool Import(WorldRunner currentWorld, NetBuffer buffer, out NetworkController nodeOut)

--- a/addons/Nebula/Core/Serialization/Serializers/NetPropertiesSerializer.cs
+++ b/addons/Nebula/Core/Serialization/Serializers/NetPropertiesSerializer.cs
@@ -224,6 +224,19 @@ namespace Nebula.Serialization.Serializers
         private const int REFRESH_CHAIN = 30;
 
         /// <summary>
+        /// The baseline-age header byte written right after the presence mask
+        /// (0 = every property in the payload is absolute).
+        /// </summary>
+        private const int AGE_HEADER_BYTES = 1;
+
+        /// <summary>
+        /// The smallest possible property write: a DeltaEncodingFlags byte plus a
+        /// one-byte value (e.g. bool). A section budget below
+        /// [presence mask + <see cref="AGE_HEADER_BYTES"/> + this] cannot ship anything.
+        /// </summary>
+        private const int MIN_PROPERTY_WRITE_BYTES = 2;
+
+        /// <summary>
         /// Server: ring of property value snapshots per exported tick, shared by all peers.
         /// Captured in Begin(). Indexed by tick % SNAPSHOT_RING_SIZE.
         /// </summary>
@@ -268,6 +281,7 @@ namespace Nebula.Serialization.Serializers
                 _propertiesUpdated = Array.Empty<byte>();
                 _actualMask = Array.Empty<byte>();
                 _dirtyOnlyMask = Array.Empty<byte>();
+                _leftoverMask = Array.Empty<byte>();
                 _decodedMask = Array.Empty<byte>();
                 _decodedValues = Array.Empty<PropertyCache>();
                 _incomingMask = Array.Empty<byte>();
@@ -317,6 +331,7 @@ namespace Nebula.Serialization.Serializers
             _propertiesUpdated = new byte[_byteCount];
             _actualMask = new byte[_byteCount];
             _dirtyOnlyMask = new byte[_byteCount];
+            _leftoverMask = new byte[_byteCount];
             _decodedMask = new byte[_byteCount];
             _decodedValues = new PropertyCache[_propertyCount];
             _incomingMask = new byte[_byteCount];
@@ -777,9 +792,10 @@ namespace Nebula.Serialization.Serializers
 
         /// <summary>
         /// Test seam: builds a serializer with hand-supplied property metadata, bypassing the
-        /// Protocol registry (which requires a registered net scene). Only the client-side
-        /// Deserialize paths are exercised on instances built this way; Export/Acknowledge
-        /// depend on Protocol and a live WorldRunner and must not be called.
+        /// Protocol registry (which requires a registered net scene). Client-side Deserialize
+        /// paths work fully; server-side Export/Acknowledge work for PRIMITIVE properties
+        /// against a WorldRunner prepared with CreatePeerStateForTests (object properties
+        /// need the Protocol serializer registry and must not be used here).
         /// </summary>
         internal NetPropertiesSerializer(NetworkController _network, SerialVariantType[] propTypes)
         {
@@ -796,6 +812,8 @@ namespace Nebula.Serialization.Serializers
             for (int i = 0; i < _propertyCount; i++) _propClassIndex[i] = -1;
             _propIsPerPeer = new bool[_propertyCount];
             _propInterestMask = new long[_propertyCount];
+            // Visible on every interest layer, like a property with no [NetInterest].
+            for (int i = 0; i < _propertyCount; i++) _propInterestMask[i] = -1L;
             _propInterestRequired = new long[_propertyCount];
             _propIntWidth = new IntWidth[_propertyCount];
             _propChunkBudget = new int[_propertyCount];
@@ -803,6 +821,7 @@ namespace Nebula.Serialization.Serializers
             _propertiesUpdated = new byte[_byteCount];
             _actualMask = new byte[_byteCount];
             _dirtyOnlyMask = new byte[_byteCount];
+            _leftoverMask = new byte[_byteCount];
             _decodedMask = new byte[_byteCount];
             _decodedValues = new PropertyCache[_propertyCount];
             _incomingMask = new byte[_byteCount];
@@ -813,6 +832,16 @@ namespace Nebula.Serialization.Serializers
         {
             Deserialize(buffer, currentTick, out bool discarded);
             return !discarded;
+        }
+
+        /// <summary>Test seam: one byte of the peer's resend-until-acked pending mask.</summary>
+        internal byte PendingDirtyByteForTests(UUID peerId, int byteIndex)
+        {
+            if (!_peerStates.TryGetValue(peerId, out var state) || !state.IsInitialized)
+            {
+                return 0;
+            }
+            return state.PendingDirtyMask[byteIndex];
         }
 
         /// <summary>Test seam: whether the applied-state ring holds an entry for this exact tick.</summary>
@@ -1497,6 +1526,14 @@ namespace Nebula.Serialization.Serializers
         private byte[] _dirtyOnlyMask;
 
         /// <summary>
+        /// Scratch mask of primitive properties that were eligible to ship in the current
+        /// Export but were rewound (or never written) for budget. Merged into
+        /// PendingDirtyMask before Export returns, so they retry as absolutes on a later
+        /// tick. Same serial-access assumption as _actualMask.
+        /// </summary>
+        private byte[] _leftoverMask;
+
+        /// <summary>
         /// Scratch for the payload currently being imported: which property indices decoded
         /// a value, and the values themselves.
         ///
@@ -1516,7 +1553,17 @@ namespace Nebula.Serialization.Serializers
         /// <summary>Scratch for the incoming presence mask read off the wire.</summary>
         private byte[] _incomingMask;
 
-        public void Export(WorldRunner currentWorld, NetPeer peer, NetBuffer buffer)
+        public ExportResult Export(WorldRunner currentWorld, NetPeer peer, NetBuffer buffer, int maxBytes)
+        {
+            // Self-limiting serializer: never writes more than maxBytes, so the host
+            // always commits what was written (in-write stamps like DeltaChain, LossyMask
+            // and object-prop chunk frontiers stay valid). Packet-coupled stamps
+            // (SentHistory, PendingDirtyMask for shipped bits, initial-sync, per-peer
+            // dirty clears) apply in CommitExport.
+            return ExportCore(currentWorld, peer, buffer, maxBytes);
+        }
+
+        private ExportResult ExportCore(WorldRunner currentWorld, NetPeer peer, NetBuffer buffer, int maxBytes)
         {
             // Only export if spawn data has been sent AND not despawning/despawned
             // NotSpawned: SpawnSerializer hasn't written spawn data yet
@@ -1526,7 +1573,7 @@ namespace Nebula.Serialization.Serializers
                 spawnState == WorldRunner.ClientSpawnState.Despawning ||
                 spawnState == WorldRunner.ClientSpawnState.Despawned)
             {
-                return;
+                return ExportResult.None;
             }
 
             // For nested scenes, don't export until parent spawn is at least being sent
@@ -1535,7 +1582,7 @@ namespace Nebula.Serialization.Serializers
                 var parentSpawnState = currentWorld.GetClientSpawnState(network.NetParent.NetId, peer);
                 if (parentSpawnState == WorldRunner.ClientSpawnState.NotSpawned)
                 {
-                    return;
+                    return ExportResult.None;
                 }
             }
 
@@ -1543,6 +1590,7 @@ namespace Nebula.Serialization.Serializers
             int byteCount = _byteCount;
 
             Array.Clear(_propertiesUpdated, 0, byteCount);
+            Array.Clear(_leftoverMask, 0, byteCount);
 
             if (!peerInitialPropSync.TryGetValue(peerId, out var initialSync))
             {
@@ -1567,7 +1615,7 @@ namespace Nebula.Serialization.Serializers
             // Filter against interest layers first
             if (!TryGetInterestLayers(peerId, out var peerInterestLayers))
             {
-                return;
+                return ExportResult.None;
             }
 
             // Snapshot the per-peer dirty mask AFTER the interest early-return, and do NOT
@@ -1697,6 +1745,35 @@ namespace Nebula.Serialization.Serializers
             }
 
             // ============================================================
+            // DEFER (budget)
+            // ============================================================
+            // The section can't fit its fixed overhead (presence mask + age byte) plus
+            // even the smallest property write. Preserve the would-be-shipped primitive
+            // bits in PendingDirtyMask: processingDirtyMask dies at the end of this tick,
+            // and a budget-skipped peer would otherwise silently lose those changes
+            // forever. They ship absolute on a later tick and clear on its ack, exactly
+            // like a loss-recovery resend. Stateful sources merged into the mask above
+            // (initial sync, per-peer overrides, lossy settles, existing pending bits)
+            // re-derive next tick, so over-merging them here is harmless. Object props
+            // keep their own resumable per-peer state and need nothing.
+            if (maxBytes < byteCount + AGE_HEADER_BYTES + MIN_PROPERTY_WRITE_BYTES)
+            {
+                for (var i = 0; i < byteCount; i++)
+                {
+                    var b = _propertiesUpdated[i];
+                    if (b == 0) continue;
+                    for (var j = 0; j < 8; j++)
+                    {
+                        if ((b & (1 << j)) == 0) continue;
+                        var propIndex = i * 8 + j;
+                        if (propIndex >= _propertyCount || _propIsObject[propIndex]) continue;
+                        state.PendingDirtyMask[i] |= (byte)(1 << j);
+                    }
+                }
+                return ExportResult.None;
+            }
+
+            // ============================================================
             // BASELINE SELECTION (snapshot-delta)
             // ============================================================
             // Delta against the server's value snapshot at the peer's latest acked
@@ -1755,6 +1832,10 @@ namespace Nebula.Serialization.Serializers
                     if (_propIsObject[propIndex]) continue;
 
                     int propStartPos = buffer.WritePosition;
+                    // Snapshot the in-write stamps so a budget rewind can restore them -
+                    // a rewound property must leave no trace of the aborted encoding.
+                    var deltaChainBefore = state.DeltaChain[propIndex];
+                    var lossyByteBefore = state.LossyMask[i];
                     try
                     {
                         // Get current value - for per-peer properties, look up in per-peer storage
@@ -1817,6 +1898,19 @@ namespace Nebula.Serialization.Serializers
                             state.DeltaChain[propIndex] = 0;
                             state.LossyMask[i] &= (byte)~(1 << j);
                         }
+
+                        // Budget: the write pushed the section past maxBytes. Rewind it,
+                        // restore its stamps, and defer the bit - smaller later
+                        // properties may still fit (the mask is backfilled below, so the
+                        // wire stays consistent).
+                        if (buffer.WritePosition - maskStartPos > maxBytes)
+                        {
+                            buffer.WritePosition = propStartPos;
+                            state.DeltaChain[propIndex] = deltaChainBefore;
+                            state.LossyMask[i] = lossyByteBefore;
+                            actualMask[i] &= (byte)~(1 << j);
+                            _leftoverMask[i] |= (byte)(1 << j);
+                        }
                     }
                     catch (Exception ex)
                     {
@@ -1833,6 +1927,7 @@ namespace Nebula.Serialization.Serializers
 
             // Write OBJECT properties (INetSerializable) - always call, they self-filter
             // These return true if they wrote data, false if nothing to send
+            bool objectDeferred = false;
             for (int propIndex = 0; propIndex < _propertyCount; propIndex++)
             {
                 if (!_propIsObject[propIndex]) continue;
@@ -1845,6 +1940,17 @@ namespace Nebula.Serialization.Serializers
 
                 var serializer = Protocol.GetSerializer(classIndex);
                 if (serializer == null) continue;
+
+                // Budget: object serializers cannot be rewound (chunk streams stamp their
+                // per-peer frontier state during the write), so one is only invoked while
+                // the section still has room for its full chunk budget - the size the
+                // serializer is designed to respect. A skipped object keeps its own
+                // resumable per-peer state and simply resumes on a later tick.
+                if (maxBytes - (buffer.WritePosition - maskStartPos) < _propChunkBudget[propIndex])
+                {
+                    objectDeferred = true;
+                    continue;
+                }
 
                 // Per-peer array properties serialize this peer's forked instance; everything else
                 // (and any peer that has not diverged) serializes the shared base.
@@ -1892,21 +1998,69 @@ namespace Nebula.Serialization.Serializers
                 }
             }
 
+            // Budget leftovers are delivery-independent: a bit that didn't fit must
+            // survive whether or not this section ships, so it merges into the pending
+            // machinery here rather than in CommitExport. It re-sends absolute on a
+            // later tick and clears on that tick's ack.
+            bool hasLeftover = false;
+            for (var i = 0; i < byteCount; i++)
+            {
+                if (_leftoverMask[i] == 0) continue;
+                hasLeftover = true;
+                state.PendingDirtyMask[i] |= _leftoverMask[i];
+            }
+
             if (!hasAnyData)
             {
                 // Nothing to send - rewind buffer to before mask
                 buffer.WritePosition = maskStartPos;
+                return ExportResult.None;
+            }
+
+            // BACKFILL: Go back and write the actual mask
+            // We need to overwrite the placeholder bytes we wrote earlier
+            // NetWriter writes at WritePosition, so we save it, set to maskStartPos, write, then restore
+            int endPos = buffer.WritePosition;
+            buffer.WritePosition = maskStartPos;
+            for (var i = 0; i < byteCount; i++)
+            {
+                NetWriter.WriteByte(buffer, actualMask[i]);
+            }
+            buffer.WritePosition = endPos;
+
+            // Packet-coupled stamps (SentHistory, shipped-bit pending, initial sync,
+            // per-peer dirty clears) apply in CommitExport once the host commits these
+            // bytes to the packet.
+            return hasLeftover || objectDeferred ? ExportResult.Partial : ExportResult.Written;
+        }
+
+        /// <summary>
+        /// The section written by the immediately preceding Export was committed to the
+        /// tick packet: stamp everything that asserts "these bytes rode tick
+        /// <paramref name="tick"/>". PendingDirtyMask and SentHistory only track
+        /// PRIMITIVE properties - object properties (INetSerializable) manage their own
+        /// per-peer pending/resend state and are acked through their own tick-gated
+        /// callbacks. The host always commits a self-limited section, which is what keeps
+        /// the in-write stamps (DeltaChain, LossyMask, chunk frontiers) valid in Export.
+        /// </summary>
+        public void CommitExport(WorldRunner currentWorld, NetPeer peer, Tick tick)
+        {
+            var peerId = NetRunner.Instance.GetPeerId(peer);
+            ref var state = ref CollectionsMarshal.GetValueRefOrAddDefault(_peerStates, peerId, out bool exists);
+            if (!exists || !state.IsInitialized)
+            {
+                return;
+            }
+            if (!peerInitialPropSync.TryGetValue(peerId, out var initialSync))
+            {
                 return;
             }
 
-            // Update tracking state. PendingDirtyMask and SentHistory only track PRIMITIVE
-            // properties - object properties (INetSerializable) manage their own per-peer
-            // pending/resend state and are acked through their own tick-gated callbacks.
             long primitiveSentMask = 0;
             long perPeerSentMask = 0;
-            for (var byteIdx = 0; byteIdx < byteCount; byteIdx++)
+            for (var byteIdx = 0; byteIdx < _byteCount; byteIdx++)
             {
-                var b = actualMask[byteIdx];
+                var b = _actualMask[byteIdx];
                 if (b == 0) continue;
                 initialSync[byteIdx] |= b;
 
@@ -1938,22 +2092,9 @@ namespace Nebula.Serialization.Serializers
 
             // Record what was sent at this tick so a future ack can be matched to exactly
             // the values the peer received (the heart of tick-correlated acknowledgment)
-            ref var sentRecord = ref state.SentHistory[currentTick % SNAPSHOT_RING_SIZE];
-            sentRecord.Tick = currentTick;
+            ref var sentRecord = ref state.SentHistory[tick % SNAPSHOT_RING_SIZE];
+            sentRecord.Tick = tick;
             sentRecord.SentMask = primitiveSentMask;
-
-            // BACKFILL: Go back and write the actual mask
-            // We need to overwrite the placeholder bytes we wrote earlier
-            // NetWriter writes at WritePosition, so we save it, set to maskStartPos, write, then restore
-            int endPos = buffer.WritePosition;
-            buffer.WritePosition = maskStartPos;
-            for (var i = 0; i < byteCount; i++)
-            {
-                NetWriter.WriteByte(buffer, actualMask[i]);
-            }
-            buffer.WritePosition = endPos;
-
-            // Debugger.Instance.Log(Debugger.DebugLevel.VERBOSE, $"[Props.Export] NetId={network.NetId} mask=[{string.Join(",", actualMask.Select(b => $"0x{b:X2}"))}] total={endPos - maskStartPos}");
         }
 
         /// <summary>

--- a/addons/Nebula/Core/Serialization/Serializers/SpawnSerializer.cs
+++ b/addons/Nebula/Core/Serialization/Serializers/SpawnSerializer.cs
@@ -50,18 +50,42 @@ namespace Nebula.Serialization.Serializers
         private static List<NetworkController> AllLocalNestedScenes => _allLocalNestedScenes ??= new(64);
 
         private NetworkController netController;
-        private Dictionary<UUID, Tick> setupTicks = new();
-        private Dictionary<UUID, Tick> despawnTicks = new(); // Track when despawn was sent per peer
 
         /// <summary>
-        /// The most recent tick at which spawn data was written for each peer. Spawn data
-        /// re-ships every tick while Spawning (see Export), so together with the soft-interest
-        /// revert this keeps the invariant "spawn rode every exported tick in
-        /// [setupTick, lastSpawnSendTick]" - which is what makes the cumulative ack commit in
-        /// Acknowledge sound: an acked tick inside that range is a packet that provably
-        /// contained the spawn data.
+        /// Per-peer contiguous run of ticks whose packets carried this node's spawn record
+        /// (see SendWindow). Presence in the dictionary means "a spawn send is in flight
+        /// (unacked)"; Acknowledge commits Spawning -> Spawned only for an acked tick the
+        /// window Covers. Budget splitting can defer a resend on any tick - RecordSend's
+        /// gap-restart is what keeps the commit rule sound when that happens.
         /// </summary>
-        private Dictionary<UUID, Tick> lastSpawnSendTicks = new();
+        private Dictionary<UUID, SendWindow> spawnWindows = new();
+
+        /// <summary>Same contract as <see cref="spawnWindows"/>, for despawn markers.</summary>
+        private Dictionary<UUID, SendWindow> despawnWindows = new();
+
+        /// <summary>
+        /// What the bytes of the immediately preceding Export were, so CommitExport knows
+        /// which packet-coupled stamps to apply. Valid only between an Export and its
+        /// commit (host contract: CommitExport runs before any other Export on this
+        /// instance, on the same world tick thread).
+        /// </summary>
+        private enum PendingCommit : byte
+        {
+            None,
+            Spawn,
+            Despawn,
+        }
+
+        private PendingCommit _pendingCommit;
+        private bool _pendingFirstSend;
+
+        /// <summary>
+        /// Nested children whose table entries were written by the preceding Export
+        /// (registration succeeded). Their Spawning flips and window stamps apply in
+        /// CommitExport - stamping at write time would corrupt their ack windows when the
+        /// host drops this record for budget.
+        /// </summary>
+        private List<NetworkController> _pendingNestedCommit = new(64);
 
         private bool hasImported = false; // Track if this serializer has already imported
 
@@ -72,6 +96,15 @@ namespace Nebula.Serialization.Serializers
         /// Despawn marker byte - when first byte is 255, it's a despawn message.
         /// </summary>
         private const byte DESPAWN_MARKER = 255;
+
+        /// <summary>The nested-table count byte preceding the entries.</summary>
+        private const int NESTED_COUNT_BYTES = 1;
+
+        /// <summary>
+        /// One nested-table entry: sceneId (1) + nodePathId (1) + netId (2) +
+        /// hasInputAuthority (1). Must match ExportNestedScenes' writes.
+        /// </summary>
+        private const int NESTED_ENTRY_BYTES = 5;
 
         public SpawnSerializer(NetworkController controller)
         {
@@ -89,9 +122,8 @@ namespace Nebula.Serialization.Serializers
 
         public void CleanupPeer(UUID peerId)
         {
-            setupTicks.Remove(peerId);
-            despawnTicks.Remove(peerId);
-            lastSpawnSendTicks.Remove(peerId);
+            spawnWindows.Remove(peerId);
+            despawnWindows.Remove(peerId);
         }
 
         /// <summary>
@@ -143,9 +175,8 @@ namespace Nebula.Serialization.Serializers
                     if (child.NetNode?.Serializers != null && child.NetNode.Serializers.Length > 0
                         && child.NetNode.Serializers[0] is SpawnSerializer childSpawn)
                     {
-                        childSpawn.setupTicks.Remove(peerId);
-                        childSpawn.despawnTicks.Remove(peerId);
-                        childSpawn.lastSpawnSendTicks.Remove(peerId);
+                        childSpawn.spawnWindows.Remove(peerId);
+                        childSpawn.despawnWindows.Remove(peerId);
                     }
                 }
 
@@ -177,7 +208,92 @@ namespace Nebula.Serialization.Serializers
             }
         }
 
-        public void Export(WorldRunner currentWorld, NetPeer peer, NetBuffer buffer)
+        public ExportResult Export(WorldRunner currentWorld, NetPeer peer, NetBuffer buffer, int maxBytes)
+        {
+            // Atomic serializer: a spawn/despawn record cannot be split, so this may
+            // write more than maxBytes; the host then drops the bytes and skips
+            // CommitExport. Packet-coupled stamps live in CommitExport, so a dropped
+            // record retries cleanly next tick.
+            _pendingCommit = PendingCommit.None;
+            var start = buffer.WritePosition;
+            ExportCore(currentWorld, peer, buffer, maxBytes);
+            return buffer.WritePosition == start ? ExportResult.None : ExportResult.Written;
+        }
+
+        public void CommitExport(WorldRunner currentWorld, NetPeer peer, Tick tick)
+        {
+            var peerId = NetRunner.Instance.GetPeerId(peer);
+            switch (_pendingCommit)
+            {
+                case PendingCommit.Spawn:
+                {
+                    spawnWindows.TryGetValue(peerId, out var window);
+                    window.RecordSend(tick);
+                    spawnWindows[peerId] = window;
+
+                    if (_pendingFirstSend)
+                    {
+                        ResetPeerBaselines(netController, peerId);
+                        currentWorld.SetClientSpawnState(netController.NetId, peer, WorldRunner.ClientSpawnState.Spawning);
+                    }
+
+                    // Nested children rode this record's spawn table: flip them Spawning
+                    // and stamp their own windows so their acks track the parent's
+                    // resend stream. States cannot have changed since Export (same
+                    // thread, adjacent calls), so this evaluates as it would have at
+                    // write time. The baseline reset must cover EVERY state except
+                    // Spawning (= "already in this parent's resend stream"; resetting per
+                    // resend would wipe props delta state every tick) - notably stale
+                    // Spawned: a per-peer despawned parent takes its nested subtree down
+                    // client-side (QueueFree frees children) without a server-side
+                    // cascade, so the nested node still reads Spawned while the client is
+                    // about to rebuild it with an empty applied ring. Skipping the reset
+                    // then leaves a delta baseline the rebuilt node can never resolve
+                    // ("missing applied-state baseline" bursts on respawn).
+                    for (int i = 0; i < _pendingNestedCommit.Count; i++)
+                    {
+                        var nested = _pendingNestedCommit[i];
+                        if (currentWorld.GetClientSpawnState(nested.NetId, peer) != WorldRunner.ClientSpawnState.Spawning)
+                        {
+                            ResetPeerBaselines(nested, peerId);
+                        }
+                        currentWorld.SetClientSpawnState(nested.NetId, peer, WorldRunner.ClientSpawnState.Spawning);
+
+                        if (nested.NetNode?.Serializers != null && nested.NetNode.Serializers.Length > 0
+                            && nested.NetNode.Serializers[0] is SpawnSerializer nestedSpawnSerializer)
+                        {
+                            nestedSpawnSerializer.spawnWindows.TryGetValue(peerId, out var nestedWindow);
+                            nestedWindow.RecordSend(tick);
+                            nestedSpawnSerializer.spawnWindows[peerId] = nestedWindow;
+                        }
+                    }
+                    break;
+                }
+
+                case PendingCommit.Despawn:
+                {
+                    despawnWindows.TryGetValue(peerId, out var window);
+                    window.RecordSend(tick);
+                    despawnWindows[peerId] = window;
+
+                    if (_pendingFirstSend)
+                    {
+                        // The marker genuinely shipped: silence the nested subtree in the
+                        // same tick (see CascadeDespawnToNestedChildren). Must not run
+                        // when the record was dropped for budget - the client still has
+                        // a live copy and keeps receiving props until the marker ships.
+                        currentWorld.SetClientSpawnState(netController.NetId, peer, WorldRunner.ClientSpawnState.Despawning);
+                        CascadeDespawnToNestedChildren(currentWorld, peer, peerId, netController, freeIds: false);
+                    }
+                    break;
+                }
+            }
+            // _pendingCommit intentionally survives until the next Export (which resets
+            // it on entry): WorldRunner's props phase reads it through
+            // NestedSceneRodeLastSpawnExport after this commit.
+        }
+
+        private void ExportCore(WorldRunner currentWorld, NetPeer peer, NetBuffer buffer, int maxBytes)
         {
             var peerId = NetRunner.Instance.GetPeerId(peer);
             var spawnState = currentWorld.GetClientSpawnState(netController.NetId, peer);
@@ -217,10 +333,9 @@ namespace Nebula.Serialization.Serializers
                 // Revert to never-spawned: on interest regain the node runs a fresh spawn
                 // cycle - same local id (registration is idempotent), and a client that did
                 // receive one of the earlier sends consumes-and-skips the duplicate.
-                if (spawnState == WorldRunner.ClientSpawnState.Spawning && setupTicks.ContainsKey(peerId))
+                if (spawnState == WorldRunner.ClientSpawnState.Spawning && spawnWindows.ContainsKey(peerId))
                 {
-                    setupTicks.Remove(peerId);
-                    lastSpawnSendTicks.Remove(peerId);
+                    spawnWindows.Remove(peerId);
                     currentWorld.SetClientSpawnState(netController.NetId, peer, WorldRunner.ClientSpawnState.NotSpawned);
                 }
                 return;
@@ -307,13 +422,6 @@ namespace Nebula.Serialization.Serializers
                 }
             }
 
-            // Only set setupTick on FIRST export - don't overwrite on re-exports
-            // Otherwise the ACK can never catch up (setupTick keeps moving forward)
-            if (!setupTicks.ContainsKey(peerId))
-            {
-                setupTicks[peerId] = currentWorld.CurrentTick;
-            }
-
             NetWriter.WriteByte(buffer, sceneId);
 
             if (netController.NetParent == null)
@@ -321,17 +429,12 @@ namespace Nebula.Serialization.Serializers
                 NetWriter.WriteUInt16(buffer, 0);
 
                 // Write nested NetScenes for root scene
-                ExportNestedScenes(currentWorld, peer, buffer, firstSend);
+                ExportNestedScenes(currentWorld, peer, buffer, firstSend, maxBytes);
 
-                // Stamped every send (first and resends) - the upper bound of the ack window.
-                lastSpawnSendTicks[peerId] = currentWorld.CurrentTick;
-
-                // Mark spawn as being sent (waiting for ACK)
-                if (firstSend)
-                {
-                    ResetPeerBaselines(netController, peerId);
-                    currentWorld.SetClientSpawnState(netController.NetId, peer, WorldRunner.ClientSpawnState.Spawning);
-                }
+                // Window stamp, Spawning flip, and nested-child stamps apply in
+                // CommitExport - only if these bytes actually ride the packet.
+                _pendingCommit = PendingCommit.Spawn;
+                _pendingFirstSend = firstSend;
                 return;
             }
 
@@ -346,17 +449,12 @@ namespace Nebula.Serialization.Serializers
             NetWriter.WriteByte(buffer, hasInputAuth);
 
             // Write nested NetScenes
-            ExportNestedScenes(currentWorld, peer, buffer, firstSend);
+            ExportNestedScenes(currentWorld, peer, buffer, firstSend, maxBytes);
 
-            // Stamped every send (first and resends) - the upper bound of the ack window.
-            lastSpawnSendTicks[peerId] = currentWorld.CurrentTick;
-
-            // Mark spawn as being sent (waiting for ACK)
-            if (firstSend)
-            {
-                ResetPeerBaselines(netController, peerId);
-                currentWorld.SetClientSpawnState(netController.NetId, peer, WorldRunner.ClientSpawnState.Spawning);
-            }
+            // Window stamp, Spawning flip, and nested-child stamps apply in
+            // CommitExport - only if these bytes actually ride the packet.
+            _pendingCommit = PendingCommit.Spawn;
+            _pendingFirstSend = firstSend;
 
             currentWorld.Debug?.Send("Spawn", $"Exported:{netController.RawNode.SceneFilePath}");
         }
@@ -393,12 +491,14 @@ namespace Nebula.Serialization.Serializers
                         CascadeDespawnToNestedChildren(currentWorld, peer, peerId, netController, freeIds: false);
                         break;
                     }
-                    // Peer received (or is receiving) spawn, send despawn data. Silence the
-                    // nested subtree in the same tick the marker first ships - this is what
-                    // closes the orphan-props window (see CascadeDespawnToNestedChildren).
+                    // Peer received (or is receiving) spawn, send despawn data. The
+                    // Despawning flip and the nested-subtree silencing cascade apply in
+                    // CommitExport, in the same tick the marker actually first ships -
+                    // that timing is what closes the orphan-props window (see
+                    // CascadeDespawnToNestedChildren).
                     WriteDespawnData(currentWorld, peer, peerId, localNodeId, buffer);
-                    currentWorld.SetClientSpawnState(netController.NetId, peer, WorldRunner.ClientSpawnState.Despawning);
-                    CascadeDespawnToNestedChildren(currentWorld, peer, peerId, netController, freeIds: false);
+                    _pendingCommit = PendingCommit.Despawn;
+                    _pendingFirstSend = true;
                     break;
 
                 case WorldRunner.ClientSpawnState.Despawning:
@@ -410,6 +510,8 @@ namespace Nebula.Serialization.Serializers
                     }
                     // Already sent despawn, resend until ACKed
                     WriteDespawnData(currentWorld, peer, peerId, localNodeId, buffer);
+                    _pendingCommit = PendingCommit.Despawn;
+                    _pendingFirstSend = false;
                     break;
 
                 case WorldRunner.ClientSpawnState.Despawned:
@@ -424,12 +526,6 @@ namespace Nebula.Serialization.Serializers
         /// </summary>
         private void WriteDespawnData(WorldRunner currentWorld, NetPeer peer, UUID peerId, ushort localNodeId, NetBuffer buffer)
         {
-            // Only set despawnTick on FIRST export - don't overwrite on re-exports
-            if (!despawnTicks.ContainsKey(peerId))
-            {
-                despawnTicks[peerId] = currentWorld.CurrentTick;
-            }
-
             // Write despawn marker
             NetWriter.WriteByte(buffer, DESPAWN_MARKER);
 
@@ -441,8 +537,13 @@ namespace Nebula.Serialization.Serializers
 
         /// <summary>
         /// Exports all nested NetScenes in the subtree that the peer has interest in.
+        /// On a FIRST send the table is capped to what fits <paramref name="maxBytes"/>:
+        /// excluded children simply stay NotSpawned - they are never part of the frozen
+        /// membership, so resends stay consistent, and once this parent commits Spawned
+        /// they spawn through their own child-spawn Export. On a resend the frozen table
+        /// rides whole (the host drops the whole record if it no longer fits).
         /// </summary>
-        private void ExportNestedScenes(WorldRunner currentWorld, NetPeer peer, NetBuffer buffer, bool firstSend)
+        private void ExportNestedScenes(WorldRunner currentWorld, NetPeer peer, NetBuffer buffer, bool firstSend, int maxBytes)
         {
             var peerUUID = NetRunner.Instance.GetPeerId(peer);
 
@@ -461,21 +562,22 @@ namespace Nebula.Serialization.Serializers
                 }
 
                 // Table membership is FROZEN per peer while this spawn is in flight: on a
-                // resend, only children whose setupTick proves they rode an earlier send of
-                // this table may appear. A client that already imported this spawn consume-
-                // and-skips every resend (hasImported), so a child ADDED to the table
-                // mid-resend rides only payloads that client is guaranteed to discard - it
-                // can never learn the id, and the child's props exporter (switched on by the
-                // Spawning flip below) then feeds it props for an unknown node: tick-import
-                // abort, no acks, and the abort starves the very ack that would commit this
-                // parent and let the child spawn standalone. Deadlock until something else
-                // acks (or the peer times out). New children instead stay NotSpawned (props
-                // gated) and spawn via their own Export once this parent commits.
+                // resend, only children whose spawn window proves they rode an earlier
+                // committed send of this table may appear. A client that already imported
+                // this spawn consume-and-skips every resend (hasImported), so a child ADDED
+                // to the table mid-resend rides only payloads that client is guaranteed to
+                // discard - it can never learn the id, and the child's props exporter
+                // (switched on by the Spawning flip in CommitExport) then feeds it props
+                // for an unknown node: tick-import abort, no acks, and the abort starves
+                // the very ack that would commit this parent and let the child spawn
+                // standalone. Deadlock until something else acks (or the peer times out).
+                // New children instead stay NotSpawned (props gated) and spawn via their
+                // own Export once this parent commits.
                 if (!firstSend
                     && (nested.NetNode?.Serializers == null
                         || nested.NetNode.Serializers.Length == 0
                         || nested.NetNode.Serializers[0] is not SpawnSerializer memberCheck
-                        || !memberCheck.setupTicks.ContainsKey(peerUUID)))
+                        || !memberCheck.spawnWindows.ContainsKey(peerUUID)))
                 {
                     continue;
                 }
@@ -483,9 +585,23 @@ namespace Nebula.Serialization.Serializers
                 _interestedNestedBuffer.Add(nested);
             }
 
-            NetWriter.WriteByte(buffer, (byte)_interestedNestedBuffer.Count);
+            var includeCount = _interestedNestedBuffer.Count;
+            if (firstSend)
+            {
+                // Budget cap: entries that don't fit are left out of this first send
+                // entirely (never flipped Spawning, never in the frozen set).
+                var entryBudget = maxBytes - buffer.WritePosition - NESTED_COUNT_BYTES;
+                var maxEntries = entryBudget > 0 ? entryBudget / NESTED_ENTRY_BYTES : 0;
+                if (includeCount > maxEntries)
+                {
+                    includeCount = maxEntries;
+                }
+            }
 
-            for (int i = 0; i < _interestedNestedBuffer.Count; i++)
+            NetWriter.WriteByte(buffer, (byte)includeCount);
+
+            _pendingNestedCommit.Clear();
+            for (int i = 0; i < includeCount; i++)
             {
                 var nested = _interestedNestedBuffer[i];
 
@@ -501,38 +617,11 @@ namespace Nebula.Serialization.Serializers
                     continue;
                 }
 
-                // Nested scenes ride along in the parent's spawn data, so the client is about
-                // to build them from scratch - their per-peer baselines must reset like the
-                // parent's own NotSpawned -> Spawning transition. This must cover EVERY state
-                // except Spawning (which means "already in this parent's resend stream" -
-                // resetting per resend would wipe props delta state every tick). Notably it
-                // must cover stale Spawned: a parent that was per-peer despawned takes its
-                // nested subtree down with it CLIENT-side (QueueFree frees children), but
-                // despawn does not cascade server-side, so the nested node still reads
-                // Spawned here while the client is about to rebuild it with an empty applied
-                // ring. Skipping the reset then leaves a delta baseline the rebuilt node can
-                // never resolve ("missing applied-state baseline" bursts on respawn).
-                if (currentWorld.GetClientSpawnState(nested.NetId, peer) != WorldRunner.ClientSpawnState.Spawning)
-                {
-                    ResetPeerBaselines(nested, peerUUID);
-                }
-
-                // IMPORTANT: Set the nested scene's state to Spawning since we're including it in the parent's spawn data.
-                // Without this, despawn logic would see NotSpawned and skip sending despawn data.
-                currentWorld.SetClientSpawnState(nested.NetId, peer, WorldRunner.ClientSpawnState.Spawning);
-
-                // Also set up the nested scene's SpawnSerializer setupTick for ACK tracking
-                if (nested.NetNode?.Serializers != null && nested.NetNode.Serializers.Length > 0
-                    && nested.NetNode.Serializers[0] is SpawnSerializer nestedSpawnSerializer)
-                {
-                    if (!nestedSpawnSerializer.setupTicks.ContainsKey(peerUUID))
-                    {
-                        nestedSpawnSerializer.setupTicks[peerUUID] = currentWorld.CurrentTick;
-                    }
-                    // Every inclusion (the nested payload rides every parent resend), so the
-                    // nested node's own ack window tracks the parent's resend stream.
-                    nestedSpawnSerializer.lastSpawnSendTicks[peerUUID] = currentWorld.CurrentTick;
-                }
+                // Nested scenes ride along in the parent's spawn data, so the client is
+                // about to build them from scratch. Their baseline resets, Spawning flips,
+                // and window stamps happen in the parent's CommitExport - only when the
+                // table provably rides the packet (see CommitExport for the reset rule).
+                _pendingNestedCommit.Add(nested);
 
                 var nestedSceneId = Protocol.PackScene(nested.NetSceneFilePath);
                 if (nestedSceneId > 245)
@@ -553,6 +642,15 @@ namespace Nebula.Serialization.Serializers
 
         // Reusable buffer for interested nested scenes to avoid allocation
         private List<NetworkController> _interestedNestedBuffer = new(64);
+
+        /// <summary>
+        /// Whether the given nested scene rode the spawn table written by this
+        /// serializer's most recent Export. Only meaningful between that Export and the
+        /// next one on this instance - WorldRunner's props phase queries it right after
+        /// its spawn phase for the same peer, inside that window.
+        /// </summary>
+        internal bool NestedSceneRodeLastSpawnExport(NetworkController nested)
+            => _pendingCommit == PendingCommit.Spawn && _pendingNestedCommit.Contains(nested);
 
         /// <summary>
         /// Recursively collects all nested NetScenes in the subtree, pruning any scene (and
@@ -583,15 +681,18 @@ namespace Nebula.Serialization.Serializers
 
             // Handle despawn acknowledgment FIRST (takes priority over spawn)
             // If despawn is in progress, we don't want spawn ACK to overwrite the state
-            if (despawnTicks.TryGetValue(peerId, out var despawnTick) && despawnTick != 0)
+            if (despawnWindows.TryGetValue(peerId, out var despawnWindow))
             {
-                if (tick >= despawnTick)
+                // Commit only when the acked tick's packet provably carried the marker.
+                // (The old rule was an unbounded `tick >= despawnTick`, which was only
+                // sound while resends could never skip a tick; budget deferral broke
+                // that assumption, and SendWindow's gap-restart restores it.)
+                if (despawnWindow.Covers(tick))
                 {
                     // Despawn acknowledged
                     currentWorld.SetClientSpawnState(netController.NetId, peer, WorldRunner.ClientSpawnState.Despawned);
-                    despawnTicks.Remove(peerId); // Clean up after successful ack
-                    setupTicks.Remove(peerId); // Also clean up spawn tracking since despawn supersedes it
-                    lastSpawnSendTicks.Remove(peerId);
+                    despawnWindows.Remove(peerId); // Clean up after successful ack
+                    spawnWindows.Remove(peerId); // Also clean up spawn tracking since despawn supersedes it
 
                     // Free the local NetId for this peer so it can be reused
                     currentWorld.DeregisterPeerNode(netController, peer);
@@ -613,34 +714,31 @@ namespace Nebula.Serialization.Serializers
                         currentWorld._pendingDeletion.Add(netController);
                     }
                 }
-                // If despawn is pending (tick < despawnTick), don't process spawn ACK
+                // If the despawn is still unacked, don't process spawn ACK
                 // The node is being despawned, so transitioning to Spawned would be wrong
-                return despawnTicks.ContainsKey(peerId) || setupTicks.ContainsKey(peerId);
+                return despawnWindows.ContainsKey(peerId) || spawnWindows.ContainsKey(peerId);
             }
 
             // Handle spawn acknowledgment (only if no despawn is pending).
             //
-            // Commit only when the acked tick falls inside [setupTick, lastSpawnSendTick]:
-            // spawn data rides every exported tick in that window (Export resends while
-            // Spawning; the soft-interest revert keeps the window contiguous), so an ack
-            // inside it is a packet that provably contained the spawn data. A bare
-            // `tick >= setupTick` would also commit on acks of ticks that carried only this
-            // node's props - which is exactly how a lost spawn packet used to get marked
-            // Spawned while the client sat on a blank node.
-            if (setupTicks.TryGetValue(peerId, out var setupTick) && setupTick != 0)
+            // Commit only when the acked tick is inside the spawn's send window: every
+            // tick in that window carried the spawn data (CommitExport records only
+            // committed sends, and any budget-deferred tick restarts the window), so an
+            // ack inside it is a packet that provably contained the spawn data. A bare
+            // `tick >= firstSend` would also commit on acks of ticks that carried only
+            // this node's props - which is exactly how a lost spawn packet used to get
+            // marked Spawned while the client sat on a blank node.
+            if (spawnWindows.TryGetValue(peerId, out var spawnWindow))
             {
-                if (tick >= setupTick
-                    && lastSpawnSendTicks.TryGetValue(peerId, out var lastSent)
-                    && tick <= lastSent)
+                if (spawnWindow.Covers(tick))
                 {
                     currentWorld.SetSpawnedForClient(netController.NetId, peer);
-                    setupTicks.Remove(peerId); // Clean up after successful ack
-                    lastSpawnSendTicks.Remove(peerId);
+                    spawnWindows.Remove(peerId); // Clean up after successful ack
                 }
             }
 
             // Still pending while an unacked spawn or despawn send exists for this peer
-            return setupTicks.ContainsKey(peerId) || despawnTicks.ContainsKey(peerId);
+            return spawnWindows.ContainsKey(peerId) || despawnWindows.ContainsKey(peerId);
         }
 
         // Import is client-only and infrequent, less critical to optimize

--- a/addons/Nebula/Core/Serialization/TickBudgetLedger.cs
+++ b/addons/Nebula/Core/Serialization/TickBudgetLedger.cs
@@ -1,0 +1,63 @@
+namespace Nebula.Serialization
+{
+    /// <summary>
+    /// Byte-budget ledger for one peer's tick payload. Charges every cost that ends up in
+    /// the assembled payload so the final buffer can never exceed the budget:
+    /// the 1-byte group mask upfront, then per committed section its payload bytes plus
+    /// the framing a node pays the first time it enters the packet — 1 byte for its
+    /// serializersRun mask, and 8 bytes for the group's node mask when the node is the
+    /// first in its 64-node group. Pure struct, allocation-free, unit-testable.
+    /// </summary>
+    internal struct TickBudgetLedger
+    {
+        /// <summary>
+        /// Worst-case framing around a single section in an otherwise empty packet:
+        /// the group-mask byte, the node's serializersRun byte, and the int64 node mask
+        /// of a newly opened group. A section larger than budget minus this can never
+        /// ship, no matter how empty the packet.
+        /// </summary>
+        public const int MaxSectionOverheadBytes = 1 + 1 + 8;
+
+        private readonly int _budget;
+        private int _used;
+
+        /// <param name="budget">Total payload budget (see NetRunner.TickPayloadBudget).</param>
+        public TickBudgetLedger(int budget)
+        {
+            _budget = budget;
+            _used = 1; // group mask byte, always present
+        }
+
+        public readonly int Budget => _budget;
+        public readonly int Used => _used;
+        public readonly int Remaining => _budget - _used;
+
+        private static int FramingCost(bool firstSectionForNode, bool opensNewGroup)
+            => (firstSectionForNode ? 1 : 0) + (opensNewGroup ? 8 : 0);
+
+        /// <summary>
+        /// Max section payload bytes that can still be committed for a node with the given
+        /// framing situation. Never negative.
+        /// </summary>
+        public readonly int SectionBudget(bool firstSectionForNode, bool opensNewGroup)
+        {
+            var available = Remaining - FramingCost(firstSectionForNode, opensNewGroup);
+            return available > 0 ? available : 0;
+        }
+
+        /// <summary>
+        /// Charges a section (payload + framing) if it fits. Returns false without
+        /// charging when it doesn't.
+        /// </summary>
+        public bool TryCommitSection(int sectionBytes, bool firstSectionForNode, bool opensNewGroup)
+        {
+            var cost = sectionBytes + FramingCost(firstSectionForNode, opensNewGroup);
+            if (cost > Remaining)
+            {
+                return false;
+            }
+            _used += cost;
+            return true;
+        }
+    }
+}

--- a/addons/Nebula/Core/Serialization/TickBudgetLedger.cs.uid
+++ b/addons/Nebula/Core/Serialization/TickBudgetLedger.cs.uid
@@ -1,0 +1,1 @@
+uid://fb74auwc3hev

--- a/addons/Nebula/Core/WorldRunner.cs
+++ b/addons/Nebula/Core/WorldRunner.cs
@@ -7,6 +7,7 @@ using Godot;
 using MongoDB.Bson;
 using Nebula.Internal.Editor.DTO;
 using Nebula.Serialization;
+using Nebula.Serialization.Serializers;
 using Nebula.Utility.Tools;
 
 namespace Nebula
@@ -23,11 +24,6 @@ namespace Nebula
     */
     public partial class WorldRunner : Node
     {
-        /// <summary>
-        /// Maximum time in seconds a peer can go without acknowledging a tick before being force disconnected.
-        /// </summary>
-        public const float PEER_ACK_TIMEOUT_SECONDS = 5.0f;
-
         /// <summary>
         /// Client identifier for debugging. Set via --clientId=X command line argument.
         /// </summary>
@@ -70,6 +66,16 @@ namespace Nebula
         {
             public NetPeer Peer;
             public Tick Tick;
+
+            /// <summary>
+            /// World tick at which this peer joined (JoinPeer). The ack-timeout sweep
+            /// applies the lenient join window for the first JoinAckTimeoutSeconds after
+            /// this tick: a client's heaviest silent stretch (world-scene load, spatial
+            /// mirror build) happens AFTER its first few acks, so neither Status nor
+            /// "has acked once" marks the end of joining - only elapsed time can.
+            /// </summary>
+            public Tick JoinedAtTick;
+
             public PeerSyncStatus Status;
             public UUID Id;
             public string Token;
@@ -205,6 +211,9 @@ namespace Nebula
             DEBUG_EVENT = 6,
             WORLD_ANNOUNCE = 7,
             WORLD_REMOVED = 8,
+
+            /// <summary>One ServerMetrics JSON line, ~1/s per world, for the editor's Performance tab.</summary>
+            METRICS = 9,
         }
 
         /// <summary>
@@ -230,7 +239,7 @@ namespace Nebula
             public void Send(string category, string message)
             {
                 var hub = Hub;
-                if (hub == null) return;
+                if (hub is not { DebugFramesEnabled: true }) return;
 
                 // Sized explicitly: NetBuffer throws on overflow rather than
                 // growing, and its 1536-byte default is not guaranteed to fit
@@ -258,7 +267,10 @@ namespace Nebula
         private List<TickLog> tickLogBuffer = [];
         public void Log(string message, Debugger.DebugLevel level = Debugger.DebugLevel.INFO)
         {
-            if (NetRunner.Instance.IsServer)
+            // Buffer for the debug channel only while something is there to read it:
+            // ServerProcessTick drains this under `debugAttached` and clears it either
+            // way, so with no debugger attached every entry was allocated and dropped.
+            if (NetRunner.Instance.IsServer && Hub is { HasClients: true, DebugFramesEnabled: true })
             {
                 tickLogBuffer.Add(new TickLog
                 {
@@ -285,7 +297,7 @@ namespace Nebula
             Debug = new DebugMessenger(this);
 
             // Parse command line args (--debugPort is handled once, process-wide,
-            // in NetRunner.StartDebugHub)
+            // in NetRunner.StartTelemetryHub)
             foreach (var argument in OS.GetCmdlineArgs())
             {
                 if (argument.StartsWith("--clientId=") && !_clientIdParsed)
@@ -1126,6 +1138,12 @@ namespace Nebula
         private Diagnostics.ServerMetrics _metrics;
 
         /// <summary>
+        /// Per-phase tick timing. Null unless <see cref="Diagnostics.TickProfiler.EnableEnvVar"/>
+        /// is set, so every <c>_profiler?.Record(...)</c> below costs a null check when off.
+        /// </summary>
+        private Diagnostics.TickProfiler _profiler;
+
+        /// <summary>
         /// Peer count and round-trip spread, for the metrics line. Only called on the tick that
         /// actually emits, so the scan is once per interval rather than once per tick.
         /// </summary>
@@ -1292,6 +1310,7 @@ namespace Nebula
             _peerPackWindows.Remove(peerId);
             _peerPendingAcks.Remove(peerId); // Fix #5: Clean up pending acks tracking
             _peerNetBufferPool.Remove(peerId); // Clean up pooled export buffer
+            _peerPropsCursors.Remove(peerId); // Round-robin cursor for the props phase
             _peerListDirty = true; // Fix #1: Mark peer list as dirty
 
             // Everything above is this world's own state, so it belongs on whichever thread is
@@ -1325,12 +1344,21 @@ namespace Nebula
         /// </summary>
         public void ServerProcessTick()
         {
+            // Bind the profiler to this tick's thread so library code reached from here (NebulaPack)
+            // can report into it without threading a parameter through every signature.
+            _profiler?.MakeCurrent();
+
             // Process buffered player joins FIRST (tick-aligned)
             // This ensures OnPlayerJoined fires at a safe, predictable point before any Export iteration
+            var phaseTs = Diagnostics.TickProfiler.Now();
             ProcessPendingPlayerJoins();
+            _profiler?.Record(Diagnostics.TickProfiler.Phase.Joins, phaseTs);
+
+            phaseTs = Diagnostics.TickProfiler.Now();
 
             // Check for peers that have timed out (no acks for too long)
-            int ackTimeoutTicks = (int)(PEER_ACK_TIMEOUT_SECONDS * NetRunner.TPS);
+            int ackTimeoutTicks = (int)(NetRunner.AckTimeoutSeconds * NetRunner.TPS);
+            int joinAckTimeoutTicks = (int)(NetRunner.JoinAckTimeoutSeconds * NetRunner.TPS);
             _peersToDisconnect.Clear();
 
             foreach (var peerId in PeerStates.Keys)
@@ -1346,10 +1374,19 @@ namespace Nebula
                     continue;
                 }
 
+                // The lenient window applies for the first JoinAckTimeoutSeconds after the
+                // peer JOINED, not merely while it has never acked: a client acks a few
+                // small early ticks before the world-scene change arrives, and only then
+                // goes silent for seconds in scene load + spatial mirror build. Status
+                // (INITIAL flips to IN_WORLD on the first ack) therefore cannot mark the
+                // end of joining - only elapsed time since join can.
+                bool inJoinWindow = CurrentTick - peerState.JoinedAtTick <= joinAckTimeoutTicks;
+                int timeoutTicks = inJoinWindow ? joinAckTimeoutTicks : ackTimeoutTicks;
+
                 var ticksSinceLastAck = CurrentTick - _peerLastAckTick[peerId];
-                if (ticksSinceLastAck > ackTimeoutTicks)
+                if (ticksSinceLastAck > timeoutTicks)
                 {
-                    Log(Debugger.DebugLevel.WARN, $"[ACK TIMEOUT] Peer {peerId} has not acknowledged for {ticksSinceLastAck} ticks ({ticksSinceLastAck / (float)NetRunner.TPS:F1}s). Force disconnecting.");
+                    Log(Debugger.DebugLevel.WARN, $"[ACK TIMEOUT] Peer {peerId} ({(inJoinWindow ? "joining" : "in world")}) has not acknowledged for {ticksSinceLastAck} ticks ({ticksSinceLastAck / (float)NetRunner.TPS:F1}s, limit {timeoutTicks / (float)NetRunner.TPS:F1}s). Force disconnecting.");
                     _metrics?.RecordAckTimeout();
                     _peersToDisconnect.Add(peerState.Peer);
                 }
@@ -1359,7 +1396,9 @@ namespace Nebula
             {
                 CleanupPlayer(peer);
             }
+            _profiler?.Record(Diagnostics.TickProfiler.Phase.AckSweep, phaseTs);
 
+            phaseTs = Diagnostics.TickProfiler.Now();
             _netIdsToRemove.Clear();
             _isProcessingNetScenes = true;
             foreach (var net_id in NetScenes.Keys)
@@ -1424,6 +1463,9 @@ namespace Nebula
                 }
 
                 // Phase 2: Simulate (root first, then children — must match client prediction/resim order)
+                // Timed separately from the scan around it: this is game code, and telling it apart
+                // from Nebula's own per-node bookkeeping is the whole point of the breakdown.
+                var gameplayTs = Diagnostics.TickProfiler.Now();
                 netController._NetworkProcess(CurrentTick);
                 foreach (var networkChild in netController.StaticNetworkChildren)
                 {
@@ -1432,12 +1474,16 @@ namespace Nebula
                     if (networkChild.RawNode.ProcessMode == ProcessModeEnum.Disabled) continue;
                     networkChild._NetworkProcess(CurrentTick);
                 }
+                _profiler?.Record(Diagnostics.TickProfiler.Phase.Gameplay, gameplayTs);
             }
             _isProcessingNetScenes = false;
             FlushPendingNetSceneChanges();
+            _profiler?.Record(Diagnostics.TickProfiler.Phase.SceneScan, phaseTs);
 
             var debugHub = Hub;
-            bool debugAttached = debugHub is { HasClients: true };
+            // DebugFramesEnabled distinguishes a metrics-only channel: the socket is up
+            // (metrics still flow) but none of this per-tick debug work should run.
+            bool debugAttached = debugHub is { HasClients: true, DebugFramesEnabled: true };
 
             if (debugAttached)
             {
@@ -1452,6 +1498,7 @@ namespace Nebula
                 EmitDebugPeers(debugHub);
             }
 
+            phaseTs = Diagnostics.TickProfiler.Now();
             foreach (var queuedFunction in queuedNetFunctions)
             {
                 var functionNode = queuedFunction.Node.GetNode(queuedFunction.FunctionInfo.NodePath) as INetNodeBase;
@@ -1499,6 +1546,7 @@ namespace Nebula
                 }
             }
             tickLogBuffer.Clear();
+            _profiler?.Record(Diagnostics.TickProfiler.Phase.NetFunctions, phaseTs);
 
             // If nobody is connected, skip ExportState entirely to avoid per-tick allocations.
             // Under SustainedLowLatency GC, these allocations can look like a leak in snapshots.
@@ -1514,7 +1562,11 @@ namespace Nebula
                     }
                     _peerListDirty = false;
                 }
+                phaseTs = Diagnostics.TickProfiler.Now();
                 var exportedState = ExportState(_cachedPeerList);
+                _profiler?.Record(Diagnostics.TickProfiler.Phase.Export, phaseTs);
+
+                phaseTs = Diagnostics.TickProfiler.Now();
                 try
                 {
                     foreach (var peer in _cachedPeerList)
@@ -1533,11 +1585,13 @@ namespace Nebula
                         var packPayload = peerStateBuffer.WrittenSpan;
 
                         using var buffer = new NetBuffer();
+                        var packTs = Diagnostics.TickProfiler.Now();
                         NetWriter.WriteInt32(buffer, CurrentTick);
                         _peerPackWindows.TryGetValue(peerId, out var packWindow);
                         NebulaPack.WritePacket(
                             buffer, packPayload, packWindow, CurrentTick,
                             NetRunner.PackEnabled, NetRunner.PackValidate);
+                        _profiler?.Record(Diagnostics.TickProfiler.Phase.PackCompress, packTs);
 
                         // Check the UNCOMPRESSED size against the MTU. Checking the compressed size
                         // would let compression mask a genuinely oversized world, and the payload
@@ -1550,10 +1604,14 @@ namespace Nebula
                         }
 
                         _metrics?.RecordPacket(buffer.Length);
+                        packTs = Diagnostics.TickProfiler.Now();
                         NetRunner.SendUnreliableSequenced(peer, (byte)NetRunner.ENetChannelId.Tick, buffer);
+                        _profiler?.Record(Diagnostics.TickProfiler.Phase.PackTransmit, packTs);
 
                         // Remember what we sent; it becomes a delta baseline once this peer acks it.
+                        packTs = Diagnostics.TickProfiler.Now();
                         RecordPackPayload(peerId, peerStateBuffer.WrittenSpan);
+                        _profiler?.Record(Diagnostics.TickProfiler.Phase.PackBaseline, packTs);
 
                         if (debugAttached)
                         {
@@ -1578,7 +1636,10 @@ namespace Nebula
                     // ExportState() now returns truly pooled NetBuffer instances that are reused between ticks.
                     // Do NOT dispose them - they will be Reset() and reused on the next tick.
                 }
+                _profiler?.Record(Diagnostics.TickProfiler.Phase.PackSend, phaseTs);
             }
+
+            phaseTs = Diagnostics.TickProfiler.Now();
 
             // Note: Despawns are now handled by SpawnSerializer through the tick channel.
             // QueueDespawnedNodes tells SpawnSerializer.Export to send despawn data.
@@ -1616,6 +1677,7 @@ namespace Nebula
                 netController.QueueNodeForDeletion();
             }
             _pendingDeletion.Clear();
+            _profiler?.Record(Diagnostics.TickProfiler.Phase.Despawn, phaseTs);
         }
 
         /// <summary>
@@ -1965,7 +2027,9 @@ namespace Nebula
                 // The ENet pump used to apply acks and inputs inline as it read them, so they landed
                 // on the frame they arrived; draining only on tick frames would add up to
                 // PhysicsTicksPerNetworkTick-1 frames of latency to every one of them.
+                var inboundTs = Diagnostics.TickProfiler.Now();
                 DrainInboundPackets();
+                _profiler?.Record(Diagnostics.TickProfiler.Phase.Inbound, inboundTs);
 
                 _frameCounter += 1;
                 if (_frameCounter < NetRunner.PhysicsTicksPerNetworkTick)
@@ -1976,6 +2040,10 @@ namespace Nebula
                 // Simple benchmark: measure ServerProcessTick execution time
                 // var stopwatch = System.Diagnostics.Stopwatch.StartNew();
 #endif
+                // Created before the tick, not after: ServerProcessTick binds it to this thread so
+                // NebulaPack can report into it, which the first tick would otherwise miss.
+                if (Diagnostics.TickProfiler.Enabled) _profiler ??= new Diagnostics.TickProfiler();
+
                 // Avoid allocating a Stopwatch object every tick.
                 long startTs = System.Diagnostics.Stopwatch.GetTimestamp();
                 ServerProcessTick();
@@ -1985,6 +2053,18 @@ namespace Nebula
                     Log(Debugger.DebugLevel.WARN, $"ServerProcessTick took {elapsedMs:F2} ms");
                 }
 
+                if (_profiler != null)
+                {
+                    // elapsedMs is the whole tick, so phase shares are against what actually
+                    // happened rather than against the sum of the phases -- the gap between the
+                    // two is tick time no phase claims, which is exactly what you want to see.
+                    _profiler.EndTick(elapsedMs);
+                    if (_profiler.IsDue(out double phaseWindow))
+                    {
+                        _profiler.Emit(WorldId, CurrentTick, PeerStates.Count, phaseWindow);
+                    }
+                }
+
                 if (Diagnostics.ServerMetrics.Enabled)
                 {
                     _metrics ??= new Diagnostics.ServerMetrics();
@@ -1992,7 +2072,25 @@ namespace Nebula
                     if (_metrics.IsDue(out double metricsWindow))
                     {
                         CollectPeerRtt(out int metricsPeers, out double rttMean, out uint rttMax);
-                        _metrics.Emit(WorldId, CurrentTick, metricsPeers, rttMean, rttMax, metricsWindow);
+                        var metricsJson = _metrics.Emit(WorldId, CurrentTick, metricsPeers, rttMean, rttMax, metricsWindow);
+
+                        // Also ship it to any attached debugger for the Performance tab.
+                        // ~400 bytes once a second - negligible next to the tick frames.
+                        // Priority + reliable: the main queue carries hundreds of frames
+                        // per second on a loaded world (one PAYLOADS frame per peer per
+                        // tick), and past its hard backstop it drops from the front,
+                        // where accumulated reliable frames sit. A once-a-second frame in
+                        // that queue is starved exactly when the numbers matter most -
+                        // measured with 22 bots, where the server logged metrics but the
+                        // editor's Performance tab received none.
+                        var metricsHub = Hub;
+                        if (metricsHub is { HasClients: true })
+                        {
+                            using var metricsBuffer = new NetBuffer(metricsJson.Length * 4 + 16, usePool: true);
+                            NetWriter.WriteString(metricsBuffer, metricsJson);
+                            metricsHub.Enqueue(WorldId, DebugDataType.METRICS, metricsBuffer,
+                                lossy: false, priority: true);
+                        }
                     }
                 }
 #if DEBUG
@@ -2629,6 +2727,7 @@ namespace Nebula
                 Id = peerId,
                 Peer = peer,
                 Tick = 0,
+                JoinedAtTick = CurrentTick,
                 Status = PeerSyncStatus.INITIAL,
                 Token = token,
                 WorldToPeerNodeMap = [],
@@ -2659,10 +2758,67 @@ namespace Nebula
             PeerStates.Remove(peerId);
         }
 
+        /// <summary>
+        /// Test seam: registers a minimal PeerState (the JoinPeer shape, minus the ENet
+        /// connection and root-scene hooks) so serializer Export/Acknowledge paths can run
+        /// against this world in unit tests. The caller is responsible for mapping the
+        /// peer in NetRunner.Instance.PeerIds and removing it again.
+        /// </summary>
+        internal void CreatePeerStateForTests(NetPeer peer, UUID peerId)
+        {
+            PeerStates[peerId] = new PeerState
+            {
+                Id = peerId,
+                Peer = peer,
+                Tick = 0,
+                JoinedAtTick = CurrentTick,
+                Status = PeerSyncStatus.INITIAL,
+                WorldToPeerNodeMap = [],
+                PeerToWorldNodeMap = [],
+                SpawnState = [],
+                AvailableNodes = NodeIdUtils.CreateMasks(),
+                OwnedNodes = []
+            };
+        }
+
         // Declare these as fields, not locals - reuse across ticks
         private Dictionary<ushort, NetBuffer> _peerNodesBuffers = new();
         private Dictionary<ushort, byte> _peerNodesSerializersList = new();
-        private NetBuffer _serializersBuffer;
+
+        /// <summary>
+        /// Per-peer round-robin cursor for the props phase of ExportState: the NetId of
+        /// the next node owed property service. Without it, whichever nodes iterate first
+        /// would monopolize every budget-limited packet and later nodes would starve.
+        /// </summary>
+        private Dictionary<UUID, long> _peerPropsCursors = new();
+
+        /// <summary>Snapshot of NetScenes.Values, stable across the phases of one export.</summary>
+        private readonly List<NetworkController> _tickNodeList = new(64);
+
+        /// <summary>
+        /// Serializer indices fixed by NetNode.SetupSerializers; the export phases run in
+        /// this order, which is also the per-node section order the client consumes.
+        /// </summary>
+        private const int SpawnSerializerIndex = 0;
+        private const int PropsSerializerIndex = 1;
+        private const int InterestResyncSerializerIndex = 2;
+
+        /// <summary>
+        /// Props phase stops serving (and defers the rest of the rotation) once the
+        /// remaining section budget drops below this. Ceiling of the smallest useful
+        /// props section: presence mask (max 64 props = 8 bytes) + age byte + smallest
+        /// property write (2 bytes), rounded up for slack.
+        /// </summary>
+        private const int PropsSectionFloor = 16;
+
+        /// <summary>
+        /// Backstop for a misconfigured MTU so small the budget math goes non-positive;
+        /// splitting still works, packets just exceed such an MTU.
+        /// </summary>
+        private const int MinTickPayloadBudget = 128;
+
+        /// <summary>One-shot guard for the "spawn record can never fit" diagnostic.</summary>
+        private bool _loggedUnfittableSpawnRecord;
         private NetBuffer _tempSerializerBuffer;
         private Dictionary<ushort, NetBuffer> _nodeBufferPool = new();
         // Hierarchical bitmask for tracking updated nodes per peer
@@ -2683,16 +2839,25 @@ namespace Nebula
             _exportPeerBuffers.Clear();
 
             // Lazy init the serializers buffers
-            _serializersBuffer ??= new NetBuffer();
             _tempSerializerBuffer ??= new NetBuffer();
 
+            // Stable node snapshot for this tick (world order: parents precede children)
+            // plus the once-per-tick Begin pass.
+            _tickNodeList.Clear();
             foreach (var netController in NetScenes.Values)
             {
-                // Initialize serializers
+                _tickNodeList.Add(netController);
                 foreach (var serializer in netController.NetNode.Serializers)
                 {
                     serializer.Begin();
                 }
+            }
+
+            // MTU reads ProjectSettings - fetch once per tick, not per node.
+            var payloadBudget = NetRunner.TickPayloadBudget(NetRunner.MTU);
+            if (payloadBudget < MinTickPayloadBudget)
+            {
+                payloadBudget = MinTickPayloadBudget;
             }
 
             foreach (NetPeer peer in peers)
@@ -2721,85 +2886,203 @@ namespace Nebula
                     _peerPendingAcks[peerId] = pendingAcks;
                 }
 
-                foreach (var netController in NetScenes.Values)
+                var ledger = new TickBudgetLedger(payloadBudget);
+                var peerState = PeerStates[peerId];
+                int spawnSectionsDeferred = 0;
+                int propsSectionsDeferred = 0;
+
+                var exportPhaseTs = Diagnostics.TickProfiler.Now();
+
+                // ---- PHASE 1: spawns/despawns, world order, first-fit --------------
+                // No cap and no cursor: the spawn set drains (each committed record
+                // leaves it within one RTT of shipping), records are small, and world
+                // order maximizes parent-before-child delivery for the child-spawn
+                // parent gate. A record that doesn't fit is dropped whole - the spawn
+                // serializer is atomic, and its packet-coupled stamps only happen in
+                // CommitExport, so a dropped record retries cleanly next tick.
+                for (var i = 0; i < _tickNodeList.Count; i++)
                 {
-                    _serializersBuffer.Reset(); // Reuse instead of new
-                    byte serializersRun = 0;
+                    var netController = _tickNodeList[i];
+                    var serializers = netController.NetNode.Serializers;
+                    if (serializers.Length <= SpawnSerializerIndex) continue;
+                    var serializer = serializers[SpawnSerializerIndex];
 
-                    for (var serializerIdx = 0; serializerIdx < netController.NetNode.Serializers.Length; serializerIdx++)
-                    {
-                        var serializer = netController.NetNode.Serializers[serializerIdx];
-                        _tempSerializerBuffer.Reset();
-                        int beforePos = _tempSerializerBuffer.WritePosition;
-                        serializer.Export(this, peer, _tempSerializerBuffer);
-                        if (_tempSerializerBuffer.WritePosition == beforePos)
-                        {
-                            continue; // Nothing written
-                        }
-                        serializersRun |= (byte)(1 << serializerIdx);
-                        NetWriter.WriteBytes(_serializersBuffer, _tempSerializerBuffer.WrittenSpan);
-                    }
+                    // Framing guess for the section budget: exact when the node already
+                    // has a local id, conservative (worst case +9) when registration
+                    // happens inside the spawn Export itself.
+                    bool hasLocalId = peerState.WorldToPeerNodeMap.TryGetValue(netController.NetId, out var knownLocalId);
+                    bool guessFirst = !hasLocalId || !NodeIdUtils.IsBitSet(_updatedNodesMask, knownLocalId);
+                    bool guessOpens = !hasLocalId || GroupIsClosed(knownLocalId);
 
-                    if (serializersRun == 0)
+                    _tempSerializerBuffer.Reset();
+                    var result = serializer.Export(this, peer, _tempSerializerBuffer,
+                        ledger.SectionBudget(guessFirst, guessOpens));
+                    if (result == ExportResult.None || _tempSerializerBuffer.WritePosition == 0)
                     {
                         continue;
                     }
 
-                    // Fix #5: Track that this object has pending data for this peer
-                    pendingAcks.Add(netController);
-
                     // Safety check: ensure node is registered before lookup
-                    if (!PeerStates[peerId].WorldToPeerNodeMap.TryGetValue(netController.NetId, out var localNodeId))
+                    if (!peerState.WorldToPeerNodeMap.TryGetValue(netController.NetId, out var localNodeId))
                     {
                         Log(Debugger.DebugLevel.ERROR,
                             $"[ExportState] Node {netController.RawNode?.Name} (NetId={netController.NetId}) wrote data but isn't registered for peer {peerId}.");
                         continue;
                     }
 
-                    // Spawn-contract breach detector: a packet may carry data WITHOUT the
-                    // spawn bit only for a node whose id the client provably has or gets:
-                    // either its spawn is committed (Spawned = the peer acked a packet that
-                    // contained the spawn data), or an ancestor's spawn is in flight and this
-                    // node rides that ancestor's nested table in this same packet (sound
-                    // because table membership is frozen per peer while a spawn is in flight -
-                    // see ExportNestedScenes). Anything else means the client may not know the
-                    // id, and then the payload length is unknowable client-side - the exact
-                    // precondition of the "[ImportState] Data for unknown node" abort.
-                    // Catching it at the SOURCE names the node and state that leaked.
-                    if (NetRunner.TraceSpawnIds && (serializersRun & 1) == 0)
+                    if (!TryAppendSection(localNodeId, SpawnSerializerIndex, ref ledger))
                     {
-                        var contractState = GetClientSpawnState(netController.NetId, peer);
-                        if (contractState != ClientSpawnState.Spawned)
+                        // Over budget: retries next tick. Should only ever be transient
+                        // (a crowded packet) - a record too big for an EMPTY packet can
+                        // never ship and means the budget math or the nested-table split
+                        // is broken. One loud line, not one per tick.
+                        if (!_loggedUnfittableSpawnRecord
+                            && _tempSerializerBuffer.WritePosition > payloadBudget - TickBudgetLedger.MaxSectionOverheadBytes)
                         {
-                            bool ridesInFlightAncestorTable = false;
-                            for (var ancestor = netController.NetParent; ancestor != null; ancestor = ancestor.NetParent)
-                            {
-                                var ancestorState = GetClientSpawnState(ancestor.NetId, peer);
-                                if (ancestorState == ClientSpawnState.NotSpawned || ancestorState == ClientSpawnState.Spawning)
-                                {
-                                    ridesInFlightAncestorTable = contractState == ClientSpawnState.Spawning;
-                                    break;
-                                }
-                            }
-                            if (!ridesInFlightAncestorTable)
-                            {
-                                Log(Debugger.DebugLevel.ERROR,
-                                    $"[IdTrace] BREACH tick={CurrentTick} peer={peerId} id={localNodeId} NetId={netController.NetId} node={netController.RawNode?.Name} mask=0b{Convert.ToString(serializersRun, 2)} state={contractState}: exported without spawn data while spawn is not committed");
-                            }
+                            _loggedUnfittableSpawnRecord = true;
+                            Log(Debugger.DebugLevel.ERROR,
+                                $"[ExportState] BUG: spawn record for {netController.RawNode?.Name} (NetId={netController.NetId}) is {_tempSerializerBuffer.WritePosition} bytes and exceeds the whole tick budget ({payloadBudget}); it can never be delivered. Further occurrences suppressed.");
+                        }
+                        spawnSectionsDeferred++;
+                        continue;
+                    }
+                    pendingAcks.Add(netController);
+                    serializer.CommitExport(this, peer, CurrentTick);
+                }
+
+                _profiler?.Record(Diagnostics.TickProfiler.Phase.ExportSpawn, exportPhaseTs);
+                exportPhaseTs = Diagnostics.TickProfiler.Now();
+
+                // ---- PHASE 2: props, round-robin from the per-peer cursor ----------
+                var nodeCount = _tickNodeList.Count;
+                if (nodeCount > 0)
+                {
+                    var startIdx = 0;
+                    if (_peerPropsCursors.TryGetValue(peerId, out var cursorNetId))
+                    {
+                        startIdx = ExportRotation.FindStartIndex(_tickNodeList, cursorNetId);
+                    }
+
+                    bool serving = true;
+                    long nextCursorNetId = 0;
+                    bool cursorPinned = false;
+
+                    for (var k = 0; k < nodeCount; k++)
+                    {
+                        var netController = _tickNodeList[(startIdx + k) % nodeCount];
+                        var serializers = netController.NetNode.Serializers;
+                        if (serializers.Length <= PropsSerializerIndex) continue;
+                        var serializer = serializers[PropsSerializerIndex];
+
+                        if (serving && ledger.Remaining < PropsSectionFloor)
+                        {
+                            // Out of room: this node is first in line next tick, and the
+                            // rest of the rotation defers below.
+                            serving = false;
+                            nextCursorNetId = netController.NetId.Value;
+                            cursorPinned = true;
+                        }
+
+                        // A props section for an uncommitted spawn may only ride a packet
+                        // that also carries the spawn data teaching the client the id.
+                        ushort localNodeId = 0;
+                        bool maySail = serving
+                            && PropsMayRidePacket(netController, peer, ref peerState, out localNodeId);
+
+                        _tempSerializerBuffer.Reset();
+                        if (!maySail)
+                        {
+                            // Defer: banks this tick's broadcast dirty bits for the peer
+                            // (they would otherwise die with processingDirtyMask).
+                            serializer.Export(this, peer, _tempSerializerBuffer, 0);
+                            propsSectionsDeferred++;
+                            continue;
+                        }
+
+                        bool first = !NodeIdUtils.IsBitSet(_updatedNodesMask, localNodeId);
+                        var result = serializer.Export(this, peer, _tempSerializerBuffer,
+                            ledger.SectionBudget(first, first && GroupIsClosed(localNodeId)));
+                        if (result == ExportResult.None || _tempSerializerBuffer.WritePosition == 0)
+                        {
+                            continue;
+                        }
+
+                        if (!TryAppendSection(localNodeId, PropsSerializerIndex, ref ledger))
+                        {
+                            // Contract breach: a self-limiting serializer wrote past its
+                            // section budget. The bytes are dropped and never committed,
+                            // so its in-write stamps (chunk frontiers) may now be ahead
+                            // of what the peer will receive - loud, not silent.
+                            Log(Debugger.DebugLevel.ERROR,
+                                $"[ExportState] BUG: props section for {netController.RawNode?.Name} (NetId={netController.NetId}) exceeded its budget and was dropped.");
+                            continue;
+                        }
+                        pendingAcks.Add(netController);
+                        serializer.CommitExport(this, peer, CurrentTick);
+
+                        if (result == ExportResult.Partial && !cursorPinned)
+                        {
+                            // Node still has data queued - it resumes first next tick.
+                            nextCursorNetId = netController.NetId.Value;
+                            cursorPinned = true;
+                            serving = false;
                         }
                     }
-                    NodeIdUtils.SetBit(_updatedNodesMask, localNodeId);
-                    _peerNodesSerializersList[localNodeId] = serializersRun;
 
-                    // Pool node buffers
-                    if (!_nodeBufferPool.TryGetValue(localNodeId, out var nodeBuffer))
+                    if (!cursorPinned)
                     {
-                        nodeBuffer = new NetBuffer();
-                        _nodeBufferPool[localNodeId] = nodeBuffer;
+                        // Full rotation served: rotate the start anyway so a fixed
+                        // iteration bias can't freeze in.
+                        nextCursorNetId = _tickNodeList[(startIdx + 1) % nodeCount].NetId.Value;
                     }
-                    nodeBuffer.Reset();
-                    NetWriter.WriteBytes(nodeBuffer, _serializersBuffer.WrittenSpan);
-                    _peerNodesBuffers[localNodeId] = nodeBuffer;
+                    _peerPropsCursors[peerId] = nextCursorNetId;
+                }
+
+                _profiler?.Record(Diagnostics.TickProfiler.Phase.ExportProps, exportPhaseTs);
+                exportPhaseTs = Diagnostics.TickProfiler.Now();
+
+                // ---- PHASE 3: interest resync (1-byte sections) --------------------
+                for (var i = 0; i < _tickNodeList.Count; i++)
+                {
+                    var netController = _tickNodeList[i];
+                    var serializers = netController.NetNode.Serializers;
+                    if (serializers.Length <= InterestResyncSerializerIndex) continue;
+                    var serializer = serializers[InterestResyncSerializerIndex];
+
+                    // Resync only exports for Spawned nodes, which are always registered.
+                    if (!peerState.WorldToPeerNodeMap.TryGetValue(netController.NetId, out var localNodeId))
+                    {
+                        continue;
+                    }
+
+                    bool first = !NodeIdUtils.IsBitSet(_updatedNodesMask, localNodeId);
+                    _tempSerializerBuffer.Reset();
+                    var result = serializer.Export(this, peer, _tempSerializerBuffer,
+                        ledger.SectionBudget(first, first && GroupIsClosed(localNodeId)));
+                    if (result == ExportResult.None || _tempSerializerBuffer.WritePosition == 0)
+                    {
+                        continue;
+                    }
+                    if (!TryAppendSection(localNodeId, InterestResyncSerializerIndex, ref ledger))
+                    {
+                        continue; // dropped: the next stagger slot resyncs, no ack state
+                    }
+                    pendingAcks.Add(netController);
+                    serializer.CommitExport(this, peer, CurrentTick);
+                }
+
+                _profiler?.Record(Diagnostics.TickProfiler.Phase.ExportResync, exportPhaseTs);
+
+                if (_metrics != null)
+                {
+                    _metrics.RecordTickBudget(ledger.Used, ledger.Budget);
+                    _metrics.RecordDeferredSections(spawnSectionsDeferred, propsSectionsDeferred);
+                    int spawningCount = 0;
+                    foreach (var spawnState in peerState.SpawnState.Values)
+                    {
+                        if (spawnState == ClientSpawnState.Spawning) spawningCount++;
+                    }
+                    _metrics.RecordSpawnBacklog(spawningCount);
                 }
 
                 // Write hierarchical bitmask: groupMask (1 byte) + nodeMasks for active groups
@@ -2822,7 +3105,42 @@ namespace Nebula
                     {
                         if ((_updatedNodesMask[g] & (1L << local)) == 0) continue;
                         ushort nodeId = NodeIdUtils.Combine(g, local);
-                        NetWriter.WriteByte(_exportPeerBuffers[peerId], _peerNodesSerializersList[nodeId]);
+                        var serializersRun = _peerNodesSerializersList[nodeId];
+                        NetWriter.WriteByte(_exportPeerBuffers[peerId], serializersRun);
+
+                        // Spawn-contract breach detector: a packet may carry data WITHOUT
+                        // the spawn bit only for a node whose id the client provably has
+                        // or gets - spawn committed (Spawned), or riding an in-flight
+                        // ancestor's nested table in this same packet. Anything else and
+                        // the payload length is unknowable client-side - the exact
+                        // precondition of the "[ImportState] Data for unknown node"
+                        // abort. The props phase gate (PropsMayRidePacket) makes this
+                        // unreachable by construction; the detector stays as a backstop
+                        // that names the node and state at the SOURCE if it ever leaks.
+                        if (NetRunner.TraceSpawnIds && (serializersRun & (1 << SpawnSerializerIndex)) == 0
+                            && PeerStates[peerId].PeerToWorldNodeMap.TryGetValue(nodeId, out var worldNetId)
+                            && NetScenes.TryGetValue(worldNetId, out var tracedController))
+                        {
+                            var contractState = GetClientSpawnState(worldNetId, peer);
+                            if (contractState != ClientSpawnState.Spawned)
+                            {
+                                bool ridesInFlightAncestorTable = false;
+                                for (var ancestor = tracedController.NetParent; ancestor != null; ancestor = ancestor.NetParent)
+                                {
+                                    var ancestorState = GetClientSpawnState(ancestor.NetId, peer);
+                                    if (ancestorState == ClientSpawnState.NotSpawned || ancestorState == ClientSpawnState.Spawning)
+                                    {
+                                        ridesInFlightAncestorTable = contractState == ClientSpawnState.Spawning;
+                                        break;
+                                    }
+                                }
+                                if (!ridesInFlightAncestorTable)
+                                {
+                                    Log(Debugger.DebugLevel.ERROR,
+                                        $"[IdTrace] BREACH tick={CurrentTick} peer={peerId} id={nodeId} NetId={worldNetId} node={tracedController.RawNode?.Name} mask=0b{Convert.ToString(serializersRun, 2)} state={contractState}: exported without spawn data while spawn is not committed");
+                                }
+                            }
+                        }
                     }
                 }
                 for (int g = 0; g < NodeIdUtils.NODE_GROUPS; g++)
@@ -2842,6 +3160,7 @@ namespace Nebula
 
             // Debugger.Instance.Log($"Export: {exportTime}ms");
 
+            var cleanupTs = Diagnostics.TickProfiler.Now();
             foreach (var netController in NetScenes.Values)
             {
                 // Finally, cleanup serializers
@@ -2850,8 +3169,109 @@ namespace Nebula
                     serializer.Cleanup();
                 }
             }
+            _profiler?.Record(Diagnostics.TickProfiler.Phase.ExportCleanup, cleanupTs);
 
             return _exportPeerBuffers;
+        }
+
+        /// <summary>True when the node's 64-node group has no included node yet (its int64 node mask is unwritten).</summary>
+        private bool GroupIsClosed(ushort nodeId)
+        {
+            var (group, _) = NodeIdUtils.Split(nodeId);
+            return _updatedNodesMask[group] == 0;
+        }
+
+        /// <summary>
+        /// Charges the ledger for the section sitting in _tempSerializerBuffer and appends
+        /// it to the node's per-peer buffer, opening the node's packet entry on its first
+        /// section. Returns false - nothing charged or appended - when it doesn't fit.
+        /// </summary>
+        private bool TryAppendSection(ushort localNodeId, int serializerIdx, ref TickBudgetLedger ledger)
+        {
+            bool firstSection = !NodeIdUtils.IsBitSet(_updatedNodesMask, localNodeId);
+            bool opensGroup = firstSection && GroupIsClosed(localNodeId);
+            if (!ledger.TryCommitSection(_tempSerializerBuffer.WritePosition, firstSection, opensGroup))
+            {
+                return false;
+            }
+
+            if (firstSection)
+            {
+                NodeIdUtils.SetBit(_updatedNodesMask, localNodeId);
+                if (!_nodeBufferPool.TryGetValue(localNodeId, out var nodeBuffer))
+                {
+                    nodeBuffer = new NetBuffer();
+                    _nodeBufferPool[localNodeId] = nodeBuffer;
+                }
+                nodeBuffer.Reset();
+                _peerNodesBuffers[localNodeId] = nodeBuffer;
+                _peerNodesSerializersList[localNodeId] = 0;
+            }
+
+            NetWriter.WriteBytes(_peerNodesBuffers[localNodeId], _tempSerializerBuffer.WrittenSpan);
+            _peerNodesSerializersList[localNodeId] |= (byte)(1 << serializerIdx);
+            return true;
+        }
+
+        /// <summary>
+        /// Gate for the props phase: may a props section for this node ride the packet
+        /// currently being assembled? For a committed spawn (Spawned), always. While the
+        /// spawn is in flight (Spawning), only when the packet itself carries the spawn
+        /// data that teaches the client the node's id - the node's own spawn section, or
+        /// an in-flight ancestor's spawn table that provably includes this node. Anything
+        /// else risks the client-side "Data for unknown node" tick-import abort, which
+        /// kills the whole tick and its ack. Nodes refused here are deferred instead
+        /// (their dirty bits bank in PendingDirtyMask).
+        /// </summary>
+        private bool PropsMayRidePacket(NetworkController netController, NetPeer peer, ref PeerState peerState, out ushort localNodeId)
+        {
+            localNodeId = 0;
+            var state = GetClientSpawnState(netController.NetId, peer);
+            if (state == ClientSpawnState.Spawned)
+            {
+                return peerState.WorldToPeerNodeMap.TryGetValue(netController.NetId, out localNodeId);
+            }
+            if (state != ClientSpawnState.Spawning)
+            {
+                // The props serializer refuses these states anyway; nothing to ride.
+                return false;
+            }
+            if (!peerState.WorldToPeerNodeMap.TryGetValue(netController.NetId, out localNodeId))
+            {
+                return false;
+            }
+
+            // Own spawn section committed into this packet?
+            if (_peerNodesSerializersList.TryGetValue(localNodeId, out var ownMask)
+                && (ownMask & (1 << SpawnSerializerIndex)) != 0)
+            {
+                return true;
+            }
+
+            // Riding an in-flight ancestor's spawn table in this packet? The ancestor's
+            // SpawnSerializer still holds the nested set of its last Export for this
+            // peer (valid: phase 1 for this peer ran immediately before this phase), so
+            // membership is checked exactly, not inferred from the hierarchy.
+            for (var ancestor = netController.NetParent; ancestor != null; ancestor = ancestor.NetParent)
+            {
+                if (GetClientSpawnState(ancestor.NetId, peer) != ClientSpawnState.Spawning)
+                {
+                    continue;
+                }
+                if (!peerState.WorldToPeerNodeMap.TryGetValue(ancestor.NetId, out var ancestorLocalId)
+                    || !_peerNodesSerializersList.TryGetValue(ancestorLocalId, out var ancestorMask)
+                    || (ancestorMask & (1 << SpawnSerializerIndex)) == 0)
+                {
+                    continue;
+                }
+                if (ancestor.NetNode?.Serializers is { Length: > 0 } ancestorSerializers
+                    && ancestorSerializers[SpawnSerializerIndex] is SpawnSerializer ancestorSpawn
+                    && ancestorSpawn.NestedSceneRodeLastSpawnExport(netController))
+                {
+                    return true;
+                }
+            }
+            return false;
         }
 
         /// <summary>

--- a/addons/Nebula/Testing/Unit/BsonWriteBufferTests.cs
+++ b/addons/Nebula/Testing/Unit/BsonWriteBufferTests.cs
@@ -1,0 +1,226 @@
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Threading;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
+using Nebula.Serialization;
+using Xunit;
+
+namespace Nebula.Testing.Unit;
+
+/// <summary>
+/// BsonWriteBuffer replaces `doc.ToBson()` + `ByteString.CopyFrom` on the periodic world save,
+/// which allocated ~3.5 MB of large-object garbage every 5 seconds (a doubling growth run, a
+/// right-sized copy, then a protobuf copy of that) and was the sole driver of the server's gen2
+/// collections.
+///
+/// The properties worth pinning are: the bytes must be identical to what ToBson produced, a
+/// shorter document must not leak the previous one's tail, and the backing array must actually be
+/// REUSED after it reaches high water — that last one is the whole point of the change.
+/// </summary>
+[NebulaUnitTest]
+public class BsonWriteBufferTests
+{
+    private static BsonDocument SmallDoc() => new()
+    {
+        ["name"] = "Zara",
+        ["level"] = 42,
+        ["health"] = 93.5,
+        ["alive"] = true,
+    };
+
+    /// <summary>A document comfortably larger than BsonWriteBuffer.DefaultCapacity (64 KB).</summary>
+    private static BsonDocument BigDoc(int entries = 8000)
+    {
+        var doc = new BsonDocument();
+        for (var i = 0; i < entries; i++)
+        {
+            doc[$"key_{i}"] = $"value_{i}_padding_padding";
+        }
+        return doc;
+    }
+
+    private static BsonDocument RoundTrip(BsonWriteBuffer buffer)
+        => BsonSerializer.Deserialize<BsonDocument>(buffer.WrittenMemory.ToArray());
+
+    // 1. The bytes must match what the replaced ToBson() call produced. This is what pins the
+    //    nominal-type choice (BsonValue, matching the BsonValue-typed variables at the call sites)
+    //    and the ambient BsonDefaults settings - a divergence here silently changes what is
+    //    persisted, which no runtime assertion would ever catch.
+    [NebulaUnitTest]
+    public void Write_ProducesBytesIdenticalToToBson()
+    {
+        var doc = SmallDoc();
+        var buffer = BsonWriteBuffer.Rent();
+        try
+        {
+            buffer.Write(doc);
+
+            Assert.Equal(doc.ToBson(), buffer.WrittenMemory.ToArray());
+            Assert.Equal(doc, RoundTrip(buffer));
+        }
+        finally
+        {
+            BsonWriteBuffer.Return(buffer);
+        }
+    }
+
+    // 2. A shorter document after a longer one must not expose the tail of the previous write.
+    //    Correctness here comes from the LENGTH SLICE, not from clearing the buffer - the test
+    //    asserts the stale bytes are still physically present so that nobody later "fixes" this
+    //    with an ~800 KB memset per save.
+    [NebulaUnitTest]
+    public void Write_ShorterDocument_DoesNotLeakPreviousTail()
+    {
+        var buffer = BsonWriteBuffer.Rent();
+        try
+        {
+            buffer.Write(BigDoc());
+            int bigLength = buffer.Length;
+
+            var small = SmallDoc();
+            buffer.Write(small);
+
+            Assert.True(buffer.Length < bigLength);
+            Assert.Equal(small, RoundTrip(buffer));
+            // BSON opens with its own total length; the slice and the document must agree.
+            Assert.Equal(buffer.Length, BinaryPrimitives.ReadInt32LittleEndian(buffer.WrittenMemory.Span));
+
+            // The old document's bytes are still in the array beyond Length - unreachable, not erased.
+            Assert.True(MemoryMarshal.TryGetArray<byte>(buffer.WrittenMemory, out var seg));
+            bool tailStillDirty = false;
+            for (var i = buffer.Length; i < bigLength; i++)
+            {
+                if (seg.Array[i] != 0) { tailStillDirty = true; break; }
+            }
+            Assert.True(tailStillDirty);
+        }
+        finally
+        {
+            BsonWriteBuffer.Return(buffer);
+        }
+    }
+
+    // 3. Growing past the initial capacity has to work and stay correct.
+    [NebulaUnitTest]
+    public void Write_GrowsBeyondDefaultCapacity()
+    {
+        var buffer = BsonWriteBuffer.Rent();
+        try
+        {
+            var big = BigDoc();
+            buffer.Write(big);
+
+            Assert.True(buffer.Length > BsonWriteBuffer.DefaultCapacity);
+            Assert.True(buffer.Capacity >= buffer.Length);
+            Assert.Equal(big, RoundTrip(buffer));
+        }
+        finally
+        {
+            BsonWriteBuffer.Return(buffer);
+        }
+    }
+
+    // 4. THE test for the actual fix: once the buffer has reached high water, a second
+    //    same-sized write must reuse the very same array. If MemoryStream ever stopped retaining
+    //    its buffer across SetLength(0), the LOH churn would silently come back and only this
+    //    assertion would notice.
+    [NebulaUnitTest]
+    public void Write_AtHighWaterMark_ReusesTheSameArray()
+    {
+        var buffer = BsonWriteBuffer.Rent();
+        try
+        {
+            buffer.Write(BigDoc());
+            Assert.True(MemoryMarshal.TryGetArray<byte>(buffer.WrittenMemory, out var first));
+            int capacityAfterGrowth = buffer.Capacity;
+
+            buffer.Write(BigDoc());
+            Assert.True(MemoryMarshal.TryGetArray<byte>(buffer.WrittenMemory, out var second));
+
+            Assert.Same(first.Array, second.Array);
+            Assert.Equal(capacityAfterGrowth, buffer.Capacity);
+        }
+        finally
+        {
+            BsonWriteBuffer.Return(buffer);
+        }
+    }
+
+    // 5. Pool mechanics. The double-return guard matters most: a double return hands one array to
+    //    two payloads, and the loser silently ships corrupted bytes.
+    [NebulaUnitTest]
+    public void Pool_ReusesReturnedBuffers_AndRejectsDoubleReturn()
+    {
+        BsonWriteBuffer.ClearPoolForTests();
+
+        var a = BsonWriteBuffer.Rent();
+        var b = BsonWriteBuffer.Rent();
+        Assert.NotSame(a, b);
+
+        BsonWriteBuffer.Return(a);
+        Assert.Equal(1, BsonWriteBuffer.PooledCountForTests);
+        Assert.Same(a, BsonWriteBuffer.Rent());
+
+        BsonWriteBuffer.Return(a);
+        Assert.Throws<InvalidOperationException>(() => BsonWriteBuffer.Return(a));
+
+        BsonWriteBuffer.Return(b);
+        BsonWriteBuffer.ClearPoolForTests();
+    }
+
+    // 6. Rent/Return happen on different threads in production (save thread vs RPC continuation),
+    //    and several worlds can save at once. Each thread must only ever see its own bytes. The
+    //    local mock DataBuddy never reads the payload, so this stands in for a hazard that
+    //    integration testing cannot reach.
+    [NebulaUnitTest]
+    public void Pool_IsSafeAcrossThreads()
+    {
+        const int threads = 4;
+        const int iterations = 25;
+        var failures = new List<string>();
+        var failureLock = new object();
+        var workers = new Thread[threads];
+
+        for (var t = 0; t < threads; t++)
+        {
+            int id = t;
+            workers[t] = new Thread(() =>
+            {
+                for (var i = 0; i < iterations; i++)
+                {
+                    var doc = new BsonDocument { ["thread"] = id, ["iteration"] = i };
+                    var buffer = BsonWriteBuffer.Rent();
+                    try
+                    {
+                        buffer.Write(doc);
+                        var read = BsonSerializer.Deserialize<BsonDocument>(buffer.WrittenMemory.ToArray());
+                        if (read["thread"].AsInt32 != id || read["iteration"].AsInt32 != i)
+                        {
+                            lock (failureLock) failures.Add($"thread {id} iteration {i} read back {read.ToJson()}");
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        lock (failureLock) failures.Add($"thread {id} iteration {i} threw {ex.Message}");
+                    }
+                    finally
+                    {
+                        BsonWriteBuffer.Return(buffer);
+                    }
+                }
+            });
+            workers[t].Start();
+        }
+
+        foreach (var worker in workers)
+        {
+            Assert.True(worker.Join(TimeSpan.FromSeconds(30)), "worker thread did not finish");
+        }
+
+        Assert.Empty(failures);
+        BsonWriteBuffer.ClearPoolForTests();
+    }
+}

--- a/addons/Nebula/Testing/Unit/BsonWriteBufferTests.cs.uid
+++ b/addons/Nebula/Testing/Unit/BsonWriteBufferTests.cs.uid
@@ -1,0 +1,1 @@
+uid://3iao8jtqp30o

--- a/addons/Nebula/Testing/Unit/ExportRotationTests.cs
+++ b/addons/Nebula/Testing/Unit/ExportRotationTests.cs
@@ -1,0 +1,116 @@
+using System.Collections.Generic;
+using Nebula;
+using Nebula.Serialization;
+using Xunit;
+
+namespace Nebula.Testing.Unit;
+
+/// <summary>
+/// ExportRotation.FindStartIndex resolves the per-peer props cursor (the NetId of the
+/// next node owed service) against the world node list, which is insertion-ordered, not
+/// sorted. Identity match wins; a despawned cursor node falls to the nearest id above;
+/// nothing above wraps to index 0.
+/// </summary>
+[NebulaUnitTest]
+public class ExportRotationTests
+{
+    private static List<NetworkController> Nodes(List<NetNode> keepAlive, params long[] ids)
+    {
+        var list = new List<NetworkController>();
+        foreach (var id in ids)
+        {
+            var node = new NetNode();
+            keepAlive.Add(node);
+            node.Network.NetId = new NetId(id);
+            list.Add(node.Network);
+        }
+        return list;
+    }
+
+    private static void Free(List<NetNode> nodes)
+    {
+        foreach (var node in nodes)
+        {
+            node.Free();
+        }
+    }
+
+    [NebulaUnitTest]
+    public void EmptyListOrUnsetCursor_StartsAtZero()
+    {
+        var keepAlive = new List<NetNode>();
+        var nodes = Nodes(keepAlive, 5, 9, 2);
+
+        Assert.Equal(0, ExportRotation.FindStartIndex(new List<NetworkController>(), 5));
+        Assert.Equal(0, ExportRotation.FindStartIndex(nodes, 0));
+        Assert.Equal(0, ExportRotation.FindStartIndex(nodes, -1));
+
+        Free(keepAlive);
+    }
+
+    [NebulaUnitTest]
+    public void ExactMatch_ReturnsItsIndex_EvenUnsorted()
+    {
+        var keepAlive = new List<NetNode>();
+        // Insertion order with id reuse: not ascending
+        var nodes = Nodes(keepAlive, 7, 3, 12, 5);
+
+        Assert.Equal(1, ExportRotation.FindStartIndex(nodes, 3));
+        Assert.Equal(3, ExportRotation.FindStartIndex(nodes, 5));
+        Assert.Equal(0, ExportRotation.FindStartIndex(nodes, 7));
+
+        Free(keepAlive);
+    }
+
+    [NebulaUnitTest]
+    public void RemovedCursorNode_FallsToNearestIdAbove()
+    {
+        var keepAlive = new List<NetNode>();
+        var nodes = Nodes(keepAlive, 7, 3, 12, 5);
+
+        // Cursor node 6 despawned: nearest above is 7 (index 0), not 12
+        Assert.Equal(0, ExportRotation.FindStartIndex(nodes, 6));
+        // Cursor 8: nearest above is 12 (index 2)
+        Assert.Equal(2, ExportRotation.FindStartIndex(nodes, 8));
+
+        Free(keepAlive);
+    }
+
+    [NebulaUnitTest]
+    public void CursorPastAllIds_WrapsToZero()
+    {
+        var keepAlive = new List<NetNode>();
+        var nodes = Nodes(keepAlive, 7, 3, 12, 5);
+
+        Assert.Equal(0, ExportRotation.FindStartIndex(nodes, 13));
+
+        Free(keepAlive);
+    }
+
+    // Fairness: rotating from the cursor and always advancing it past the served window
+    // must visit every node within ceil(N / perTick) rotations, regardless of list order.
+    [NebulaUnitTest]
+    public void Rotation_ServesEveryNodeWithinOneCycle()
+    {
+        var keepAlive = new List<NetNode>();
+        var nodes = Nodes(keepAlive, 7, 3, 12, 5, 9, 1);
+        const int perTick = 2;
+        var served = new HashSet<long>();
+        long cursor = 0;
+
+        for (var tick = 0; tick < (nodes.Count + perTick - 1) / perTick; tick++)
+        {
+            var start = ExportRotation.FindStartIndex(nodes, cursor);
+            for (var k = 0; k < perTick; k++)
+            {
+                var node = nodes[(start + k) % nodes.Count];
+                served.Add(node.NetId.Value);
+            }
+            cursor = nodes[(start + perTick) % nodes.Count].NetId.Value;
+        }
+
+        Assert.Equal(nodes.Count, served.Count);
+
+        Free(keepAlive);
+    }
+}

--- a/addons/Nebula/Testing/Unit/ExportRotationTests.cs.uid
+++ b/addons/Nebula/Testing/Unit/ExportRotationTests.cs.uid
@@ -1,0 +1,1 @@
+uid://cjmfw3s6gn26b

--- a/addons/Nebula/Testing/Unit/NebulaPackWordScanTests.cs
+++ b/addons/Nebula/Testing/Unit/NebulaPackWordScanTests.cs
@@ -1,0 +1,370 @@
+using System;
+using System.Collections.Generic;
+using Nebula.Serialization;
+using Xunit;
+
+namespace Nebula.Testing.Unit;
+
+/// <summary>
+/// Differential tests for the word-at-a-time scan inside NebulaPack's encoder.
+///
+/// The encoder's inner loop was rewritten to compare eight bytes at a time -- XOR plus a
+/// trailing-zero count to locate the first differing byte, and a has-zero-byte test to step over
+/// runs that differ throughout. That is a hand-vectorization of wire-format code, where a mistake
+/// does not throw: it produces a subtly different delta that still decodes, and desynchronizes a
+/// client somewhere downstream.
+///
+/// So passing the existing round-trip tests is not sufficient evidence. These compare the encoder
+/// against a straightforward scalar model of the SAME format, byte for byte, over the shapes most
+/// likely to break a word-based scan: runs that straddle the eight-byte stride, windows shorter and
+/// longer than the input, lengths either side of the stride, and the has-zero-byte helper's known
+/// false positives (borrow propagation can flag a byte the borrow manufactured, which must only
+/// cost a slower path and never end a run early).
+/// </summary>
+[NebulaUnitTest]
+public class NebulaPackWordScanTests
+{
+    /// <summary>
+    /// The format, written the obvious way: alternate a run of bytes matching the window with a run
+    /// that differs, and price each as varint(skip) + varint(literals) + literals. This mirrors the
+    /// encoder's contract without sharing any of its scanning logic, which is the point.
+    /// </summary>
+    private static int ReferenceMeasure(ReadOnlySpan<byte> input, ReadOnlySpan<byte> window)
+    {
+        static int VarintSize(uint v)
+            => v < 0x80u ? 1 : v < 0x4000u ? 2 : v < 0x200000u ? 3 : v < 0x10000000u ? 4 : 5;
+
+        int size = VarintSize((uint)input.Length);
+        int i = 0;
+        while (i < input.Length)
+        {
+            int skipStart = i;
+            while (i < input.Length && i < window.Length && input[i] == window[i]) i++;
+            int skip = i - skipStart;
+
+            int literalStart = i;
+            while (i < input.Length && (i >= window.Length || input[i] != window[i])) i++;
+            int literals = i - literalStart;
+
+            size += VarintSize((uint)skip) + VarintSize((uint)literals) + literals;
+        }
+        return size;
+    }
+
+    /// <summary>Asserts the encoder agrees with the model, and that the bytes still round-trip.</summary>
+    private static void AssertMatchesReference(byte[] input, byte[] window)
+    {
+        int reference = ReferenceMeasure(input, window);
+        int measured = NebulaPack.MeasureDelta(input, window);
+        Assert.True(reference == measured,
+            $"MeasureDelta disagreed with the reference model: {measured} vs {reference} "
+            + $"(input {input.Length} B, window {window.Length} B)");
+
+        var encoded = new byte[Math.Max(measured, 1)];
+        int written = NebulaPack.EncodeDelta(input, window, encoded);
+        Assert.True(written == measured,
+            $"EncodeDelta wrote {written} bytes where MeasureDelta promised {measured}");
+
+        var decoded = new byte[input.Length];
+        int produced = NebulaPack.DecodeDelta(encoded.AsSpan(0, written), window, decoded);
+        Assert.Equal(input.Length, produced);
+        Assert.Equal(input, decoded);
+    }
+
+    [NebulaUnitTest]
+    public void TestRunsStraddlingTheEightByteStride()
+    {
+        // A matching run ending at every offset within the stride, so the trailing-zero path is
+        // exercised at each byte position rather than only where a run happens to align.
+        for (int matchLength = 0; matchLength <= 24; matchLength++)
+        {
+            var input = new byte[48];
+            var window = new byte[48];
+            for (int i = 0; i < input.Length; i++)
+            {
+                input[i] = (byte)(i + 1);
+                window[i] = i < matchLength ? (byte)(i + 1) : (byte)0xFF;
+            }
+            AssertMatchesReference(input, window);
+        }
+    }
+
+    [NebulaUnitTest]
+    public void TestDifferingRunsStraddlingTheStride()
+    {
+        // The inverse: a differing run of every length, which drives the has-zero-byte stepping.
+        for (int diffLength = 0; diffLength <= 24; diffLength++)
+        {
+            var input = new byte[48];
+            var window = new byte[48];
+            for (int i = 0; i < input.Length; i++)
+            {
+                input[i] = 0x11;
+                window[i] = i < diffLength ? (byte)0x22 : (byte)0x11;
+            }
+            AssertMatchesReference(input, window);
+        }
+    }
+
+    [NebulaUnitTest]
+    public void TestLengthsAroundTheStride()
+    {
+        // Payloads shorter than one word, exactly one word, and one either side -- the boundaries
+        // where an off-by-one in the `i + sizeof(ulong) <= limit` guard would show up.
+        foreach (int length in new[] { 0, 1, 2, 7, 8, 9, 15, 16, 17, 31, 32, 33 })
+        {
+            var input = new byte[length];
+            var window = new byte[length];
+            for (int i = 0; i < length; i++)
+            {
+                input[i] = (byte)i;
+                window[i] = (byte)(i % 3 == 0 ? i : i ^ 0x5A);
+            }
+            AssertMatchesReference(input, window);
+        }
+    }
+
+    [NebulaUnitTest]
+    public void TestMismatchedWindowLengths()
+    {
+        // Past the end of the window everything is literal by definition, and the word loop must
+        // stop at that boundary rather than reading beyond it.
+        foreach (int windowLength in new[] { 0, 1, 7, 8, 9, 40, 63, 64, 65 })
+        {
+            var input = new byte[64];
+            var window = new byte[windowLength];
+            for (int i = 0; i < input.Length; i++) input[i] = (byte)(i * 7);
+            for (int i = 0; i < window.Length; i++) window[i] = (byte)(i * 7);   // identical prefix
+            AssertMatchesReference(input, window);
+        }
+    }
+
+    [NebulaUnitTest]
+    public void TestBytesThatProvokeTheHasZeroByteFalsePositive()
+    {
+        // The has-zero-byte test borrows across byte boundaries, so words containing 0x01 and 0x00
+        // are where a manufactured zero can appear. A false positive must only cost a slower path;
+        // if it ever ended a run early the reference comparison below would diverge.
+        var patterns = new byte[][]
+        {
+            new byte[] { 0x01, 0x00, 0x01, 0x00, 0x01, 0x00, 0x01, 0x00 },
+            new byte[] { 0x00, 0x01, 0x80, 0x7F, 0xFF, 0x01, 0x00, 0x80 },
+            new byte[] { 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80 },
+            new byte[] { 0xFF, 0x01, 0xFF, 0x01, 0xFF, 0x01, 0xFF, 0x01 },
+        };
+        foreach (var pattern in patterns)
+        {
+            foreach (var other in patterns)
+            {
+                var input = new byte[64];
+                var window = new byte[64];
+                for (int i = 0; i < 64; i++)
+                {
+                    input[i] = pattern[i % pattern.Length];
+                    window[i] = other[i % other.Length];
+                }
+                AssertMatchesReference(input, window);
+            }
+        }
+    }
+
+    [NebulaUnitTest]
+    public void TestRandomPayloadsAgainstTheReference()
+    {
+        // Seeded so a failure is reproducible. Densities span "almost everything matches" to
+        // "almost nothing does" -- real tick payloads sit near the sparse end, but the encoder has
+        // to be right across the range.
+        var random = new Random(20260807);
+        for (int trial = 0; trial < 400; trial++)
+        {
+            int length = random.Next(0, 300);
+            int windowLength = random.Next(0, 300);
+            int matchPercent = random.Next(0, 101);
+
+            var window = new byte[windowLength];
+            random.NextBytes(window);
+
+            var input = new byte[length];
+            random.NextBytes(input);
+            for (int i = 0; i < length && i < windowLength; i++)
+            {
+                if (random.Next(100) < matchPercent) input[i] = window[i];
+            }
+
+            AssertMatchesReference(input, window);
+        }
+    }
+
+    // ---- the bounded measure -------------------------------------------------------------
+    //
+    // Baseline selection stops measuring a candidate once its running size reaches the best size
+    // found so far. The claim is that this is EXACT -- it finds the same global minimum an
+    // unbounded search would -- because the size only ever grows. That claim is what these pin;
+    // if it were wrong the server would quietly ship larger deltas than it reports.
+
+    [NebulaUnitTest]
+    public void TestBoundedMeasureAgreesWhenTheBoundDoesNotBite()
+    {
+        var random = new Random(1234);
+        for (int trial = 0; trial < 200; trial++)
+        {
+            var window = new byte[random.Next(1, 400)];
+            random.NextBytes(window);
+            var input = (byte[])window.Clone();
+            for (int i = 0; i < input.Length; i++)
+                if (random.Next(100) < 40) input[i] ^= 0x3C;
+
+            int exact = NebulaPack.MeasureDelta(input, window);
+            // A bound above the true size must not change the answer.
+            Assert.Equal(exact, NebulaPack.MeasureDeltaBounded(input, window, exact + 1));
+            Assert.Equal(exact, NebulaPack.MeasureDeltaBounded(input, window, int.MaxValue));
+        }
+    }
+
+    [NebulaUnitTest]
+    public void TestBoundedMeasureNeverUnderreports()
+    {
+        var random = new Random(5678);
+        for (int trial = 0; trial < 200; trial++)
+        {
+            var window = new byte[random.Next(1, 400)];
+            random.NextBytes(window);
+            var input = (byte[])window.Clone();
+            for (int i = 0; i < input.Length; i++)
+                if (random.Next(100) < 60) input[i] ^= 0x77;
+
+            int exact = NebulaPack.MeasureDelta(input, window);
+            // Below the true size the call may stop early, but whatever it returns must still be
+            // at or above the bound -- never a number that would make a losing candidate look like
+            // a winner.
+            for (int bound = 1; bound <= exact; bound += Math.Max(1, exact / 8))
+            {
+                int bounded = NebulaPack.MeasureDeltaBounded(input, window, bound);
+                Assert.True(bounded >= bound,
+                    $"bounded measure returned {bounded} under its own bound {bound} (exact {exact})");
+            }
+        }
+    }
+
+    [NebulaUnitTest]
+    public void TestBoundedSearchFindsTheSameWinnerAsAnUnboundedOne()
+    {
+        // The property that actually matters: running a field of candidates with a tightening
+        // bound must select the same baseline, and report the same size, as measuring them all
+        // exactly. This is the whole justification for the early abort.
+        var random = new Random(99);
+        for (int trial = 0; trial < 120; trial++)
+        {
+            int length = random.Next(50, 500);
+            var input = new byte[length];
+            random.NextBytes(input);
+
+            var candidates = new List<byte[]>();
+            for (int c = 0; c < 12; c++)
+            {
+                var candidate = (byte[])input.Clone();
+                int churn = random.Next(0, 100);
+                for (int i = 0; i < length; i++)
+                    if (random.Next(100) < churn) candidate[i] ^= (byte)random.Next(1, 256);
+                candidates.Add(candidate);
+            }
+
+            int exhaustiveBest = int.MaxValue, exhaustivePick = -1;
+            for (int c = 0; c < candidates.Count; c++)
+            {
+                int size = NebulaPack.MeasureDelta(input, candidates[c]);
+                if (size < exhaustiveBest) { exhaustiveBest = size; exhaustivePick = c; }
+            }
+
+            int bound = length, boundedBest = int.MaxValue, boundedPick = -1;
+            for (int c = 0; c < candidates.Count; c++)
+            {
+                int size = NebulaPack.MeasureDeltaBounded(input, candidates[c], bound);
+                if (size < bound) { bound = size; boundedBest = size; boundedPick = c; }
+            }
+
+            // Only compare when a delta was actually usable; otherwise both correctly decline.
+            if (exhaustiveBest < length)
+            {
+                Assert.Equal(exhaustiveBest, boundedBest);
+                Assert.Equal(exhaustivePick, boundedPick);
+            }
+            else
+            {
+                Assert.True(boundedPick < 0 || boundedBest >= length);
+            }
+        }
+    }
+
+    // ---- block digests -------------------------------------------------------------------
+
+    [NebulaUnitTest]
+    public void TestDigestsAreDeterministicAndBlockLocal()
+    {
+        var random = new Random(31337);
+        var payload = new byte[300];
+        random.NextBytes(payload);
+
+        var first = new ulong[NebulaPack.BlockCount(payload.Length)];
+        var second = new ulong[first.Length];
+        NebulaPack.ComputeDigests(payload, first);
+        NebulaPack.ComputeDigests(payload, second);
+        Assert.Equal(first, second);
+
+        // Changing one byte must move its own block's digest and leave the others alone -- that
+        // locality is exactly what makes a differing-block count mean anything.
+        var mutated = (byte[])payload.Clone();
+        int touched = 100;
+        mutated[touched] ^= 0xFF;
+        var after = new ulong[first.Length];
+        NebulaPack.ComputeDigests(mutated, after);
+
+        int touchedBlock = touched / NebulaPack.DigestBlockBytes;
+        for (int b = 0; b < first.Length; b++)
+        {
+            if (b == touchedBlock) Assert.NotEqual(first[b], after[b]);
+            else Assert.Equal(first[b], after[b]);
+        }
+    }
+
+    [NebulaUnitTest]
+    public void TestDigestsSeparateReorderedBytes()
+    {
+        // A plain XOR fold would collide here: same bytes, different order. Ranking would then
+        // treat unrelated baselines as identical and pick badly.
+        var a = new byte[NebulaPack.DigestBlockBytes];
+        var b = new byte[NebulaPack.DigestBlockBytes];
+        for (int i = 0; i < a.Length; i++) { a[i] = (byte)i; b[i] = (byte)(a.Length - 1 - i); }
+
+        var da = new ulong[1];
+        var db = new ulong[1];
+        NebulaPack.ComputeDigests(a, da);
+        NebulaPack.ComputeDigests(b, db);
+        Assert.NotEqual(da[0], db[0]);
+    }
+
+    [NebulaUnitTest]
+    public void TestPayloadsShapedLikeRealTickTraffic()
+    {
+        // The shape measured off a live 40-peer server: a mostly-matching first tenth, then long
+        // differing runs broken by very short matches (~2 bytes). This is the case the rewrite was
+        // built for, so it should be the case most obviously correct.
+        var random = new Random(4242);
+        for (int trial = 0; trial < 200; trial++)
+        {
+            int length = random.Next(600, 1200);
+            var window = new byte[length];
+            random.NextBytes(window);
+            var input = (byte[])window.Clone();
+
+            int i = length / 10;             // leave the first tenth matching
+            while (i < length)
+            {
+                int differing = random.Next(8, 24);
+                for (int d = 0; d < differing && i < length; d++, i++) input[i] = (byte)(window[i] ^ 0xA5);
+                i += random.Next(1, 4);      // a short matching run
+            }
+            AssertMatchesReference(input, window);
+        }
+    }
+}

--- a/addons/Nebula/Testing/Unit/NebulaPackWordScanTests.cs.uid
+++ b/addons/Nebula/Testing/Unit/NebulaPackWordScanTests.cs.uid
@@ -1,0 +1,1 @@
+uid://rhrhx8noiofr

--- a/addons/Nebula/Testing/Unit/PropsBudgetTests.cs
+++ b/addons/Nebula/Testing/Unit/PropsBudgetTests.cs
@@ -1,0 +1,188 @@
+using Nebula;
+using Nebula.Serialization;
+using Nebula.Serialization.Serializers;
+using Xunit;
+
+namespace Nebula.Testing.Unit;
+
+/// <summary>
+/// Server-side budget behavior of NetPropertiesSerializer under MTU splitting:
+/// a deferred export (maxBytes too small for anything) must preserve the tick's
+/// broadcast dirty bits in PendingDirtyMask instead of losing them with
+/// processingDirtyMask; a tight budget must self-limit (never exceed maxBytes,
+/// report Partial, defer the leftovers); and the packet-coupled stamps must only
+/// exist after CommitExport, so an ack can only clear what provably shipped.
+///
+/// Built on the Protocol-free ctor (primitive props only) plus
+/// WorldRunner.CreatePeerStateForTests - no live ENet connection.
+/// </summary>
+[NebulaUnitTest]
+public class PropsBudgetTests
+{
+    private sealed class Fixture : System.IDisposable
+    {
+        public WorldRunner World;
+        public NetPeer Peer;      // default(NetPeer): ID 0, mapped in PeerIds below
+        public UUID PeerId;
+        public NetNode Node;
+        public NetPropertiesSerializer Serializer;
+
+        public Fixture(params SerialVariantType[] propTypes)
+        {
+            World = new WorldRunner();
+            Peer = default;
+            PeerId = UUID.NewUUID();
+            NetRunner.Instance.PeerIds[0] = PeerId;
+            World.CreatePeerStateForTests(Peer, PeerId);
+
+            Node = new NetNode();
+            Node.Network.InterestLayers[PeerId] = 1;
+            for (var i = 0; i < propTypes.Length; i++)
+            {
+                Node.Network.CachedProperties[i] = new PropertyCache { Type = propTypes[i], IntValue = 40 + i };
+            }
+            Serializer = new NetPropertiesSerializer(Node.Network, propTypes);
+
+            // Spawning: the props gate allows exports while the spawn is in flight
+            World.SetClientSpawnState(Node.Network.NetId, Peer, WorldRunner.ClientSpawnState.Spawning);
+        }
+
+        public void Dispose()
+        {
+            NetRunner.Instance.PeerIds.Remove(0);
+            Node.Free();
+            World.Free();
+        }
+    }
+
+    private static NetBuffer Buffer() => new(512, usePool: false);
+
+    // 1. THE data-loss hazard of splitting: Begin() consumes the global dirty mask, so a
+    //    peer whose export is deferred for budget must bank those bits in PendingDirtyMask
+    //    and ship them (absolute) on a later tick.
+    [NebulaUnitTest]
+    public void DeferredExport_BanksDirtyBits_ShipsThemLater()
+    {
+        using var f = new Fixture(SerialVariantType.Int, SerialVariantType.Int);
+
+        f.World.CurrentTick = 1;
+        f.Node.Network.DirtyMask = 0b11;
+        f.Serializer.Begin();
+
+        var buf = Buffer();
+        var result = f.Serializer.Export(f.World, f.Peer, buf, 0);
+
+        Assert.Equal(ExportResult.None, result);
+        Assert.Equal(0, buf.WrittenSpan.Length);
+        Assert.Equal(0b11, f.Serializer.PendingDirtyByteForTests(f.PeerId, 0));
+
+        // Next tick, no new dirt: the banked bits ship, presence mask covers both props
+        f.World.CurrentTick = 2;
+        f.Serializer.Begin();
+        buf.Reset();
+        result = f.Serializer.Export(f.World, f.Peer, buf, int.MaxValue);
+
+        Assert.Equal(ExportResult.Written, result);
+        Assert.Equal(0b11, buf.WrittenSpan[0]);
+    }
+
+    // 2. A deferred export with nothing eligible banks nothing.
+    [NebulaUnitTest]
+    public void DeferredExport_NothingDirty_BanksNothing()
+    {
+        using var f = new Fixture(SerialVariantType.Int, SerialVariantType.Int);
+
+        f.World.CurrentTick = 1;
+        f.Serializer.Begin();
+
+        var buf = Buffer();
+        var result = f.Serializer.Export(f.World, f.Peer, buf, 0);
+
+        Assert.Equal(ExportResult.None, result);
+        Assert.Equal(0, f.Serializer.PendingDirtyByteForTests(f.PeerId, 0));
+    }
+
+    // 3. Self-limiting: one byte under the full section size must drop exactly the last
+    //    property - section stays within maxBytes, result is Partial, and the rewound
+    //    bit is banked for a later tick.
+    [NebulaUnitTest]
+    public void TightBudget_SelfLimits_ReportsPartial_BanksLeftover()
+    {
+        int fullSize;
+        using (var sizing = new Fixture(SerialVariantType.Int, SerialVariantType.Int))
+        {
+            sizing.World.CurrentTick = 1;
+            sizing.Node.Network.DirtyMask = 0b11;
+            sizing.Serializer.Begin();
+            var sizingBuf = Buffer();
+            Assert.Equal(ExportResult.Written, sizing.Serializer.Export(sizing.World, sizing.Peer, sizingBuf, int.MaxValue));
+            fullSize = sizingBuf.WrittenSpan.Length;
+        }
+
+        using var f = new Fixture(SerialVariantType.Int, SerialVariantType.Int);
+        f.World.CurrentTick = 1;
+        f.Node.Network.DirtyMask = 0b11;
+        f.Serializer.Begin();
+
+        var buf = Buffer();
+        var maxBytes = fullSize - 1;
+        var result = f.Serializer.Export(f.World, f.Peer, buf, maxBytes);
+
+        Assert.Equal(ExportResult.Partial, result);
+        Assert.True(buf.WrittenSpan.Length <= maxBytes);
+        Assert.Equal(0b01, buf.WrittenSpan[0]);
+        Assert.Equal(0b10, f.Serializer.PendingDirtyByteForTests(f.PeerId, 0));
+    }
+
+    // 4. Packet-coupled stamps live in CommitExport: after commit, the exact-tick ack
+    //    clears the pending bits (nothing left unacked); the same ack without a commit
+    //    would find no SentHistory record and clear nothing.
+    [NebulaUnitTest]
+    public void CommittedTickAck_ClearsPending()
+    {
+        using var f = new Fixture(SerialVariantType.Int, SerialVariantType.Int);
+        f.World.CurrentTick = 5;
+        f.Node.Network.DirtyMask = 0b11;
+        f.Serializer.Begin();
+
+        var buf = Buffer();
+        Assert.Equal(ExportResult.Written, f.Serializer.Export(f.World, f.Peer, buf, int.MaxValue));
+        f.Serializer.CommitExport(f.World, f.Peer, 5);
+        Assert.Equal(0b11, f.Serializer.PendingDirtyByteForTests(f.PeerId, 0));
+
+        bool stillPending = f.Serializer.Acknowledge(f.World, f.Peer, 5);
+
+        Assert.False(stillPending);
+        Assert.Equal(0, f.Serializer.PendingDirtyByteForTests(f.PeerId, 0));
+    }
+
+    // 5. Split safety: an ack of a tick whose export was deferred (no committed section,
+    //    no SentHistory record) must NOT clear pending bits stamped by an earlier commit.
+    [NebulaUnitTest]
+    public void DeferredTickAck_DoesNotFalselyClearPending()
+    {
+        using var f = new Fixture(SerialVariantType.Int, SerialVariantType.Int);
+        f.World.CurrentTick = 5;
+        f.Node.Network.DirtyMask = 0b11;
+        f.Serializer.Begin();
+
+        var buf = Buffer();
+        Assert.Equal(ExportResult.Written, f.Serializer.Export(f.World, f.Peer, buf, int.MaxValue));
+        f.Serializer.CommitExport(f.World, f.Peer, 5);
+
+        // Tick 6 is deferred for budget - no section, no record
+        f.World.CurrentTick = 6;
+        f.Serializer.Begin();
+        buf.Reset();
+        Assert.Equal(ExportResult.None, f.Serializer.Export(f.World, f.Peer, buf, 0));
+
+        bool stillPending = f.Serializer.Acknowledge(f.World, f.Peer, 6);
+
+        Assert.True(stillPending);
+        Assert.Equal(0b11, f.Serializer.PendingDirtyByteForTests(f.PeerId, 0));
+
+        // The genuine send-tick ack still lands
+        Assert.False(f.Serializer.Acknowledge(f.World, f.Peer, 5));
+        Assert.Equal(0, f.Serializer.PendingDirtyByteForTests(f.PeerId, 0));
+    }
+}

--- a/addons/Nebula/Testing/Unit/PropsBudgetTests.cs.uid
+++ b/addons/Nebula/Testing/Unit/PropsBudgetTests.cs.uid
@@ -1,0 +1,1 @@
+uid://dse8vbkfe3f32

--- a/addons/Nebula/Testing/Unit/SendWindowTests.cs
+++ b/addons/Nebula/Testing/Unit/SendWindowTests.cs
@@ -1,0 +1,80 @@
+using Nebula.Serialization;
+using Xunit;
+
+namespace Nebula.Testing.Unit;
+
+/// <summary>
+/// SendWindow backs the spawn/despawn ack commit rule under budget splitting: an acked
+/// tick may only commit a record that provably rode that tick's packet. The window is the
+/// contiguous run of send ticks; any budget-deferred tick restarts it, so a stale ack can
+/// at worst cost one extra resend round, never a false commit.
+/// </summary>
+[NebulaUnitTest]
+public class SendWindowTests
+{
+    [NebulaUnitTest]
+    public void NeverSent_CoversNothing()
+    {
+        var window = new SendWindow();
+
+        Assert.False(window.Covers(0));
+        Assert.False(window.Covers(1));
+    }
+
+    [NebulaUnitTest]
+    public void ContiguousSends_CoverTheWholeRun()
+    {
+        var window = new SendWindow();
+        window.RecordSend(10);
+        window.RecordSend(11);
+        window.RecordSend(12);
+
+        Assert.True(window.Covers(10));
+        Assert.True(window.Covers(11));
+        Assert.True(window.Covers(12));
+        Assert.False(window.Covers(9));
+        Assert.False(window.Covers(13));
+    }
+
+    // The budget-splitting scenario: the record rode ticks 10-11, was deferred on 12,
+    // and rode again on 13. An ack of 12 (a packet without the record) must not commit,
+    // and neither may the pre-gap ticks - the client may have dropped those packets and
+    // the server can no longer distinguish "acked 13 because it saw 10" from "saw only 13".
+    [NebulaUnitTest]
+    public void GapRestartsWindow_PreGapTicksNoLongerCovered()
+    {
+        var window = new SendWindow();
+        window.RecordSend(10);
+        window.RecordSend(11);
+        window.RecordSend(13);
+
+        Assert.False(window.Covers(10));
+        Assert.False(window.Covers(11));
+        Assert.False(window.Covers(12));
+        Assert.True(window.Covers(13));
+    }
+
+    [NebulaUnitTest]
+    public void SendAfterGap_ExtendsFromRestart()
+    {
+        var window = new SendWindow();
+        window.RecordSend(5);
+        window.RecordSend(20);
+        window.RecordSend(21);
+
+        Assert.False(window.Covers(5));
+        Assert.True(window.Covers(20));
+        Assert.True(window.Covers(21));
+    }
+
+    [NebulaUnitTest]
+    public void SingleSend_CoversExactlyThatTick()
+    {
+        var window = new SendWindow();
+        window.RecordSend(7);
+
+        Assert.False(window.Covers(6));
+        Assert.True(window.Covers(7));
+        Assert.False(window.Covers(8));
+    }
+}

--- a/addons/Nebula/Testing/Unit/SendWindowTests.cs.uid
+++ b/addons/Nebula/Testing/Unit/SendWindowTests.cs.uid
@@ -1,0 +1,1 @@
+uid://bs5bvw4826p5t

--- a/addons/Nebula/Testing/Unit/TickBudgetLedgerTests.cs
+++ b/addons/Nebula/Testing/Unit/TickBudgetLedgerTests.cs
@@ -1,0 +1,79 @@
+using Nebula.Serialization;
+using Xunit;
+
+namespace Nebula.Testing.Unit;
+
+/// <summary>
+/// TickBudgetLedger mirrors the assembled payload layout of ExportState: 1 byte group
+/// mask, 8 bytes node mask per active 64-node group, 1 serializersRun byte per included
+/// node, then the section payloads. These tests pin the framing charges so the assembled
+/// buffer can never exceed the budget the ledger was constructed with.
+/// </summary>
+[NebulaUnitTest]
+public class TickBudgetLedgerTests
+{
+    [NebulaUnitTest]
+    public void GroupMaskByte_ChargedUpfront()
+    {
+        var ledger = new TickBudgetLedger(100);
+
+        Assert.Equal(100, ledger.Budget);
+        Assert.Equal(1, ledger.Used);
+        Assert.Equal(99, ledger.Remaining);
+    }
+
+    [NebulaUnitTest]
+    public void FirstSectionForNode_ChargesMaskByteAndGroupMask()
+    {
+        var ledger = new TickBudgetLedger(100);
+
+        // First node of a new group: payload 10 + 1 (serializersRun) + 8 (group node mask)
+        Assert.True(ledger.TryCommitSection(10, firstSectionForNode: true, opensNewGroup: true));
+        Assert.Equal(1 + 10 + 1 + 8, ledger.Used);
+
+        // Second section for the same node: payload only
+        Assert.True(ledger.TryCommitSection(5, firstSectionForNode: false, opensNewGroup: false));
+        Assert.Equal(1 + 10 + 1 + 8 + 5, ledger.Used);
+
+        // New node in the already-open group: payload + serializersRun byte
+        Assert.True(ledger.TryCommitSection(7, firstSectionForNode: true, opensNewGroup: false));
+        Assert.Equal(1 + 10 + 1 + 8 + 5 + 7 + 1, ledger.Used);
+    }
+
+    [NebulaUnitTest]
+    public void SectionBudget_SubtractsFramingAndClampsToZero()
+    {
+        var ledger = new TickBudgetLedger(30);
+
+        // Remaining 29; new node in new group costs 9 framing
+        Assert.Equal(20, ledger.SectionBudget(firstSectionForNode: true, opensNewGroup: true));
+        Assert.Equal(28, ledger.SectionBudget(firstSectionForNode: true, opensNewGroup: false));
+        Assert.Equal(29, ledger.SectionBudget(firstSectionForNode: false, opensNewGroup: false));
+
+        Assert.True(ledger.TryCommitSection(20, firstSectionForNode: true, opensNewGroup: true));
+        Assert.Equal(0, ledger.Remaining);
+        Assert.Equal(0, ledger.SectionBudget(firstSectionForNode: true, opensNewGroup: true));
+    }
+
+    [NebulaUnitTest]
+    public void OverBudgetSection_RejectedWithoutCharging()
+    {
+        var ledger = new TickBudgetLedger(20);
+        var usedBefore = ledger.Used;
+
+        // 19 remaining; 11 payload + 9 framing = 20 > 19
+        Assert.False(ledger.TryCommitSection(11, firstSectionForNode: true, opensNewGroup: true));
+        Assert.Equal(usedBefore, ledger.Used);
+
+        // Exactly fitting section commits
+        Assert.True(ledger.TryCommitSection(10, firstSectionForNode: true, opensNewGroup: true));
+        Assert.Equal(0, ledger.Remaining);
+    }
+
+    [NebulaUnitTest]
+    public void TickPayloadBudget_Math()
+    {
+        // MTU 1200 - 4 tick - 1 flags - 2 checksum - 16 headroom
+        Assert.Equal(1177, NetRunner.TickPayloadBudget(1200));
+    }
+}

--- a/addons/Nebula/Testing/Unit/TickBudgetLedgerTests.cs.uid
+++ b/addons/Nebula/Testing/Unit/TickBudgetLedgerTests.cs.uid
@@ -1,0 +1,1 @@
+uid://bt541nujxchqq

--- a/addons/Nebula/Tools/Debugger/NebulaDebugView.cs
+++ b/addons/Nebula/Tools/Debugger/NebulaDebugView.cs
@@ -78,6 +78,39 @@ namespace Nebula.Internal.Editor
         private readonly byte[] readBuffer = new byte[8192];
         private double sinceConnectAttempt;
         private bool loggedFrameError;
+        private bool loggedMetricsError;
+
+        private NebulaPerformanceView performanceView;
+
+        /// <summary>
+        /// Finds the sibling Performance tab, which receives every METRICS frame. This
+        /// view stays the single owner of the debug-channel connections so a second tab
+        /// doesn't double the hub's traffic.
+        ///
+        /// <para>Resolved from the live scene tree on demand rather than wired once as a
+        /// C# event or an injected reference. A .NET assembly reload — which every Play
+        /// press triggers via its build — recreates the managed side of each node and
+        /// DROPS managed state (event subscriptions, plain fields) WITHOUT re-running
+        /// _Ready. A subscription made in NebulaMainScreen._Ready is therefore silently
+        /// dead for the rest of the session: frames arrived, `subscribers=0`, and the
+        /// Performance tab never updated. Re-resolving is reload-proof.</para>
+        /// </summary>
+        private NebulaPerformanceView ResolvePerformanceView()
+        {
+            if (performanceView is not null && GodotObject.IsInstanceValid(performanceView))
+                return performanceView;
+
+            performanceView = null;
+            foreach (var sibling in GetParent()?.GetChildren() ?? new Godot.Collections.Array<Node>())
+            {
+                if (sibling is NebulaPerformanceView found)
+                {
+                    performanceView = found;
+                    break;
+                }
+            }
+            return performanceView;
+        }
 
         public override void _Ready()
         {
@@ -186,8 +219,11 @@ namespace Nebula.Internal.Editor
 
         public override void _Process(double delta)
         {
-            if (!IsVisibleInTree())
-                return;
+            // Drains regardless of visibility. An attached-but-undrained socket fills
+            // until the server's DebugHub write times out and drops the editor client,
+            // which is unrecoverable for the session — so "the user switched tabs" must
+            // never stop the reader. (This also can't be delegated to a flag set from
+            // outside: assembly reloads reset plain fields without re-running _Ready.)
 
             if (!IsDebugServerEnabled)
             {
@@ -354,6 +390,34 @@ namespace Nebula.Internal.Editor
                     if (connection.Panels.TryGetValue(key, out var removed))
                         removed.MarkDisconnected();
                     return;
+
+                case WorldRunner.DebugDataType.METRICS:
+                {
+                    // Handled before the panel lookup: metrics are process-level data
+                    // for the Performance tab, not per-panel state. Guarded because a
+                    // throwing handler would otherwise escape ConsumeFrames before the
+                    // inbox tail-slide, re-parsing (and re-throwing on) the same frame
+                    // every editor frame.
+                    //
+                    // Its own one-shot flag, NOT the shared loggedFrameError: one
+                    // unrelated panel-frame error would otherwise permanently silence
+                    // every metrics failure after it.
+                    try
+                    {
+                        using var metricsBuffer = new NetBuffer(payload, usePool: false);
+                        ResolvePerformanceView()?.OnMetricsReceived(
+                            connection.Port, NetReader.ReadString(metricsBuffer));
+                    }
+                    catch (Exception ex)
+                    {
+                        if (!loggedMetricsError)
+                        {
+                            loggedMetricsError = true;
+                            GD.PushError($"Nebula: metrics frame failed: {ex}");
+                        }
+                    }
+                    return;
+                }
             }
 
             if (!connection.Panels.TryGetValue(key, out var panel))

--- a/addons/Nebula/Tools/Main.cs
+++ b/addons/Nebula/Tools/Main.cs
@@ -402,19 +402,12 @@ public partial class Main : EditorPlugin
             $"--debugPort={serverDebugPort}",
         };
 
+        // List order is spawn order (the orchestrator staggers spawns): bots first, the
+        // player client(s) last. A bot flood saturates the host exactly when a joining
+        // client is doing its heaviest main-thread work (world + player scene builds), and
+        // a client stalled past the server's ack timeout gets force-disconnected - so the
+        // player client only launches once every bot process already exists.
         var clientArgsList = new Godot.Collections.Array();
-        for (int i = 0; i < config.ClientCount; i++)
-        {
-            int clientDebugPort = ReserveLoopbackPort();
-            debugPorts.Add(clientDebugPort);
-            clientArgsList.Add(new[]
-            {
-                "--path", projectPath,
-                "--remote-debug", debugUri,
-                $"--debugPort={clientDebugPort}",
-                $"--clientId={i}",
-            });
-        }
 
         // Bots are ordinary client instances with a behavior attached, so they ride the same
         // orchestrator list rather than needing a launch path of their own. Their clientId
@@ -438,6 +431,19 @@ public partial class Main : EditorPlugin
                 botArgs.Add("--headless");
 
             clientArgsList.Add(botArgs.ToArray());
+        }
+
+        for (int i = 0; i < config.ClientCount; i++)
+        {
+            int clientDebugPort = ReserveLoopbackPort();
+            debugPorts.Add(clientDebugPort);
+            clientArgsList.Add(new[]
+            {
+                "--path", projectPath,
+                "--remote-debug", debugUri,
+                $"--debugPort={clientDebugPort}",
+                $"--clientId={i}",
+            });
         }
 
         GetOrchestrator(createIfMissing: true).Call("launch",

--- a/addons/Nebula/Tools/MainScreen/NebulaMainScreen.cs
+++ b/addons/Nebula/Tools/MainScreen/NebulaMainScreen.cs
@@ -14,11 +14,18 @@ using Nebula.Internal.Editor;
 /// tab body is now the debugger that attaches to whatever the Play button
 /// launched. This class is just the shell; <see cref="NebulaDebugView"/> owns
 /// the connections and the per-world panels.
+///
+/// <para>The body is a Debugger/Performance tab pair. The Performance tab is
+/// always present; whether it has data depends on the servers, which only
+/// collect and report metrics when <see cref="Diagnostics.ServerMetrics.EnableEnvVar"/>
+/// is set for them (process environment or .env.server) — a production instance
+/// spends nothing on metrics unless asked.</para>
 /// </summary>
 [Tool]
 public partial class NebulaMainScreen : Control
 {
     private NebulaDebugView debugView;
+    private NebulaPerformanceView performanceView;
 
     public override void _Ready()
     {
@@ -42,7 +49,27 @@ public partial class NebulaMainScreen : Control
             SizeFlagsHorizontal = SizeFlags.ExpandFill,
             SizeFlagsVertical = SizeFlags.ExpandFill,
         };
-        margin.AddChild(debugView);
+
+        var tabs = new TabContainer
+        {
+            SizeFlagsHorizontal = SizeFlags.ExpandFill,
+            SizeFlagsVertical = SizeFlags.ExpandFill,
+        };
+        margin.AddChild(tabs);
+
+        // Child node names become tab titles.
+        debugView.Name = "Debugger";
+        tabs.AddChild(debugView);
+
+        performanceView = new NebulaPerformanceView();
+        tabs.AddChild(performanceView);
+
+        // Deliberately NO wiring between the two here. Anything established in _Ready
+        // (an event subscription, an injected reference) is lost on the next .NET
+        // assembly reload, which recreates the managed instances without re-running
+        // _Ready — the tabs then look correct while quietly delivering nothing. The
+        // debug view resolves this Performance tab from the tree per frame instead;
+        // see NebulaDebugView.ResolvePerformanceView.
     }
 
     /// <summary>

--- a/addons/Nebula/Tools/MainScreen/NebulaPerformanceView.cs
+++ b/addons/Nebula/Tools/MainScreen/NebulaPerformanceView.cs
@@ -1,0 +1,255 @@
+namespace Nebula.Tools;
+
+#if TOOLS
+
+using System.Collections.Generic;
+using Godot;
+
+/// <summary>
+/// "Performance" tab of the Nebula main screen: one live row per server world,
+/// fed by the ServerMetrics JSON lines that ride the debug channel (~1/s per
+/// world). Always present; it has data only when the server is collecting, which
+/// <see cref="Nebula.Diagnostics.ServerMetrics.EnableEnvVar"/> gates server-side
+/// (process environment or .env.server) so production instances spend nothing.
+///
+/// <para>This view owns no sockets: <see cref="Internal.Editor.NebulaDebugView"/>
+/// keeps the debug-channel connections and forwards METRICS frames here, so the
+/// tab adds no traffic to the hub.</para>
+/// </summary>
+[Tool]
+public partial class NebulaPerformanceView : Control
+{
+    private Tree table;
+    private Label placeholder;
+
+    /// <summary>Row per (process port, world id); updated in place each metrics line.</summary>
+    private readonly Dictionary<string, TreeItem> rows = new();
+
+    private enum Column
+    {
+        World,
+        Peers,
+        TickP50,
+        TickP95,
+        TickMax,
+        BytesPerPeer,
+        PayloadP50,
+        PayloadP95,
+        PayloadP99,
+        PayloadMax,
+        Deferred,
+        SpawnBacklog,
+        AckTimeouts,
+        MtuExceeded,
+        Gc,
+    }
+
+    /// <summary>
+    /// Column definitions. MinWidth is explicit and no column expands: leaving one
+    /// column expanding handed it every spare pixel (World was enormous) while the
+    /// rest were autosized down until their contents clipped (GC).
+    /// </summary>
+    private static readonly (Column Col, string Title, string Tooltip, int MinWidth)[] Columns =
+    {
+        (Column.World, "World", "World id (first 8 chars) @ process debug port", 420),
+        (Column.Peers, "Peers", "Connected peers", 60),
+        (Column.TickP50, "Tick p50", "Server tick time, median (ms)", 72),
+        (Column.TickP95, "Tick p95", "Server tick time, 95th percentile (ms)", 72),
+        (Column.TickMax, "Tick max", "Server tick time, worst in window (ms)", 72),
+        (Column.BytesPerPeer, "B/peer/s", "Outgoing bytes per peer per second (post-compression, on the wire)", 84),
+        (Column.PayloadP50, "Size p50", "Per-peer tick payload, median (bytes, pre-compression)", 72),
+        (Column.PayloadP95, "Size p95", "Per-peer tick payload, 95th percentile (bytes, pre-compression)", 72),
+        (Column.PayloadP99, "Size p99", "Per-peer tick payload, 99th percentile (bytes, pre-compression)", 72),
+        (Column.PayloadMax, "Size max", "Largest per-peer tick payload / the budget cap. Splitting keeps this at or under the cap.", 220),
+        (Column.Deferred, "Deferred s/p", "Spawn / props sections deferred for budget this window", 96),
+        (Column.SpawnBacklog, "Backlog", "Worst per-peer count of in-flight (Spawning) spawn records", 70),
+        (Column.AckTimeouts, "Ack TO", "Peers force-disconnected for ack timeout this window", 64),
+        (Column.MtuExceeded, "MTU", "Packets exceeding the MTU this window (must be 0)", 56),
+        (Column.Gc, "GC", "Gen0/1/2 collections this window (netcode target: 0/0/0)", 138),
+    };
+
+    private const string TableName = "MetricsTable";
+    private const string PlaceholderName = "MetricsPlaceholder";
+
+    public override void _Ready()
+    {
+        Name = "Performance";
+        SetAnchorsPreset(LayoutPreset.FullRect);
+        SizeFlagsHorizontal = SizeFlags.ExpandFill;
+        SizeFlagsVertical = SizeFlags.ExpandFill;
+        EnsureUi();
+    }
+
+    /// <summary>
+    /// Binds <see cref="table"/> and <see cref="placeholder"/>, building them on first
+    /// use. Also the recovery path after a .NET assembly reload: that recreates this
+    /// node's managed side — dropping both references and the <see cref="rows"/> map —
+    /// WITHOUT re-running _Ready, while the engine-side children survive. Silently
+    /// dropping every metric in that state is exactly the kind of failure that looks
+    /// like "the feature is broken", so re-bind instead of assuming _Ready ran.
+    /// </summary>
+    private bool EnsureUi()
+    {
+        if (table is not null && GodotObject.IsInstanceValid(table)
+            && placeholder is not null && GodotObject.IsInstanceValid(placeholder))
+            return true;
+
+        table = FindChild(TableName, recursive: true, owned: false) as Tree;
+        placeholder = FindChild(PlaceholderName, recursive: true, owned: false) as Label;
+
+        if (table is not null && placeholder is not null)
+        {
+            // Re-bound after a reload: the row map is gone but the engine-side items
+            // remain, so start the table over rather than appending duplicates. Rows
+            // repopulate on the next report, a second later.
+            rows.Clear();
+            table.Clear();
+            table.CreateItem();
+            UpdatePlaceholder();
+            return true;
+        }
+
+        BuildUi();
+        return table is not null;
+    }
+
+    private void BuildUi()
+    {
+        var rootVBox = new VBoxContainer
+        {
+            SizeFlagsHorizontal = SizeFlags.ExpandFill,
+            SizeFlagsVertical = SizeFlags.ExpandFill,
+        };
+        rootVBox.SetAnchorsPreset(LayoutPreset.FullRect);
+        rootVBox.AddThemeConstantOverride("separation", 6);
+        AddChild(rootVBox);
+
+        table = new Tree
+        {
+            Name = TableName,
+            SizeFlagsHorizontal = SizeFlags.ExpandFill,
+            SizeFlagsVertical = SizeFlags.ExpandFill,
+            HideRoot = true,
+            Columns = Columns.Length,
+            ColumnTitlesVisible = true,
+            SelectMode = Tree.SelectModeEnum.Row,
+        };
+        for (int i = 0; i < Columns.Length; i++)
+        {
+            table.SetColumnTitle(i, Columns[i].Title);
+            table.SetColumnTitleTooltipText(i, Columns[i].Tooltip);
+            table.SetColumnCustomMinimumWidth(i, Columns[i].MinWidth);
+            table.SetColumnExpand(i, false);
+        }
+        table.CreateItem(); // hidden root
+        rootVBox.AddChild(table);
+
+        placeholder = new Label
+        {
+            Name = PlaceholderName,
+            Text = "No metrics — the server reports only when NEBULA_PERFORMANCE is set"
+                + " (environment variable or .env entry). Independent of NEBULA_DEBUG.",
+            HorizontalAlignment = HorizontalAlignment.Center,
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+        placeholder.SetAnchorsPreset(LayoutPreset.FullRect);
+        placeholder.AddThemeColorOverride("font_color", new Color(1, 1, 1, 0.4f));
+        AddChild(placeholder);
+        UpdatePlaceholder();
+    }
+
+    /// <summary>
+    /// Called by <see cref="Internal.Editor.NebulaDebugView"/> for each METRICS frame,
+    /// which resolves this node from the tree per frame. One call per world per second;
+    /// parsing at that rate is free.
+    /// </summary>
+    public void OnMetricsReceived(int port, string json)
+    {
+        if (!EnsureUi())
+            return;
+
+        var parsed = Json.ParseString(json);
+        if (parsed.VariantType != Variant.Type.Dictionary)
+            return;
+        var data = parsed.AsGodotDictionary();
+
+        string worldId = data.TryGetValue("world", out var worldVar) ? worldVar.AsString() : "?";
+        string rowKey = $"{port}:{worldId}";
+
+        if (!rows.TryGetValue(rowKey, out var row) || !GodotObject.IsInstanceValid(row))
+        {
+            row = table.CreateItem(table.GetRoot());
+            string shortWorld = worldId.Length > 8 ? worldId[..8] : worldId;
+            row.SetText((int)Column.World, $"{shortWorld} @ :{port}");
+            row.SetTooltipText((int)Column.World, worldId);
+            rows[rowKey] = row;
+            UpdatePlaceholder();
+        }
+
+        var tickMs = GetDict(data, "tick_ms");
+        var payload = GetDict(data, "payload");
+        var budget = GetDict(data, "budget");
+
+        row.SetText((int)Column.Peers, GetInt(data, "peers").ToString());
+        row.SetText((int)Column.TickP50, $"{GetFloat(tickMs, "p50"):F1}");
+        row.SetText((int)Column.TickP95, $"{GetFloat(tickMs, "p95"):F1}");
+        row.SetText((int)Column.TickMax, $"{GetFloat(tickMs, "max"):F1}");
+        row.SetText((int)Column.BytesPerPeer, GetInt(data, "bytes_per_peer_s").ToString());
+        row.SetText((int)Column.PayloadP50, GetInt(payload, "p50").ToString());
+        row.SetText((int)Column.PayloadP95, GetInt(payload, "p95").ToString());
+        row.SetText((int)Column.PayloadP99, GetInt(payload, "p99").ToString());
+
+        // Shown against the cap so "is this near the limit?" needs no second lookup.
+        int payloadMax = GetInt(payload, "max");
+        int cap = GetInt(payload, "cap");
+        row.SetText((int)Column.PayloadMax, cap > 0 ? $"{payloadMax} / {cap}" : payloadMax.ToString());
+
+        row.SetText((int)Column.Deferred, $"{GetInt(budget, "spawn_deferred")}/{GetInt(budget, "props_deferred")}");
+        row.SetText((int)Column.SpawnBacklog, GetInt(budget, "spawn_backlog_max").ToString());
+        SetCountCell(row, Column.AckTimeouts, GetInt(data, "ack_timeouts"));
+        SetCountCell(row, Column.MtuExceeded, GetInt(data, "mtu_exceeded"));
+
+        string gc = "?";
+        if (data.TryGetValue("gc", out var gcVar) && gcVar.VariantType == Variant.Type.Array)
+        {
+            var gcArray = gcVar.AsGodotArray();
+            if (gcArray.Count == 3)
+                gc = $"{gcArray[0].AsInt32()}/{gcArray[1].AsInt32()}/{gcArray[2].AsInt32()}";
+        }
+        row.SetText((int)Column.Gc, gc);
+    }
+
+    /// <summary>Zero renders plain; any failure count renders in the editor's error red.</summary>
+    private void SetCountCell(TreeItem row, Column column, int count)
+    {
+        row.SetText((int)column, count.ToString());
+        if (count > 0)
+        {
+            row.SetCustomColor((int)column, new Color(1.0f, 0.47f, 0.42f));
+        }
+        else
+        {
+            row.ClearCustomColor((int)column);
+        }
+    }
+
+    private static Godot.Collections.Dictionary GetDict(Godot.Collections.Dictionary data, string key)
+        => data.TryGetValue(key, out var value) && value.VariantType == Variant.Type.Dictionary
+            ? value.AsGodotDictionary()
+            : new Godot.Collections.Dictionary();
+
+    private static int GetInt(Godot.Collections.Dictionary data, string key)
+        => data.TryGetValue(key, out var value) ? value.AsInt32() : 0;
+
+    private static float GetFloat(Godot.Collections.Dictionary data, string key)
+        => data.TryGetValue(key, out var value) ? (float)value.AsDouble() : 0f;
+
+    private void UpdatePlaceholder()
+    {
+        if (placeholder is null)
+            return;
+        placeholder.Visible = rows.Count == 0;
+    }
+}
+
+#endif // TOOLS

--- a/addons/Nebula/Tools/MainScreen/NebulaPerformanceView.cs.uid
+++ b/addons/Nebula/Tools/MainScreen/NebulaPerformanceView.cs.uid
@@ -1,0 +1,1 @@
+uid://dkbe133vkytf1

--- a/addons/Nebula/Tools/MainScreen/nebula_play_orchestrator.gd
+++ b/addons/Nebula/Tools/MainScreen/nebula_play_orchestrator.gd
@@ -17,7 +17,16 @@ signal log_line(line: String)
 
 const MAX_LOG_LINES := 200
 
+## Pacing between client spawns: at most 10 instances per second. The C# tab
+## orders client_args_list bots-first / player-clients-last, so this both keeps
+## a bot flood from saturating the host in one burst and guarantees the player
+## client spawns only after every bot process exists.
+const CLIENT_SPAWN_INTERVAL_SEC := 0.1
+
 var _pids: Array[int] = []
+## Bumped by stop() so a staggered launch coroutine that is still awaiting
+## between spawns notices the session ended and stops spawning.
+var _launch_generation := 0
 var _config_name: String = ""
 var _log_lines: PackedStringArray = PackedStringArray()
 ## Nebula debug-channel ports baked into the launch arguments, in spawn order
@@ -52,7 +61,16 @@ func _do_launch(dummy_scene: String, exe: String, server_args: PackedStringArray
 	else:
 		failed = true
 
+	var generation := _launch_generation
+	var first_client := true
 	for client_args in client_args_list:
+		if first_client:
+			first_client = false
+		else:
+			await get_tree().create_timer(CLIENT_SPAWN_INTERVAL_SEC).timeout
+		if generation != _launch_generation:
+			_log("[play] launch cancelled mid-stagger; remaining instances not spawned")
+			return
 		var client_pid := OS.create_process(exe, client_args)
 		_log("[play] client pid %d: %s" % [client_pid, " ".join(client_args)])
 		if client_pid > 0:
@@ -69,6 +87,7 @@ func _do_launch(dummy_scene: String, exe: String, server_args: PackedStringArray
 	state_changed.emit()
 
 func stop() -> void:
+	_launch_generation += 1
 	for pid in _pids:
 		var err := OS.kill(pid)
 		if err == OK:

--- a/addons/Nebula/Tools/ProjectSettingsController.cs
+++ b/addons/Nebula/Tools/ProjectSettingsController.cs
@@ -118,6 +118,23 @@ public partial class ProjectSettingsController : Node
             {"hint_string", "100,65535,1"},
         });
 
+        // Liveness cutoff for in-world peers: seconds without a tick ack before the
+        // server force-disconnects.
+        Register(NetRunner.ACK_TIMEOUT_SETTING, NetRunner.DefaultAckTimeoutSeconds, new(){
+            {"type", (int)Variant.Type.Float},
+            {"hint", (int)PropertyHint.Range},
+            {"hint_string", "1,300,0.5"},
+        });
+
+        // Same cutoff for a JOINING peer (never acked yet): its first ack only follows
+        // boot + world-scene load + a successfully imported tick, so it needs far more
+        // headroom than the in-world cutoff.
+        Register(NetRunner.JOIN_ACK_TIMEOUT_SETTING, NetRunner.DefaultJoinAckTimeoutSeconds, new(){
+            {"type", (int)Variant.Type.Float},
+            {"hint", (int)PropertyHint.Range},
+            {"hint_string", "1,300,0.5"},
+        });
+
         // Network tick rate in ticks per second. The network tick fires on whole physics
         // frames, so this should divide physics/common/physics_ticks_per_second evenly
         // (with 60 physics: 60, 30, 20, 15, 12, 10, ...); anything else snaps to the

--- a/addons/Nebula/Utils/Env/Env.cs
+++ b/addons/Nebula/Utils/Env/Env.cs
@@ -102,6 +102,33 @@ namespace Nebula.Utility.Tools
             Instance = this;
         }
 
+        /// <summary>
+        /// Reads a boolean switch from the process environment, falling back to this
+        /// process's .env file (<c>.env.server</c> or <c>.env.client</c>). <c>"0"</c> and
+        /// <c>"false"</c> mean off; any other non-empty value means on.
+        /// </summary>
+        /// <returns>
+        /// False when the variable is absent everywhere, leaving <paramref name="value"/>
+        /// untouched — callers use that to fall back to a project setting rather than
+        /// treating "unset" as "off".
+        /// </returns>
+        public static bool TryGetFlag(string name, out bool value)
+        {
+            value = false;
+
+            // Instance is null in contexts that run no autoloads (the editor, bare unit
+            // tests); the process environment is still readable there.
+            string raw = Instance is not null
+                ? Instance.GetValue(name)
+                : (OS.HasEnvironment(name) ? OS.GetEnvironment(name) : "");
+
+            if (string.IsNullOrEmpty(raw))
+                return false;
+
+            value = raw != "0" && !raw.Equals("false", StringComparison.OrdinalIgnoreCase);
+            return true;
+        }
+
         public string GetValue(string valuename)
         {
             if (OS.HasEnvironment(valuename))

--- a/test/NebulaTests.csproj
+++ b/test/NebulaTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Godot.NET.Sdk/4.5.1">
+<Project Sdk="Godot.NET.Sdk/4.7.1">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <EnableDynamicLoading>true</EnableDynamicLoading>


### PR DESCRIPTION
Large worlds could serialize a per-peer tick payload past the MTU, and the baseline search had become the single most expensive thing the server did. This splits the payload across ticks, makes the pack search cheap, and adds the instrumentation that made both problems visible in the first place.

Budgeted serialization
- TickBudgetLedger charges every byte that lands in the assembled payload (group mask, per-node serializersRun byte, per-group node mask) so the finished packet can never exceed NetRunner.TickPayloadBudget(MTU).
- ExportState runs three explicit phases: spawns (world order, first-fit), props (round-robin from a per-peer cursor so early nodes cannot starve later ones), then interest resync.
- IStateSerializer.Export takes a byte budget and returns ExportResult; packet-coupled state moves out of Export into a new CommitExport, which the host calls only when the bytes actually ride the packet. A dropped atomic record now retries cleanly instead of stamping state for bytes that were discarded.
- SpawnSerializer tracks per-peer SendWindows instead of bare send ticks: an ack commits a spawn/despawn only when that tick's packet provably carried the record. Budget deferral can gap the resend stream, which the old unbounded `tick >= setupTick` rule assumed could never happen.
- NetPropertiesSerializer self-limits, rewinding a property that would overflow the section and banking its bit in PendingDirtyMask so a budget-skipped peer cannot silently lose a change.
- PropsMayRidePacket keeps a props section for an uncommitted spawn off any packet that does not also carry the id, closing the "Data for unknown node" import abort by construction.

NebulaPack
- PickBaseline is now two-stage: rank ~29 acked candidates by differing 32-byte block digests (computed once per payload stored), then measure only the top 3 exactly, each bounded by the best size so far. Previously every candidate paid a full encode pass over the payload, which measured 26% of the world tick.
- The delta scan steps a machine word at a time instead of calling CommonPrefixLength, whose SIMD setup cost dominated at the sub-two-byte match runs live traffic actually produces.
- BsonWriteBuffer pools and reuses the save buffer, so a periodic large save stops churning ~3.5 MB of large-object traffic per emit.

Diagnostics
- TickProfiler (NEBULA_PROFILE) reports per-phase tick timing in-process, because attaching a sampling profiler doubles tick time and attributes most of it to thread-suspension artifacts.
- ServerMetrics gains payload-size percentiles against the budget cap, deferred-section counts and spawn backlog, and now also ships its line over the debug channel to a new editor Performance tab.
- DebugHub gets a priority lane so once-a-second telemetry is not starved by the per-peer-per-tick frame flood, and a DebugFramesEnabled flag so NEBULA_PERFORMANCE can use the socket without NEBULA_DEBUG paying for per-tick debug work.

Ack timeouts
- Joining peers get their own longer window (default 30s vs 5s), measured from join rather than from first ack: a client's heaviest silent stretch is world-scene load and mirror build, which happens after its first few acks. Both are now project settings.

Also: the play orchestrator staggers instance spawns and launches bots before player clients, so a bot flood cannot stall a joining client past the ack timeout. Godot SDK moves to 4.7.1 to match the toolchain.

Adds unit coverage for the ledger, send window, export rotation, props budgeting, the word-at-a-time scan, and the BSON buffer. 262 tests pass.