### PR TITLE
Seed the value-property cache, and add an allocation-free main-thread hop

### DIFF
--- a/addons/Nebula/Core/Diagnostics/ServerMetrics.cs
+++ b/addons/Nebula/Core/Diagnostics/ServerMetrics.cs
@@ -256,7 +256,6 @@ namespace Nebula.Diagnostics
             _line.Append(",\"spawn_backlog_max\":").Append(_spawnBacklogMax).Append('}');
             _line.Append('}');
 
-            GD.Print(_line.ToString());
             string json = _line.ToString(LinePrefix.Length, _line.Length - LinePrefix.Length);
 
             _windowStartUsec = Time.GetTicksUsec();

--- a/addons/Nebula/Core/NebulaThread.cs
+++ b/addons/Nebula/Core/NebulaThread.cs
@@ -19,6 +19,24 @@ namespace Nebula
     /// compile out entirely in release builds, so annotate freely: any method that mutates
     /// cross-world state, touches the SceneTree, or assumes serial execution is a candidate.
     /// </summary>
+    /// <summary>
+    /// Something a long-lived object can hand to <c>NetRunner.RunOnMainThread</c> without allocating.
+    ///
+    /// The point is that the caller IS the work item: it passes <c>this</c>, so there is no delegate to
+    /// construct and no closure to capture. A lambda would allocate on every deferral, which is fine at
+    /// join/leave frequency and is not fine for anything a world tick can reach repeatedly.
+    ///
+    /// Implement it on the object that owns the state being changed, so what runs on the main thread
+    /// stays next to what it touches.
+    /// </summary>
+    public interface IMainThreadWork
+    {
+        /// <param name="tag">Which job, for an implementer that defers more than one kind of work.
+        /// Handed back exactly as it was passed, so no per-job state has to be stored to tell them
+        /// apart.</param>
+        void OnMainThread(int tag);
+    }
+
     public static class NebulaThread
     {
         /// <summary>

--- a/addons/Nebula/Core/NetRunner.cs
+++ b/addons/Nebula/Core/NetRunner.cs
@@ -708,12 +708,42 @@ namespace Nebula
         /// entry allocates a closure, which is fine at join/leave frequency and would not be inside
         /// ExportState. Callers already on the main thread run inline and never queue.
         /// </summary>
-        private readonly Queue<Action> _mainThreadWork = new();
+        private readonly Queue<MainThreadItem> _mainThreadWork = new();
         private readonly object _mainThreadWorkLock = new();
+
+        /// <summary>
+        /// One queued job, in whichever of the two forms the caller had.
+        ///
+        /// A struct so the queue itself never allocates per item, and ONE queue rather than two so
+        /// both forms keep a single, obvious execution order -- a peer join queued as a closure and a
+        /// node's state change queued as an interface still run in the order they were asked for.
+        /// </summary>
+        private readonly struct MainThreadItem
+        {
+            private readonly Action _action;
+            private readonly IMainThreadWork _work;
+            private readonly int _tag;
+
+            internal MainThreadItem(Action action) { _action = action; _work = null; _tag = 0; }
+            internal MainThreadItem(IMainThreadWork work, int tag) { _action = null; _work = work; _tag = tag; }
+
+            internal void Run()
+            {
+                if (_action != null) _action();
+                else _work?.OnMainThread(_tag);
+            }
+        }
 
         /// <summary>
         /// Runs <paramref name="work"/> on the main thread: inline if already there, otherwise
         /// queued for the next <see cref="_PhysicsProcess"/>.
+        ///
+        /// Allocates a delegate (and a display class, if the lambda captures) per call, which is why
+        /// this form is for one-off lifecycle events. A caller that defers REPEATEDLY should implement
+        /// <see cref="IMainThreadWork"/> and use the overload below instead.
+        ///
+        /// This overload cannot go away even so: <c>INotifyCompletion.OnCompleted</c> hands its
+        /// continuation over as an <see cref="Action"/>, so <see cref="SwitchToMainThread"/> needs it.
         /// </summary>
         internal void RunOnMainThread(Action work)
         {
@@ -722,9 +752,36 @@ namespace Nebula
                 work();
                 return;
             }
+            Enqueue(new MainThreadItem(work));
+        }
+
+        /// <summary>
+        /// The same hop, with NOTHING allocated.
+        ///
+        /// The caller is the work: a long-lived object implements <see cref="IMainThreadWork"/> and
+        /// hands over <c>this</c>, so there is no delegate to construct and no closure to capture. Use
+        /// it wherever the deferral happens often enough that a per-call allocation would show up --
+        /// anything reached from a world tick rather than from a join or a world creation.
+        /// </summary>
+        /// <param name="tag">Which job, for an object that defers more than one kind of work. Passed
+        /// straight back, so the callee needs no state to tell them apart.</param>
+        internal void RunOnMainThread(IMainThreadWork work, int tag = 0)
+        {
+            if (work == null) return;
+
+            if (NebulaThread.IsMain)
+            {
+                work.OnMainThread(tag);
+                return;
+            }
+            Enqueue(new MainThreadItem(work, tag));
+        }
+
+        private void Enqueue(in MainThreadItem item)
+        {
             lock (_mainThreadWorkLock)
             {
-                _mainThreadWork.Enqueue(work);
+                _mainThreadWork.Enqueue(item);
             }
         }
 
@@ -791,7 +848,7 @@ namespace Nebula
 
             while (pending-- > 0)
             {
-                Action work;
+                MainThreadItem work;
                 lock (_mainThreadWorkLock)
                 {
                     if (!_mainThreadWork.TryDequeue(out work)) return;
@@ -799,7 +856,7 @@ namespace Nebula
 
                 try
                 {
-                    work();
+                    work.Run();
                 }
                 catch (Exception ex)
                 {
@@ -1242,7 +1299,7 @@ namespace Nebula
         /// and only once it acks is the peer admitted to the target — so the target streams no state into
         /// a not-yet-reset client (the World channel and the tick channel are not cross-channel ordered).
         /// The peer joins the target as INITIAL and transitions to IN_WORLD on its first tick ack, which
-        /// fires the target's PlayerSpawnManager to (re)spawn the player under the same identity.
+        /// raises OnPlayerJoined on the target so it can (re)spawn the player under the same identity.
         /// </summary>
         public void MigratePeerToWorld(NetPeer peer, WorldRunner target)
         {
@@ -1369,8 +1426,7 @@ namespace Nebula
         /// <param name="onTreeReady">
         /// Runs on the main thread once the world is in the tree and network-prepared, but before
         /// it goes Live. This is where per-world infrastructure a caller wants in place before any
-        /// peer can join belongs -- a PlayerSpawnManager, say. Attaching it after awaiting would be
-        /// a race against the first join.
+        /// peer can join belongs. Attaching it after awaiting would be a race against the first join.
         /// </param>
         public async Task<WorldRunner> CreateWorld(
             UUID worldId,

--- a/addons/Nebula/Core/NetworkController.cs
+++ b/addons/Nebula/Core/NetworkController.cs
@@ -1113,6 +1113,49 @@ namespace Nebula
 		}
 
 		/// <summary>
+		/// Records a property's starting value in the cache WITHOUT marking it dirty.
+		///
+		/// The cache is otherwise only written by <see cref="MarkDirty"/>, which fires on a CHANGE, so
+		/// a property whose value never differs from its inline initializer is never cached at all and
+		/// the cache reads default(T) for it forever. That is invisible for most properties, because
+		/// both roles run the same initializer and the property itself is correct on both. It is fatal
+		/// for a PREDICTED one: the generated StoreConfirmedState sources the server's confirmed value
+		/// from this cache rather than from the property, so reconciliation compares against default(T)
+		/// on every tick -- and since a miss on any one predicted property restores ALL of them, a
+		/// single such property drags the whole entity backwards at the tick rate.
+		/// PlayerCharacter.HeightAboveTerrain (inline 1f, and 1f at every spawn and while grounded) did
+		/// exactly that.
+		///
+		/// Deliberately does NOT touch <see cref="DirtyMask"/>. Begin() derives nonDefaultProperties --
+		/// "which properties have ever been set", and therefore what a NEW peer is sent -- from the
+		/// dirty mask, on the sound assumption that an unset property is still at its default. Seeding
+		/// through MarkDirty would put every property on that list and change what goes on the wire at
+		/// spawn. The cache is the only thing that was wrong, so the cache is the only thing corrected.
+		///
+		/// Safe to seed identically on both roles, and it must be done on both: the value is the type's
+		/// own initializer, which both sides evaluate the same way, so this leaves the two caches
+		/// agreeing exactly as they did when both held default(T). Any property whose real value
+		/// differs from its initializer goes dirty through the normal path and overwrites this.
+		/// </summary>
+		internal void SeedCachedValue<T>(INetNodeBase sourceNode, string propertyName, T value) where T : struct
+		{
+			// Static children propagate to the parent net scene, which owns the cache.
+			if (!IsNetScene())
+			{
+				NetParent?.SeedCachedValue(sourceNode, propertyName, value);
+				return;
+			}
+
+			var staticChildId = sourceNode.Network.StaticChildId;
+			if (!Protocol.LookupPropertyByStaticChildId(NetSceneFilePath, staticChildId, propertyName, out var prop))
+			{
+				return;
+			}
+
+			SetCachedValue(prop.Index, prop.VariantType, value);
+		}
+
+		/// <summary>
 		/// Marks a reference-type property as dirty and caches its value.
 		/// Called by generated On{Prop}Changed methods.
 		/// </summary>

--- a/addons/Nebula/Generator/NetPropertyGenerator.cs
+++ b/addons/Nebula/Generator/NetPropertyGenerator.cs
@@ -701,12 +701,24 @@ public class NetPropertyGenerator : IIncrementalGenerator
             // Called from _NetworkPrepare. Automatic (based on the type implementing INetSerializable),
             // so a mutable object NetProperty can no longer silently "replicate empty" by forgetting a marker.
             var serializableObjectProps = propList.Where(p => p!.ImplementsINetSerializable).ToList();
-            if (serializableObjectProps.Count > 0)
+
+            // Value properties are seeded CACHE-ONLY -- see NetworkController.SeedCachedValue for why
+            // that must not go through MarkDirty. Per-peer properties are excluded: their storage is
+            // per-peer dictionaries rather than the shared cache.
+            var seedableValueProps = propList
+                .Where(p => p != null && p.IsValueType && !p.ImplementsINetSerializable && !p.IsPerPeer)
+                .ToList();
+
+            if (serializableObjectProps.Count > 0 || seedableValueProps.Count > 0)
             {
                 sb.AppendLine("    /// <summary>");
-                sb.AppendLine("    /// Seeds the network property cache for INetSerializable object properties initialized inline.");
-                sb.AppendLine("    /// Inline initialization bypasses the property setter, so without this the every-tick");
-                sb.AppendLine("    /// object serializer would read a null cache and ship empty. Called from _NetworkPrepare.");
+                sb.AppendLine("    /// Seeds the network property cache for properties initialized inline.");
+                sb.AppendLine("    ///");
+                sb.AppendLine("    /// Inline initialization bypasses the property setter, so the cache never learns the value.");
+                sb.AppendLine("    /// INetSerializable objects are marked dirty here, because the every-tick object serializer");
+                sb.AppendLine("    /// would otherwise read a null cache and ship empty. Value properties are seeded WITHOUT");
+                sb.AppendLine("    /// being marked dirty, so what a new peer receives is unchanged -- see");
+                sb.AppendLine("    /// NetworkController.SeedCachedValue. Called from _NetworkPrepare.");
                 sb.AppendLine("    /// </summary>");
                 sb.AppendLine("    internal override void InitializeNetPropertyBindings()");
                 sb.AppendLine("    {");
@@ -722,6 +734,11 @@ public class NetPropertyGenerator : IIncrementalGenerator
                     // no per-mutation callback: object properties self-filter every tick (their per-peer
                     // sync state lives in the serializer).
                     sb.AppendLine($"        if ({prop.PropertyName} != null) Network.MarkDirtyRef(this, \"{prop.PropertyName}\", {prop.PropertyName});");
+                }
+
+                foreach (var prop in seedableValueProps)
+                {
+                    sb.AppendLine($"        Network.SeedCachedValue(this, \"{prop!.PropertyName}\", {prop.PropertyName});");
                 }
 
                 sb.AppendLine("    }");

--- a/addons/Nebula/Testing/Unit/InboundPacketQueueTests.cs
+++ b/addons/Nebula/Testing/Unit/InboundPacketQueueTests.cs
@@ -303,4 +303,120 @@ public class MainThreadWorkQueueTests
         // resume the caller ON the draining thread itself.
         Assert.Equal(System.Environment.CurrentManagedThreadId, resumedOnThread);
     }
+
+    // ---- Allocation-free form -------------------------------------------------------------------
+
+    /// <summary>A work item that is also the thing being changed, which is the whole point: handing
+    /// over `this` costs nothing, where a lambda would allocate.</summary>
+    private sealed class Recorder : IMainThreadWork
+    {
+        internal readonly List<int> Tags = new();
+        internal int Thread;
+
+        public void OnMainThread(int tag)
+        {
+            Tags.Add(tag);
+            Thread = System.Environment.CurrentManagedThreadId;
+        }
+    }
+
+    [NebulaUnitTest]
+    public void TestWorkItemRunsInlineWhenAlreadyOnMainThread()
+    {
+        var recorder = new Recorder();
+        NetRunner.Instance.RunOnMainThread(recorder, 7);
+
+        Assert.Equal(new[] { 7 }, recorder.Tags);
+    }
+
+    [NebulaUnitTest]
+    public void TestWorkItemDefersAndCarriesItsTag()
+    {
+        var recorder = new Recorder();
+
+        var worker = new Thread(() => NetRunner.Instance.RunOnMainThread(recorder, 42));
+        worker.Start();
+        Assert.True(worker.Join(10_000), "worker thread did not finish");
+
+        Assert.Empty(recorder.Tags);
+
+        Drain();
+        Assert.Equal(new[] { 42 }, recorder.Tags);
+        Assert.Equal(System.Environment.CurrentManagedThreadId, recorder.Thread);
+    }
+
+    /// <summary>
+    /// The two forms share one queue, so they must also share one order. A closure queued before a
+    /// work item has to run before it -- otherwise a peer join and the node change that depends on it
+    /// could swap places.
+    /// </summary>
+    [NebulaUnitTest]
+    public void TestBothFormsKeepOneOrder()
+    {
+        var order = new List<string>();
+        var recorder = new Recorder();
+
+        var worker = new Thread(() =>
+        {
+            NetRunner.Instance.RunOnMainThread(() => order.Add("action"));
+            NetRunner.Instance.RunOnMainThread(recorder, 1);
+            NetRunner.Instance.RunOnMainThread(() => order.Add("after"));
+        });
+        worker.Start();
+        Assert.True(worker.Join(10_000), "worker thread did not finish");
+
+        Drain();
+
+        Assert.Equal(new[] { "action", "after" }, order);
+        Assert.Equal(new[] { 1 }, recorder.Tags);
+    }
+
+    /// <summary>
+    /// The reason this overload exists: deferring through the work-item form must allocate NOTHING,
+    /// where the closure form allocates a delegate (and a display class) every single time.
+    ///
+    /// Measured on the WORKER, deliberately. The main-thread path short-circuits to an inline call and
+    /// never touches the queue, so measuring there would pass no matter what the queued path did --
+    /// which is exactly the false confidence this test exists to avoid.
+    ///
+    /// The closure figure is asserted too, as the control: if it ever reads zero the measurement itself
+    /// has stopped working, and a green "allocates nothing" would mean nothing.
+    /// </summary>
+    [NebulaUnitTest]
+    public void TestWorkItemFormAllocatesNothing()
+    {
+        var recorder = new Recorder();
+
+        // Grow the queue's backing array first and drain it. Queue<T> keeps its capacity across a
+        // drain, so the measured run below cannot be charged for a resize it did not cause.
+        var warm = new Thread(() =>
+        {
+            for (int i = 0; i < 1024; i++) NetRunner.Instance.RunOnMainThread(recorder, i);
+        });
+        warm.Start();
+        Assert.True(warm.Join(10_000), "warm-up thread did not finish");
+        Drain();
+
+        long workItemBytes = 0;
+        long closureBytes = 0;
+
+        var worker = new Thread(() =>
+        {
+            long before = System.GC.GetAllocatedBytesForCurrentThread();
+            for (int i = 0; i < 256; i++) NetRunner.Instance.RunOnMainThread(recorder, i);
+            workItemBytes = System.GC.GetAllocatedBytesForCurrentThread() - before;
+
+            before = System.GC.GetAllocatedBytesForCurrentThread();
+            for (int i = 0; i < 256; i++) NetRunner.Instance.RunOnMainThread(() => recorder.Thread = i);
+            closureBytes = System.GC.GetAllocatedBytesForCurrentThread() - before;
+        });
+        worker.Start();
+        Assert.True(worker.Join(10_000), "worker thread did not finish");
+        Drain();
+
+        Assert.True(workItemBytes == 0,
+            $"work-item hop allocated {workItemBytes} bytes over 256 deferrals; it must allocate none");
+        Assert.True(closureBytes > 0,
+            "the closure form allocated nothing either, so this measurement is not measuring anything");
+    }
 }

--- a/addons/Nebula/Testing/Unit/InputPacketTests.cs
+++ b/addons/Nebula/Testing/Unit/InputPacketTests.cs
@@ -18,7 +18,7 @@ namespace Nebula.Testing.Unit;
 [NebulaUnitTest]
 public class InputPacketTests
 {
-    private const int InputSize = 25;   // PlayerShipInput: 13 bools + a Vector3, Pack = 1
+    private const int InputSize = 26;   // PlayerShipInput: 14 bools + a Vector3, Pack = 1
 
     private static byte[] Payload(byte seed)
     {

--- a/addons/Nebula/plugin.cfg
+++ b/addons/Nebula/plugin.cfg
@@ -3,5 +3,5 @@
 name="Nebula"
 description="Netcode Framework for Online Multiplayer Games"
 author="Heavenlode"
-version="1.8.0"
+version="1.8.1"
 script="Tools/Main.cs"


### PR DESCRIPTION
Two fixes that both surfaced from the same tick-rate path.

Seeding: the property cache is only ever written by MarkDirty, which fires on a CHANGE, so a property whose value never differs from its inline initializer was never cached and read default(T) forever. Invisible for most properties -- both roles run the same initializer -- but fatal for a PREDICTED one, since the generated StoreConfirmedState sources the confirmed value from the cache and so reconciled against default(T) every tick. A miss on any single predicted property restores all of them, so one such property dragged the whole entity backwards at the tick rate. The generator now emits SeedCachedValue for value properties (excluding per-peer ones, whose storage is per-peer dictionaries), which writes the cache WITHOUT marking dirty, so what a new peer receives at spawn is unchanged.

Main-thread hop: RunOnMainThread(Action) allocates a delegate, and a display class when the lambda captures. Fine at join/leave frequency, not fine for anything a world tick can reach. Adds an IMainThreadWork overload where the caller IS the work item -- it passes `this` plus an int tag, so nothing is allocated. Both forms share one queue, and therefore one execution order. The Action overload stays regardless: INotifyCompletion.OnCompleted hands its continuation over as an Action, so SwitchToMainThread needs it.

Also drops a stray GD.Print from the ServerMetrics line emitter and bumps the plugin to 1.8.1.