### PR TITLE
Rate-corrected render clock, adaptive interpolation buffer, and network impairment sim

### DIFF
--- a/addons/Nebula/Core/Diagnostics/NetworkImpairment.cs
+++ b/addons/Nebula/Core/Diagnostics/NetworkImpairment.cs
@@ -1,0 +1,322 @@
+using Godot;
+
+namespace Nebula.Diagnostics
+{
+    /// <summary>
+    /// Synthetic network impairment for inbound packets: added latency, jitter, and loss.
+    ///
+    /// <para>WHY THIS EXISTS. Everything about the render clock and the interpolation buffer was
+    /// developed and measured on localhost, where arrival jitter is 19-43ms against a 33.3ms nominal
+    /// and loss is zero. Those are the conditions under which the OLD render clock also looked fine --
+    /// its uneven stepping only became obvious once it was measured properly. A jitter buffer that has
+    /// never seen jitter is a guess, so this makes a bad link something that can be produced on
+    /// purpose rather than waited for.</para>
+    ///
+    /// <para>Pure and clock-injected: it decides, given a moment and a packet, whether the packet is
+    /// dropped and when it should be released. The queueing and the pool bookkeeping belong to the two
+    /// call sites, which differ (the server already has an inbound ring; the client does not).</para>
+    ///
+    /// <para>Inert unless configured, and configured per PROCESS so a single play session can run one
+    /// healthy client beside one bad one -- which is the case that matters, because an impaired peer is
+    /// only interesting when a healthy observer is watching it.</para>
+    /// </summary>
+    public sealed class NetworkImpairment
+    {
+        // Per-client, so these must be command-line capable: a project setting is process-global and
+        // would apply identically to every instance the Play tab spawns. Env vars cover the
+        // headless/CI case, project settings the editor default. Same three-tier shape as
+        // Env.Instance.InitialWorldScene.
+        private const string LatencyArg = "--simLatencyMs=";
+        private const string JitterArg = "--simJitterMs=";
+        private const string LossArg = "--simLossPct=";
+        private const string SeedArg = "--simSeed=";
+        private const string BurstLossArg = "--simBurstLossPct=";
+        private const string BurstEveryArg = "--simBurstEverySec=";
+        private const string BurstMsArg = "--simBurstMs=";
+
+        private const string LatencyEnvVar = "NEBULA_SIM_LATENCY_MS";
+        private const string JitterEnvVar = "NEBULA_SIM_JITTER_MS";
+        private const string LossEnvVar = "NEBULA_SIM_LOSS_PCT";
+        private const string SeedEnvVar = "NEBULA_SIM_SEED";
+        private const string BurstLossEnvVar = "NEBULA_SIM_BURST_LOSS_PCT";
+        private const string BurstEveryEnvVar = "NEBULA_SIM_BURST_EVERY_SEC";
+        private const string BurstMsEnvVar = "NEBULA_SIM_BURST_MS";
+
+        private const string LatencySetting = "Nebula/config/debug/sim_latency_ms";
+        private const string JitterSetting = "Nebula/config/debug/sim_jitter_ms";
+        private const string LossSetting = "Nebula/config/debug/sim_loss_pct";
+        private const string BurstLossSetting = "Nebula/config/debug/sim_burst_loss_pct";
+        private const string BurstEverySetting = "Nebula/config/debug/sim_burst_every_sec";
+        private const string BurstMsSetting = "Nebula/config/debug/sim_burst_ms";
+
+        /// <summary>
+        /// The setting the original client-side loss simulator used. Still honoured so existing
+        /// project files and any muscle memory keep working; it feeds the same loss knob.
+        /// </summary>
+        private const string LegacyLossSetting = "Nebula/config/debug/simulate_incoming_tick_loss";
+
+        /// <summary>One-way delay added to every packet, in milliseconds.</summary>
+        public int LatencyMs { get; private set; }
+
+        /// <summary>Random spread around <see cref="LatencyMs"/>, plus or minus, in milliseconds.</summary>
+        public int JitterMs { get; private set; }
+
+        /// <summary>Percentage of droppable packets discarded, 0-100. Applies steadily.</summary>
+        public int LossPct { get; private set; }
+
+        /// <summary>
+        /// Loss percentage DURING a burst, 0-100. Zero disables bursts entirely.
+        ///
+        /// <para>Steady loss and burst loss model different things and both are worth having. Real
+        /// links rarely lose packets independently -- a handover, a congestion event or interference
+        /// takes out a RUN of consecutive packets, and a run leaves a hole that uniform loss almost
+        /// never produces. 2% independent loss barely dents an interpolation buffer; 100% loss for
+        /// 300ms empties it. Set this to 100 for a full dropout, which is what a connection hiccup
+        /// looks like from the application's side.</para>
+        /// </summary>
+        public int BurstLossPct { get; private set; }
+
+        /// <summary>Average seconds between burst onsets. The actual interval is drawn from an
+        /// exponential distribution so bursts arrive like real faults rather than on a metronome.</summary>
+        public float BurstEverySec { get; private set; }
+
+        /// <summary>How long each burst lasts, in milliseconds.</summary>
+        public int BurstMs { get; private set; }
+
+        /// <summary>Whether anything here will actually do something. Callers skip the whole path when
+        /// false, so an unconfigured build pays a single bool test.</summary>
+        public bool IsActive =>
+            LatencyMs > 0 || JitterMs > 0 || LossPct > 0 || (BurstLossPct > 0 && BurstMs > 0);
+
+        /// <summary>Whether a burst is in progress as of the last scheduling decision. Exposed so the
+        /// health readout can say WHY a window looked bad.</summary>
+        public bool InBurst { get; private set; }
+
+        private ulong _burstUntilMsec;
+        private ulong _nextBurstAtMsec;
+
+        private readonly RandomNumberGenerator _rng = new();
+
+        /// <summary>
+        /// Builds an impairment from the process's own configuration: command line first (per
+        /// instance), then environment, then project setting.
+        /// </summary>
+        public static NetworkImpairment FromProcessConfig()
+        {
+            var impairment = new NetworkImpairment
+            {
+                LatencyMs = ResolveInt(LatencyArg, LatencyEnvVar, LatencySetting, 0, 0, 10_000),
+                JitterMs = ResolveInt(JitterArg, JitterEnvVar, JitterSetting, 0, 0, 10_000),
+                LossPct = ResolveInt(LossArg, LossEnvVar, LossSetting, LegacyLoss(), 0, 100),
+                BurstLossPct = ResolveInt(BurstLossArg, BurstLossEnvVar, BurstLossSetting, 0, 0, 100),
+                BurstEverySec = ResolveInt(BurstEveryArg, BurstEveryEnvVar, BurstEverySetting, 10, 1, 3600),
+                BurstMs = ResolveInt(BurstMsArg, BurstMsEnvVar, BurstMsSetting, 0, 0, 10_000),
+            };
+
+            // Seeded so a bad run reproduces. Without this an impairment test that fails once cannot
+            // be re-run, which is most of the value of having it.
+            int seed = ResolveInt(SeedArg, SeedEnvVar, null, 0, int.MinValue, int.MaxValue);
+            if (seed != 0) impairment._rng.Seed = (ulong)seed;
+            else impairment._rng.Randomize();
+
+            return impairment;
+        }
+
+        /// <summary>Test seam: an impairment with explicit values and a fixed seed.</summary>
+        public static NetworkImpairment ForTest(
+            int latencyMs, int jitterMs, int lossPct, ulong seed,
+            int burstLossPct = 0, float burstEverySec = 10f, int burstMs = 0)
+        {
+            var impairment = new NetworkImpairment
+            {
+                LatencyMs = latencyMs,
+                JitterMs = jitterMs,
+                LossPct = lossPct,
+                BurstLossPct = burstLossPct,
+                BurstEverySec = burstEverySec,
+                BurstMs = burstMs,
+            };
+            impairment._rng.Seed = seed;
+            return impairment;
+        }
+
+        /// <summary>
+        /// Whether a packet on <paramref name="channel"/> may be discarded.
+        ///
+        /// <para>THE UNRELIABLE CHANNELS ONLY -- Tick (Unsequenced) and Input (None). Neither is
+        /// retransmitted by ENet, so both really can vanish on a live link and the protocol already
+        /// has to survive it: ticks are re-sent as newer ticks, and input packets carry
+        /// INPUT_REDUNDANCY_COUNT ticks of history precisely so a lost one is recoverable.</para>
+        ///
+        /// <para>Function and World are Reliable, and ENet has ALREADY delivered them by the time
+        /// they reach this layer. Discarding one here does not simulate a lost packet -- it loses it
+        /// permanently, which no retransmission can recover, and breaks the protocol rather than
+        /// stressing it.</para>
+        /// </summary>
+        public static bool IsDroppable(byte channel) =>
+            channel == (byte)NetRunner.ENetChannelId.Tick
+            || channel == (byte)NetRunner.ENetChannelId.Input;
+
+        /// <summary>
+        /// Decides a packet's fate.
+        ///
+        /// <para>Returns false when the packet is dropped. Otherwise <paramref name="releaseAtMsec"/>
+        /// is when it should be delivered -- never earlier than <paramref name="nowMsec"/>, so an
+        /// impairment can only ever hold a packet back.</para>
+        ///
+        /// <para>REORDERING NEEDS NO KNOB and is not simulated separately: jitter alone releases
+        /// packets out of the order they arrived, which is how reordering happens on a real link. Note
+        /// what that means on the Tick channel specifically -- it is sent Unsequenced and ordering is
+        /// enforced in software by <c>ClientProcessTick</c>'s "ignore ticks at or behind the current
+        /// one" guard, so a tick that arrives late is DISCARDED. Reordering therefore presents as
+        /// loss there, which is also what happens in production.</para>
+        /// </summary>
+        public bool TryScheduleInbound(byte channel, ulong nowMsec, out ulong releaseAtMsec)
+        {
+            releaseAtMsec = nowMsec;
+            if (!IsActive) return true;
+
+            // The RNG and the burst state are mutable and now reached from two threads: ingress from
+            // the network pump, egress from a world's tick thread (see NetRunner.SendPacket's
+            // EnetLock note). IsActive is fixed at construction, so an unconfigured build never
+            // reaches this lock.
+            lock (_gate)
+            {
+                int lossPct = AdvanceBurstState(nowMsec) ? BurstLossPct : LossPct;
+
+                if (lossPct > 0 && IsDroppable(channel) && _rng.RandiRange(1, 100) <= lossPct)
+                {
+                    return false;
+                }
+
+                int delay = LatencyMs;
+                if (JitterMs > 0) delay += _rng.RandiRange(-JitterMs, JitterMs);
+                if (delay > 0) releaseAtMsec = nowMsec + (ulong)delay;
+                return true;
+            }
+        }
+
+        /// <summary>Guards the RNG and burst state; see TryScheduleInbound.</summary>
+        private readonly object _gate = new();
+
+        /// <summary>
+        /// Whether an outgoing packet survives the link.
+        ///
+        /// <para>AN OUTAGE HAS TO BE BIDIRECTIONAL, which ingress alone cannot express. Impairment is
+        /// configured per process so one bad client can sit beside a healthy one, and that means the
+        /// SERVER is unimpaired -- so with ingress-only filtering a client sailed through a "100%
+        /// loss" burst still delivering perfect input, which is not an outage at all. It also hid a
+        /// whole class of bug: the server holds the last-known input across a gap, so an outage that
+        /// never interrupts input never exercises that fallback.</para>
+        ///
+        /// <para>Loss only, deliberately. The configured latency is modelled as a single one-way hop
+        /// on the RECEIVE path -- which is what <c>WorldRunner.EffectiveRoundTripMs</c> accounts for --
+        /// so delaying here as well would silently double it. Loss is the part of an outage that has
+        /// no direction.</para>
+        ///
+        /// <para>Shares the burst state machine with <see cref="TryScheduleInbound"/> on purpose: the
+        /// same outage must take out both directions, not two independently-rolled ones.</para>
+        /// </summary>
+        public bool TrySendOutbound(byte channel, ulong nowMsec)
+        {
+            if (!IsActive) return true;
+            if (!IsDroppable(channel)) return true;
+
+            lock (_gate)
+            {
+                int lossPct = AdvanceBurstState(nowMsec) ? BurstLossPct : LossPct;
+                return !(lossPct > 0 && _rng.RandiRange(1, 100) <= lossPct);
+            }
+        }
+
+        /// <summary>
+        /// Advances the good/bad link state and reports whether a burst is currently in progress.
+        ///
+        /// <para>A two-state model, which is the standard way bursty loss is described: the link sits
+        /// in a good state for an exponentially-distributed while, then drops into a bad state for a
+        /// fixed span. Exponential intervals matter -- a burst every N seconds ON THE DOT is a pattern
+        /// the rest of the system could accidentally sync with, and real faults do not schedule
+        /// themselves.</para>
+        ///
+        /// <para>Driven entirely off the caller's clock, so it is deterministic under a fixed seed and
+        /// testable without waiting in real time.</para>
+        /// </summary>
+        private bool AdvanceBurstState(ulong nowMsec)
+        {
+            if (BurstLossPct <= 0 || BurstMs <= 0)
+            {
+                InBurst = false;
+                return false;
+            }
+
+            if (_nextBurstAtMsec == 0)
+            {
+                // First call: schedule the opening burst rather than firing one immediately, so a
+                // session does not begin mid-fault.
+                _nextBurstAtMsec = nowMsec + NextBurstDelayMsec();
+            }
+
+            if (InBurst && nowMsec >= _burstUntilMsec)
+            {
+                InBurst = false;
+                _nextBurstAtMsec = nowMsec + NextBurstDelayMsec();
+            }
+            else if (!InBurst && nowMsec >= _nextBurstAtMsec)
+            {
+                InBurst = true;
+                _burstUntilMsec = nowMsec + (ulong)BurstMs;
+            }
+
+            return InBurst;
+        }
+
+        /// <summary>
+        /// Time to the next burst, drawn from an exponential distribution with mean
+        /// <see cref="BurstEverySec"/> -- the memoryless spacing of a Poisson process, which is how
+        /// independent faults actually arrive.
+        /// </summary>
+        private ulong NextBurstDelayMsec()
+        {
+            // Guard the tail: Randf can return values arbitrarily close to 1, and log(0) is infinite.
+            float u = Mathf.Clamp(1f - _rng.Randf(), 0.0001f, 1f);
+            float seconds = -BurstEverySec * Mathf.Log(u);
+            return (ulong)Mathf.Max(seconds * 1000f, 0f);
+        }
+
+        /// <summary>Describes the configuration for a startup log line, so a run's conditions are
+        /// recoverable from its output.</summary>
+        public override string ToString()
+            => BurstLossPct > 0 && BurstMs > 0
+                ? $"latency={LatencyMs}ms jitter=+/-{JitterMs}ms loss={LossPct}% "
+                  + $"burst={BurstLossPct}%/{BurstMs}ms every~{BurstEverySec:F0}s"
+                : $"latency={LatencyMs}ms jitter=+/-{JitterMs}ms loss={LossPct}%";
+
+        private static int LegacyLoss()
+            => (int)ProjectSettings.GetSetting(LegacyLossSetting, 0).AsInt32();
+
+        private static int ResolveInt(
+            string arg, string envVar, string setting, int fallback, int min, int max)
+        {
+            foreach (var argument in OS.GetCmdlineArgs())
+            {
+                if (!argument.StartsWith(arg)) continue;
+                if (int.TryParse(argument.Substring(arg.Length), out int fromArg))
+                    return Mathf.Clamp(fromArg, min, max);
+            }
+
+            if (OS.HasEnvironment(envVar)
+                && int.TryParse(OS.GetEnvironment(envVar), out int fromEnv))
+            {
+                return Mathf.Clamp(fromEnv, min, max);
+            }
+
+            if (setting != null)
+            {
+                int fromSetting = ProjectSettings.GetSetting(setting, fallback).AsInt32();
+                return Mathf.Clamp(fromSetting, min, max);
+            }
+
+            return Mathf.Clamp(fallback, min, max);
+        }
+    }
+}

--- a/addons/Nebula/Core/Diagnostics/NetworkImpairment.cs.uid
+++ b/addons/Nebula/Core/Diagnostics/NetworkImpairment.cs.uid
@@ -1,0 +1,1 @@
+uid://cdeongfu0w881

--- a/addons/Nebula/Core/Diagnostics/PayloadCensus.cs
+++ b/addons/Nebula/Core/Diagnostics/PayloadCensus.cs
@@ -1,0 +1,212 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+
+namespace Nebula.Diagnostics
+{
+    /// <summary>
+    /// Per-property byte accounting for the tick payload, so "the packet is full" can be
+    /// answered with WHAT is filling it rather than a guess.
+    ///
+    /// <para>Off unless <c>NEBULA_CENSUS</c> is set. Deliberately NOT allocation-free — it
+    /// exists to be switched on for one measuring run, not to ride production. It does
+    /// allocate on the record path (dictionary growth, and the boxed key on first sight of
+    /// a property), so read tick timings from a run with it OFF.</para>
+    ///
+    /// <para>Emits one <c>NEBULA_CENSUS</c> line per interval listing the heaviest
+    /// properties by total bytes across all peers in the window, with a per-tick-per-peer
+    /// average so entries compare directly against the payload cap.</para>
+    /// </summary>
+    public static class PayloadCensus
+    {
+        public const string EnableEnvVar = "NEBULA_CENSUS";
+        public const string LinePrefix = "NEBULA_CENSUS ";
+
+        /// <summary>How many of the heaviest properties to list.</summary>
+        private const int TopN = 40;
+
+        private static readonly CultureInfo Inv = CultureInfo.InvariantCulture;
+
+        private static bool _parsed;
+        private static bool _enabled;
+
+        public static bool Enabled
+        {
+            get
+            {
+                if (!_parsed)
+                {
+                    _parsed = true;
+                    Nebula.Utility.Tools.Env.TryGetFlag(EnableEnvVar, out _enabled);
+                }
+                return _enabled;
+            }
+        }
+
+        private sealed class Entry
+        {
+            public long Bytes;
+            public long Writes;
+            public long DeltaWrites;
+        }
+
+        private static readonly Dictionary<string, Entry> _entries = new();
+        private static readonly StringBuilder _line = new(2048);
+        private static int _peerSections;
+
+        /// <summary>Records one property write. <paramref name="key"/> is scene-scoped.</summary>
+        public static void Record(string key, int bytes, bool delta)
+        {
+            if (bytes <= 0) return;
+            lock (_entries)
+            {
+                if (!_entries.TryGetValue(key, out var entry))
+                {
+                    entry = new Entry();
+                    _entries[key] = entry;
+                }
+                entry.Bytes += bytes;
+                entry.Writes++;
+                if (delta) entry.DeltaWrites++;
+            }
+        }
+
+        /// <summary>Counts one per-peer props section, for the per-section average.</summary>
+        public static void RecordSection()
+        {
+            lock (_entries) { _peerSections++; }
+        }
+
+        // ─── Gameplay time census ────────────────────────────────────────────
+        //
+        // The payload answers "what is on the wire"; this answers "what is the
+        // tick spending itself on", which the phase profiler only reports as one
+        // lump called `gameplay`. Keyed by scene file path, so it names the scene
+        // to go look at rather than a node instance.
+
+        private sealed class TimeEntry
+        {
+            public long Ticks;
+            public long Calls;
+        }
+
+        private static readonly Dictionary<string, TimeEntry> _times = new();
+
+        /// <summary>Charges one node's _NetworkProcess to its scene. Stopwatch ticks.</summary>
+        public static void RecordGameplay(string scenePath, long elapsedTicks)
+        {
+            if (string.IsNullOrEmpty(scenePath)) scenePath = "(no scene)";
+            lock (_times)
+            {
+                if (!_times.TryGetValue(scenePath, out var entry))
+                {
+                    entry = new TimeEntry();
+                    _times[scenePath] = entry;
+                }
+                entry.Ticks += elapsedTicks;
+                entry.Calls++;
+            }
+        }
+
+        private static void EmitGameplay(int ticksInWindow)
+        {
+            lock (_times)
+            {
+                if (_times.Count == 0) return;
+
+                var ordered = new List<KeyValuePair<string, TimeEntry>>(_times);
+                ordered.Sort((a, b) => b.Value.Ticks.CompareTo(a.Value.Ticks));
+
+                long total = 0;
+                foreach (var kv in ordered) total += kv.Value.Ticks;
+                double toMs = 1000.0 / System.Diagnostics.Stopwatch.Frequency;
+
+                var sb = new StringBuilder(2048);
+                sb.Append("NEBULA_GAMEPLAY {\"ticks\":").Append(ticksInWindow.ToString(Inv));
+                sb.Append(",\"total_ms_per_tick\":")
+                  .Append((ticksInWindow > 0 ? total * toMs / ticksInWindow : 0).ToString("F3", Inv));
+                sb.Append(",\"top\":[");
+                int listed = 0;
+                foreach (var kv in ordered)
+                {
+                    if (listed >= TopN) break;
+                    if (listed > 0) sb.Append(',');
+                    sb.Append("{\"scene\":\"").Append(kv.Key).Append('"');
+                    sb.Append(",\"ms_per_tick\":")
+                      .Append((ticksInWindow > 0 ? kv.Value.Ticks * toMs / ticksInWindow : 0).ToString("F3", Inv));
+                    sb.Append(",\"pct\":")
+                      .Append((total > 0 ? kv.Value.Ticks * 100.0 / total : 0).ToString("F1", Inv));
+                    sb.Append(",\"calls_per_tick\":")
+                      .Append((ticksInWindow > 0 ? kv.Value.Calls / (double)ticksInWindow : 0).ToString("F1", Inv));
+                    sb.Append(",\"us_per_call\":")
+                      .Append((kv.Value.Calls > 0 ? kv.Value.Ticks * toMs * 1000.0 / kv.Value.Calls : 0).ToString("F1", Inv));
+                    sb.Append('}');
+                    listed++;
+                }
+                sb.Append("]}");
+                Godot.GD.Print(sb.ToString());
+
+                _times.Clear();
+            }
+        }
+
+        /// <summary>Writes the window report to stdout and resets. Called once per interval.</summary>
+        public static void Emit(int peers, double elapsedSeconds, int ticksInWindow)
+        {
+            EmitGameplay(ticksInWindow);
+
+            lock (_entries)
+            {
+                if (_entries.Count == 0) return;
+
+                var ordered = new List<KeyValuePair<string, Entry>>(_entries);
+                ordered.Sort((a, b) => b.Value.Bytes.CompareTo(a.Value.Bytes));
+
+                long total = 0;
+                foreach (var kv in ordered) total += kv.Value.Bytes;
+
+                _line.Clear();
+                _line.Append(LinePrefix);
+                _line.Append("{\"peers\":").Append(peers.ToString(Inv));
+                _line.Append(",\"window_s\":").Append(elapsedSeconds.ToString("F2", Inv));
+                _line.Append(",\"sections\":").Append(_peerSections.ToString(Inv));
+                _line.Append(",\"total_bytes\":").Append(total.ToString(Inv));
+                // Bytes of property payload per peer per second: the bandwidth number,
+                // before framing and before pack compression.
+                double perPeerSec = peers > 0 && elapsedSeconds > 0
+                    ? total / (double)peers / elapsedSeconds : 0;
+                _line.Append(",\"prop_bytes_per_peer_s\":").Append(perPeerSec.ToString("F0", Inv));
+                _line.Append(",\"top\":[");
+
+                int listed = 0;
+                foreach (var kv in ordered)
+                {
+                    if (listed >= TopN) break;
+                    if (listed > 0) _line.Append(',');
+                    var e = kv.Value;
+                    _line.Append("{\"prop\":\"").Append(kv.Key).Append('"');
+                    _line.Append(",\"bytes\":").Append(e.Bytes.ToString(Inv));
+                    _line.Append(",\"pct\":")
+                         .Append((total > 0 ? e.Bytes * 100.0 / total : 0).ToString("F1", Inv));
+                    _line.Append(",\"writes\":").Append(e.Writes.ToString(Inv));
+                    _line.Append(",\"b_per_write\":")
+                         .Append((e.Writes > 0 ? e.Bytes / (double)e.Writes : 0).ToString("F1", Inv));
+                    // The share of writes that used delta encoding rather than an
+                    // absolute. A hot property sitting at 0 means the delta gate is
+                    // never opening for it.
+                    _line.Append(",\"delta_pct\":")
+                         .Append((e.Writes > 0 ? e.DeltaWrites * 100.0 / e.Writes : 0).ToString("F0", Inv));
+                    _line.Append('}');
+                    listed++;
+                }
+                _line.Append("]}");
+
+                Godot.GD.Print(_line.ToString());
+
+                _entries.Clear();
+                _peerSections = 0;
+            }
+        }
+    }
+}

--- a/addons/Nebula/Core/Diagnostics/PayloadCensus.cs.uid
+++ b/addons/Nebula/Core/Diagnostics/PayloadCensus.cs.uid
@@ -1,0 +1,1 @@
+uid://b6hdjauxx760i

--- a/addons/Nebula/Core/Diagnostics/ServerMetrics.cs
+++ b/addons/Nebula/Core/Diagnostics/ServerMetrics.cs
@@ -123,6 +123,12 @@ namespace Nebula.Diagnostics
         private int _gc0, _gc1, _gc2;
         private bool _started;
 
+        /// <summary>
+        /// Ticks counted by the window <see cref="Emit"/> most recently closed, so a
+        /// companion reporter can express its own totals per tick over the same window.
+        /// </summary>
+        public int TicksInLastWindow { get; private set; }
+
         /// <summary>Records one completed server tick. Hot path — no allocation.</summary>
         public void RecordTick(double elapsedMs)
         {
@@ -256,7 +262,14 @@ namespace Nebula.Diagnostics
             _line.Append(",\"spawn_backlog_max\":").Append(_spawnBacklogMax).Append('}');
             _line.Append('}');
 
+            // Stdout, as the class doc promises: the DebugHub copy the caller also ships
+            // only exists while a debugger is attached, so without this a headless soak
+            // (the exact case metrics exist for) produces no metrics at all.
+            Godot.GD.Print(_line.ToString());
+
             string json = _line.ToString(LinePrefix.Length, _line.Length - LinePrefix.Length);
+
+            TicksInLastWindow = _ticksThisWindow;
 
             _windowStartUsec = Time.GetTicksUsec();
             _tickCount = 0;

--- a/addons/Nebula/Core/NetNode.cs
+++ b/addons/Nebula/Core/NetNode.cs
@@ -165,33 +165,8 @@ namespace Nebula
 
         public static bool NetworkSerialize(WorldRunner currentWorld, NetPeer peer, NetNode obj, NetBuffer buffer, int maxBytes)
         {
-            // maxBytes is ignored - NetNode serialization is always small (node reference)
-            if (obj == null)
-            {
-                NetWriter.WriteUInt16(buffer, 0);
-                return true;
-            }
-            NetId targetNetId;
-            byte staticChildId = 0;
-            if (obj.Network.IsNetScene())
-            {
-                targetNetId = obj.Network.NetId;
-            }
-            else
-            {
-                if (Protocol.PackNode(obj.Network.NetSceneFilePath, obj.Network.NetParent.RawNode.GetPathTo(obj), out staticChildId))
-                {
-                    targetNetId = obj.Network.NetParent.NetId;
-                }
-                else
-                {
-                    throw new Exception($"Failed to pack node: {obj.Network.NetParent.NetSceneFilePath} cannot find static child {obj.Network.NetParent.RawNode.GetPathTo(obj)}: {obj.GetPath()}");
-                }
-            }
-            var peerNodeId = currentWorld.GetPeerWorldState(peer).Value.WorldToPeerNodeMap[targetNetId];
-            NetWriter.WriteUInt16(buffer, peerNodeId);
-            NetWriter.WriteByte(buffer, staticChildId);
-            return true;
+            // maxBytes is ignored - a node reference is always small.
+            return Nebula.Utility.NetNodeCommon.TryWriteNodeReference(currentWorld, peer, obj, buffer);
         }
 
         public static void OnPeerAcknowledge(NetNode obj, UUID peerId, Tick tick)

--- a/addons/Nebula/Core/NetNode2D.cs
+++ b/addons/Nebula/Core/NetNode2D.cs
@@ -156,33 +156,14 @@ namespace Nebula
 
         public static bool NetworkSerialize(WorldRunner currentWorld, NetPeer peer, NetNode2D obj, NetBuffer buffer, int maxBytes)
         {
-            // maxBytes is ignored - NetNode2D serialization is always small (node reference)
-            if (obj == null)
-            {
-                NetWriter.WriteUInt16(buffer, 0);
-                return true;
-            }
-            NetId targetNetId;
-            byte staticChildId = 0;
-            if (obj.Network.IsNetScene())
-            {
-                targetNetId = obj.Network.NetId;
-            }
-            else
-            {
-                // if (Protocol.PackNode(obj.Network.NetSceneFilePath, obj.Network.NetParent.RawNode.GetPathTo(obj), out staticChildId))
-                // {
-                //     targetNetId = obj.Network.NetParent.NetId;
-                // }
-                // else
-                // {
-                //     throw new Exception($"Failed to pack node: {obj.Network.NetParent.NetSceneFilePath} cannot find static child {obj.Network.NetParent.RawNode.GetPathTo(obj)}: {obj.GetPath()}");
-                // }
-            }
-            // var peerNodeId = currentWorld.GetPeerWorldState(peer).Value.WorldToPeerNodeMap[targetNetId];
-            // NetWriter.WriteUInt16(buffer, peerNodeId);
-            // NetWriter.WriteByte(buffer, staticChildId);
-            return true;
+            // maxBytes is ignored - a node reference is always small.
+            //
+            // This body used to be commented out below a live `return true`, so a non-null
+            // NetNode2D reference wrote ZERO bytes and claimed success while
+            // NetworkDeserialize read three - desyncing every property after it in the
+            // packet. Sharing the writer with NetNode/NetNode3D is what stops that
+            // recurring.
+            return Nebula.Utility.NetNodeCommon.TryWriteNodeReference(currentWorld, peer, obj, buffer);
         }
 
         public static void OnPeerAcknowledge(NetNode2D obj, UUID peerId, Tick tick)

--- a/addons/Nebula/Core/NetNode3D.cs
+++ b/addons/Nebula/Core/NetNode3D.cs
@@ -167,33 +167,8 @@ namespace Nebula
 
         public static bool NetworkSerialize(WorldRunner currentWorld, NetPeer peer, NetNode3D obj, NetBuffer buffer, int maxBytes)
         {
-            // maxBytes is ignored - NetNode3D serialization is always small (node reference)
-            if (obj == null)
-            {
-                NetWriter.WriteUInt16(buffer, 0);
-                return true;
-            }
-            NetId targetNetId;
-            byte staticChildId = 0;
-            if (obj.Network.IsNetScene())
-            {
-                targetNetId = obj.Network.NetId;
-            }
-            else
-            {
-                if (Protocol.PackNode(obj.Network.NetSceneFilePath, obj.Network.NetParent.RawNode.GetPathTo(obj), out staticChildId))
-                {
-                    targetNetId = obj.Network.NetParent.NetId;
-                }
-                else
-                {
-                    throw new Exception($"Failed to pack node: {obj.Network.NetSceneFilePath} cannot find static child {obj.Network.NetParent.RawNode.GetPathTo(obj)}: {obj.GetPath()}");
-                }
-            }
-            var peerNodeId = currentWorld.GetPeerWorldState(peer).Value.WorldToPeerNodeMap[targetNetId];
-            NetWriter.WriteUInt16(buffer, peerNodeId);
-            NetWriter.WriteByte(buffer, staticChildId);
-            return true;
+            // maxBytes is ignored - a node reference is always small.
+            return NetNodeCommon.TryWriteNodeReference(currentWorld, peer, obj, buffer);
         }
 
         public static void OnPeerAcknowledge(NetNode3D obj, UUID peerId, Tick tick)

--- a/addons/Nebula/Core/NetNodeCommon.cs
+++ b/addons/Nebula/Core/NetNodeCommon.cs
@@ -249,5 +249,85 @@ namespace Nebula.Utility
             return node;
         }
 
+        /// <summary>One-shot guard for the "reference can never be packed" diagnostic.</summary>
+        private static bool _loggedUnpackableReference;
+
+        /// <summary>
+        /// Writes a node reference for one peer: the peer-local node id, plus the packed child
+        /// id when the target is a static child. Shared by <see cref="NetNode"/>,
+        /// <see cref="NetNode2D"/> and <see cref="NetNode3D"/>, whose reference serializers are
+        /// otherwise identical and have silently drifted apart before.
+        ///
+        /// <para>Returns false having written NOTHING when the reference cannot be delivered
+        /// yet. The property framework reads that as "nothing to send" and retries on a later
+        /// tick, so a deferred reference costs latency, never correctness.</para>
+        ///
+        /// <para>The spawn gate is the load-bearing part. A peer-local id is assigned inside the
+        /// spawn <c>Export</c>, BEFORE <c>WorldRunner.ExportState</c> decides whether that spawn
+        /// section fits the tick budget — so a registered id is not by itself a promise that the
+        /// client has the node. Shipping one anyway decodes as null on the client. That used to
+        /// self-heal only because references were re-sent every tick; once they are sent on
+        /// change, an ungated id would strand the reference at null permanently. Requiring
+        /// <see cref="WorldRunner.ClientSpawnState.Spawned"/> — the peer ACKED the spawn — is
+        /// what makes send-on-change safe.</para>
+        /// </summary>
+        internal static bool TryWriteNodeReference(
+            WorldRunner currentWorld, NetPeer peer, INetNodeBase obj, NetBuffer buffer)
+        {
+            if (obj == null)
+            {
+                // A null reference is a real value and must be sent, not deferred.
+                NetWriter.WriteUInt16(buffer, 0);
+                return true;
+            }
+
+            var network = obj.Network;
+            NetId targetNetId;
+            byte staticChildId = 0;
+            if (network.IsNetScene())
+            {
+                targetNetId = network.NetId;
+            }
+            else if (Protocol.PackNode(
+                network.NetSceneFilePath,
+                network.NetParent.RawNode.GetPathTo(network.RawNode),
+                out staticChildId))
+            {
+                targetNetId = network.NetParent.NetId;
+            }
+            else
+            {
+                // Previously an exception, which the object-property loop caught and logged
+                // once per node per peer per TICK. It is a build-data fault, not a per-peer
+                // one, so say it once and decline to write.
+                if (!_loggedUnpackableReference)
+                {
+                    _loggedUnpackableReference = true;
+                    Debugger.Instance.Log(
+                        $"[NodeReference] Cannot pack {network.NetParent.NetSceneFilePath} static child "
+                        + $"{network.NetParent.RawNode.GetPathTo(network.RawNode)} ({network.RawNode.GetPath()}); "
+                        + "the reference will never replicate. Further occurrences suppressed.",
+                        Debugger.DebugLevel.ERROR);
+                }
+                return false;
+            }
+
+            // The peer must have ACKED the target's spawn, or it cannot resolve the id.
+            if (currentWorld.GetClientSpawnState(targetNetId, peer) != WorldRunner.ClientSpawnState.Spawned)
+            {
+                return false;
+            }
+
+            var peerState = currentWorld.GetPeerWorldState(peer);
+            if (peerState == null
+                || !peerState.Value.WorldToPeerNodeMap.TryGetValue(targetNetId, out var peerNodeId))
+            {
+                return false;
+            }
+
+            NetWriter.WriteUInt16(buffer, peerNodeId);
+            NetWriter.WriteByte(buffer, staticChildId);
+            return true;
+        }
     }
 }

--- a/addons/Nebula/Core/NetRunner.cs
+++ b/addons/Nebula/Core/NetRunner.cs
@@ -428,6 +428,14 @@ namespace Nebula
             NetStarted = true;
             Debugger.Instance.Log($"Started on port {Port}");
 
+            // A run under synthetic impairment must SAY SO. It is off by default and applies per
+            // process, so without this line a log is indistinguishable from a healthy one and no
+            // measurement taken from it can be attributed to anything.
+            if (Impairment.IsActive)
+            {
+                Debugger.Instance.Log($"Network impairment ACTIVE: {Impairment}");
+            }
+
             // The debug channel is not started here: it is process-wide (see
             // StartTelemetryHub) so that clients get one too, and so it is already
             // listening before the network starts.
@@ -467,6 +475,14 @@ namespace Nebula
             WorldRunner.CurrentWorld = worldRunner;
             GetTree().CurrentScene.AddChild(worldRunner);
             Debugger.Instance.Log("Started");
+
+            // A run under synthetic impairment must SAY SO. It is off by default and applies per
+            // process, so without this line a log is indistinguishable from a healthy one and no
+            // measurement taken from it can be attributed to anything.
+            if (Impairment.IsActive)
+            {
+                Debugger.Instance.Log($"Network impairment ACTIVE: {Impairment}");
+            }
         }
 
         /// <summary>
@@ -606,20 +622,19 @@ namespace Nebula
         public static bool LogTickPayloads =>
             _logTickPayloads ??= ProjectSettings.GetSetting("Nebula/config/debug/log_tick_payloads", false).AsBool();
 
-        private static int? _simulateIncomingTickLoss;
-        /// <summary>
-        /// Debug: percentage (0-100) of received tick packets the CLIENT drops before
-        /// processing, via <c>Nebula/config/debug/simulate_incoming_tick_loss</c>. Simulates
-        /// an unreliable link on a lossless LAN so loss-recovery paths (spawn resend-until-
-        /// acked, delta baseline fallback) can be exercised deterministically. Client-side
-        /// only; 0 (default) is a no-op. Cached on first read.
-        /// </summary>
-        public static int SimulateIncomingTickLoss =>
-            _simulateIncomingTickLoss ??= Math.Clamp(
-                ProjectSettings.GetSetting("Nebula/config/debug/simulate_incoming_tick_loss", 0).AsInt32(), 0, 100);
+        private static Diagnostics.NetworkImpairment _impairment;
 
-        /// <summary>RNG for <see cref="SimulateIncomingTickLoss"/>. Debug-only, client-local.</summary>
-        private static readonly RandomNumberGenerator _tickLossRng = new();
+        /// <summary>
+        /// Synthetic network impairment applied to INBOUND packets -- added latency, jitter and loss.
+        ///
+        /// <para>Exists because everything about the render clock and the interpolation buffer was
+        /// developed on localhost, where jitter is small and loss is zero. A jitter buffer that has
+        /// never seen jitter is a guess. Configured per process (command line first, so one play
+        /// session can run a healthy client beside a bad one), inert when unset, and superseding the
+        /// older <c>simulate_incoming_tick_loss</c> setting, which still feeds its loss knob.</para>
+        /// </summary>
+        public static Diagnostics.NetworkImpairment Impairment =>
+            _impairment ??= Diagnostics.NetworkImpairment.FromProcessConfig();
 
         private static bool? _traceSpawnIds;
         /// <summary>
@@ -916,12 +931,98 @@ namespace Nebula
             return default;
         }
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Applies <see cref="Impairment"/> to an outgoing packet.
+        ///
+        /// <para>Deliberately at the LAST possible moment, after the caller has finished building the
+        /// packet and mutating whatever state that took. A packet is lost on the wire, not un-sent:
+        /// an input packet that has already consumed the pending tick ack must lose that ack too, or
+        /// the simulation quietly tests a failure mode the network cannot produce.</para>
+        ///
+        /// <para>Egress covers what ingress structurally cannot. Impairment is per process so one bad
+        /// client can run beside a healthy one, which leaves the SERVER unimpaired -- so without this
+        /// a client kept delivering flawless input straight through a "100% loss" outage.</para>
+        /// </summary>
+        private static bool TrySendOutbound(byte channelId)
+        {
+            if (!Impairment.IsActive) return true;
+            return Impairment.TrySendOutbound(channelId, Godot.Time.GetTicksMsec());
+        }
+
+        /// <summary>
+        /// Applies <see cref="Impairment"/> to an inbound packet destined for a world's queue.
+        /// Returns false when the packet is dropped; otherwise <paramref name="releaseAtMsec"/> is
+        /// when the world may apply it (0 = immediately, the unimpaired path).
+        /// </summary>
+        private static bool TryScheduleInbound(byte channel, out ulong releaseAtMsec)
+        {
+            releaseAtMsec = 0;
+            if (!Impairment.IsActive) return true;
+
+            var now = Time.GetTicksMsec();
+            if (!Impairment.TryScheduleInbound(channel, now, out var releaseAt)) return false;
+            if (releaseAt > now) releaseAtMsec = releaseAt;
+            return true;
+        }
+
+        // ------------------------------------------------------- client-side delayed tick delivery
+
+        /// <summary>
+        /// A server tick held back by synthetic impairment.
+        ///
+        /// <para>The client parses ticks inline in the pump and has no inbound queue of its own -- the
+        /// server's ring cannot be reused here because it is per world and applies server-side
+        /// channels. This is the smallest thing that can hold a tick: the payload is already a
+        /// materialized copy (<c>NetReader.ReadRemainingBytes</c>), so nothing pooled is pinned.</para>
+        /// </summary>
+        private readonly struct DelayedClientTick
+        {
+            public readonly ulong ReleaseAtMsec;
+            public readonly int Tick;
+            public readonly byte[] Payload;
+
+            public DelayedClientTick(ulong releaseAtMsec, int tick, byte[] payload)
+            {
+                ReleaseAtMsec = releaseAtMsec;
+                Tick = tick;
+                Payload = payload;
+            }
+        }
+
+        private readonly List<DelayedClientTick> _delayedClientTicks = new();
+
+        private void EnqueueDelayedClientTick(ulong releaseAtMsec, int tick, byte[] payload)
+            => _delayedClientTicks.Add(new DelayedClientTick(releaseAtMsec, tick, payload));
+
+        /// <summary>
+        /// Delivers held ticks that have come due.
+        ///
+        /// <para>Released in RELEASE order, not arrival order, which is the point: jitter is what
+        /// produces reordering on a real link. On the tick channel a reordered-late tick is then
+        /// discarded by ClientProcessTick's "ignore ticks at or behind the current one" guard, so it
+        /// presents as loss -- again, as in production.</para>
+        /// </summary>
+        private void DrainDelayedClientTicks()
+        {
+            if (_delayedClientTicks.Count == 0) return;
+
+            var now = Time.GetTicksMsec();
+            for (int i = _delayedClientTicks.Count - 1; i >= 0; i--)
+            {
+                var held = _delayedClientTicks[i];
+                if (held.ReleaseAtMsec > now) continue;
+
+                _delayedClientTicks.RemoveAt(i);
+                WorldRunner.CurrentWorld?.ClientProcessTick(held.Tick, held.Payload);
+            }
+        }
+
         public override void _PhysicsProcess(double delta)
         {
             // Before anything else, and regardless of whether the network is up: work deferred from
             // world threads (peer registry mutations, world creation) is owed a main-thread turn.
             DrainMainThreadWork();
+            if (IsClient && Impairment.IsActive) DrainDelayedClientTicks();
 
             if (!NetStarted)
                 return;
@@ -1033,9 +1134,11 @@ namespace Nebula
                                     // Queued, not applied: this world may be mid-tick on its own
                                     // thread. See WorldRunner.EnqueueInboundPacket.
                                     var peerId = GetPeerId(netEvent.Peer);
-                                    if (PeerWorldMap.TryGetValue(peerId, out var world))
+                                    if (PeerWorldMap.TryGetValue(peerId, out var world)
+                                        && TryScheduleInbound(channel, out var ackReleaseAt))
                                     {
-                                        world.EnqueueInboundPacket(netEvent.Peer, channel, packetData, packetLength);
+                                        world.EnqueueInboundPacket(
+                                            netEvent.Peer, channel, packetData, packetLength, ackReleaseAt);
                                         payloadHandedOff = true;
                                     }
                                 }
@@ -1055,14 +1158,21 @@ namespace Nebula
                                         Debugger.Instance.Log(Debugger.DebugLevel.INFO,
                                             $"[Nebula][TickPayload] tick={tick} ({bytes.Length} bytes) {Convert.ToHexString(bytes)}");
                                     }
-                                    // Debug: simulate packet loss by dropping received ticks before
-                                    // processing. Client-side only, never touches the shared sim -
-                                    // exists to exercise loss-recovery paths (spawn resend, delta
-                                    // baseline fallback) deterministically on a LAN with no real loss.
-                                    if (SimulateIncomingTickLoss > 0
-                                        && _tickLossRng.RandiRange(1, 100) <= SimulateIncomingTickLoss)
+                                    // Synthetic impairment: drop, hold, or pass through. `bytes` is
+                                    // already a materialized copy, so holding it is safe and the
+                                    // rented packetData still returns to the pool below.
+                                    if (Impairment.IsActive)
                                     {
-                                        break;
+                                        if (!Impairment.TryScheduleInbound(
+                                                channel, Time.GetTicksMsec(), out var releaseAt))
+                                        {
+                                            break;
+                                        }
+                                        if (releaseAt > Time.GetTicksMsec())
+                                        {
+                                            EnqueueDelayedClientTick(releaseAt, tick, bytes);
+                                            break;
+                                        }
                                     }
                                     WorldRunner.CurrentWorld.ClientProcessTick(tick, bytes);
                                 }
@@ -1074,8 +1184,12 @@ namespace Nebula
                                     var peerId = GetPeerId(netEvent.Peer);
                                     if (PeerWorldMap.TryGetValue(peerId, out var world))
                                     {
-                                        world.EnqueueInboundPacket(netEvent.Peer, channel, packetData, packetLength);
-                                        payloadHandedOff = true;
+                                        if (TryScheduleInbound(channel, out var inputReleaseAt))
+                                        {
+                                            world.EnqueueInboundPacket(
+                                                netEvent.Peer, channel, packetData, packetLength, inputReleaseAt);
+                                            payloadHandedOff = true;
+                                        }
                                     }
                                 }
                                 // Clients should never receive messages on the Input channel
@@ -1087,8 +1201,12 @@ namespace Nebula
                                     var peerId = GetPeerId(netEvent.Peer);
                                     if (PeerWorldMap.TryGetValue(peerId, out var world))
                                     {
-                                        world.EnqueueInboundPacket(netEvent.Peer, channel, packetData, packetLength);
-                                        payloadHandedOff = true;
+                                        if (TryScheduleInbound(channel, out var fnReleaseAt))
+                                        {
+                                            world.EnqueueInboundPacket(
+                                                netEvent.Peer, channel, packetData, packetLength, fnReleaseAt);
+                                            payloadHandedOff = true;
+                                        }
                                     }
                                 }
                                 else
@@ -1156,6 +1274,8 @@ namespace Nebula
         /// </summary>
         public static void SendPacket(Peer peer, byte channelId, byte[] data, PacketFlags flags)
         {
+            if (!TrySendOutbound(channelId)) return;
+
             // Reached from world tick threads (ExportState, net functions) as well as the main
             // thread. See EnetLock.
             lock (EnetLock)
@@ -1172,6 +1292,8 @@ namespace Nebula
         /// </summary>
         public static void SendPacket(Peer peer, byte channelId, NetBuffer buffer, PacketFlags flags)
         {
+            if (!TrySendOutbound(channelId)) return;
+
             // See EnetLock. packet.Create copies the bytes out of the buffer synchronously, so the
             // caller's pooled NetBuffer stays reusable the moment this returns.
             lock (EnetLock)

--- a/addons/Nebula/Core/NetworkController.cs
+++ b/addons/Nebula/Core/NetworkController.cs
@@ -149,7 +149,9 @@ namespace Nebula
 			to = default;
 			t = 0f;
 
-			if (SnapshotCount < 2) return false;
+			// Nothing to blend between: the caller will snap to the newest value, which is a frozen
+			// entity for as long as it lasts.
+			if (SnapshotCount < 2) { return false; }
 
 			// Use GLOBAL render tick from WorldRunner (not per-entity)
 			float renderTick = CurrentWorld.GetRenderTick();
@@ -165,17 +167,30 @@ namespace Nebula
 					toIdx = idx;
 			}
 
-			// Edge case: render tick is beyond all snapshots - hold last value (no extrapolation)
+			// Edge case: render tick is beyond all snapshots - hold last value (no extrapolation).
 			if (toIdx == -1)
 			{
 				int lastIdx = (SnapshotWriteIndex - 1 + SNAPSHOT_BUFFER_SIZE) % SNAPSHOT_BUFFER_SIZE;
+
+				// DELIBERATELY NOT REPORTED ANYWHERE. Running past the newest snapshot has two
+				// completely different causes and this branch cannot tell them apart: the data may be
+				// LATE (a deeper buffer would absorb it) or simply STOPPED, because the entity has
+				// nothing to say -- a parked ship is not dirty, so no snapshots are produced and the
+				// render clock inevitably walks past the last one. An earlier version counted this as
+				// a buffering failure and an idle world consequently read as a failing link, pinning
+				// the jitter buffer at its ceiling while motion stayed perfectly smooth.
+				//
+				// The buffer is sized from tick ARRIVAL GAPS instead (WorldRunner.RecordTickGap),
+				// which is one level up and unambiguous: an idle entity is quiet while every other
+				// entity keeps arriving, whereas a real dropout stops the whole stream.
 				from = SnapshotBuffer[lastIdx].Properties[propertyIndex];
 				to = from; // Same value = no interpolation
 				t = 0f;
 				return true;
 			}
 
-			// Edge case: render tick is before all snapshots - snap to earliest
+			// Edge case: render tick is before all snapshots - snap to earliest. The opposite
+			// complaint: the buffer is deeper than the clock needs.
 			if (fromIdx == -1)
 			{
 				from = SnapshotBuffer[toIdx].Properties[propertyIndex];

--- a/addons/Nebula/Core/Nodes/NetTransform/NetTransform3D.cs
+++ b/addons/Nebula/Core/Nodes/NetTransform/NetTransform3D.cs
@@ -614,6 +614,25 @@ namespace Nebula.Utility.Nodes
                             int ticksAdvanced = _hermiteLatestTick - _hermiteLastProcessedTick;
                             double tickDelta = 1.0 / NetRunner.TPS;
                             _hermiteTimeSincePhysicsUpdate -= ticksAdvanced * tickDelta;
+
+                            // FLOOR ONLY. Capping this at one tick here as well looks like the tidier
+                            // fix for the ratchet and is actively wrong: it makes the window sawtooth
+                            // 0 -> one tick every tick. For an OWNED entity that is invisible, because
+                            // the buffered physics position advances exactly one tick at the same
+                            // moment and the two cancel -- which is what the carry-over above exists
+                            // for. A NON-OWNED entity has no such cancellation: its source position
+                            // comes from interpolated NetPosition and advances smoothly, so a
+                            // sawtoothing window multiplied by its velocity is pure oscillation --
+                            // measured as remote ships juddering at several units per tick.
+                            //
+                            // And this branch DOES run for them: NetworkController.IsCurrentOwner is
+                            // `IsServer || (IsClient && InputAuthority.IsSet)`, which on a client is
+                            // true for any node that has an input authority at all, not just one this
+                            // peer owns. Treat "owner" here as "someone's owned entity".
+                            //
+                            // A standing offset is harmless -- it is constant, so it reads as the
+                            // entity simply being drawn slightly ahead. The ceiling below is what
+                            // bounds it; this floor is all that belongs here.
                             if (_hermiteTimeSincePhysicsUpdate < 0)
                                 _hermiteTimeSincePhysicsUpdate = 0;
                         }
@@ -626,6 +645,27 @@ namespace Nebula.Utility.Nodes
                         _hermiteVisualVelocity = physicsVel;
                         _hermiteInitialized = true;
                     }
+
+                    // BOUND THE EXTRAPOLATION WINDOW. Without this the accumulator above is an
+                    // unanchored integrator: frames add delta, ticks subtract ticksAdvanced * tickDelta,
+                    // and in steady state those balance exactly -- so it PRESERVES whatever offset it
+                    // holds instead of converging on the right one. The floor at zero clips downward
+                    // excursions while upward ones accumulate in full, making it a one-way ratchet that
+                    // a single startup hitch can wind up permanently.
+                    //
+                    // Measured before this clamp: pinned at 188ms (5.6 ticks) for an entire session,
+                    // which drew the player's ship 37 units AHEAD of its own simulated position at
+                    // 200 u/s -- worse than the Exponential mode's ~10 units of lag that Hermite was
+                    // chosen over. The tell was that visual error / speed was exactly 0.188s at every
+                    // speed from 143 to 200 u/s.
+                    //
+                    // The ceiling is derived, not tuned: extrapolation exists to cover the gap between
+                    // physics updates, so anything past one tick is drawing motion the simulation has
+                    // not produced. The half-tick over is headroom for frame jitter.
+                    const float MaxExtrapolationTicks = 1.5f;
+                    double maxExtrapolation = MaxExtrapolationTicks / NetRunner.TPS;
+                    if (_hermiteTimeSincePhysicsUpdate > maxExtrapolation)
+                        _hermiteTimeSincePhysicsUpdate = maxExtrapolation;
 
                     // Extrapolate physics to current frame time.
                     // Because we carry over excess time, this line is continuous
@@ -700,6 +740,7 @@ namespace Nebula.Utility.Nodes
 
             ApplyAbsorbedOffset(target, (float)delta);
         }
+
 
         /// <summary>
         /// Teleports to a position, skipping interpolation.

--- a/addons/Nebula/Core/Protocol.cs
+++ b/addons/Nebula/Core/Protocol.cs
@@ -539,6 +539,39 @@ namespace Nebula.Serialization
             return method;
         }
 
+        private static readonly Dictionary<int, bool> _nodeRefClassCache = new();
+
+        /// <summary>
+        /// Whether this class index serializes a NODE REFERENCE — an id lookup — rather than
+        /// in-place-mutated content.
+        ///
+        /// <para>The distinction decides whether the property may be gated on its dirty bit.
+        /// Types like <c>NetArray&lt;T&gt;</c> and game snapshot objects are mutated in place, so
+        /// their setter never fires, <c>MarkDirty</c> never runs, and the dirty mask cannot see the
+        /// change — which is why the object write loop calls every object serializer every tick and
+        /// lets each self-filter. A node reference is only ever ASSIGNED, and
+        /// <see cref="NetworkController.MarkDirtyRef"/> already sets its bit, so the every-tick call
+        /// is pure cost.</para>
+        ///
+        /// <para>Resolved from the type rather than a hardcoded list of the three node classes, so a
+        /// property typed as any game subclass is covered — their <c>NetworkSerialize</c> is the
+        /// inherited static one on NetNode/NetNode2D/NetNode3D.</para>
+        /// </summary>
+        public static bool IsNodeReferenceClass(int classIndex)
+        {
+            if (classIndex < 0) return false;
+            if (_nodeRefClassCache.TryGetValue(classIndex, out var cached)) return cached;
+
+            bool isNodeRef = false;
+            if (GeneratedProtocol.StaticMethods.TryGetValue(classIndex, out var info))
+            {
+                var type = GetCachedType(info.TypeFullName);
+                isNodeRef = type != null && typeof(INetNodeBase).IsAssignableFrom(type);
+            }
+            _nodeRefClassCache[classIndex] = isNodeRef;
+            return isNodeRef;
+        }
+
         private static Type GetCachedType(string typeName)
         {
             if (_typeCache.TryGetValue(typeName, out var cached))

--- a/addons/Nebula/Core/Serialization/Serializers/NetPropertiesSerializer.cs
+++ b/addons/Nebula/Core/Serialization/Serializers/NetPropertiesSerializer.cs
@@ -158,6 +158,12 @@ namespace Nebula.Serialization.Serializers
 
         /// <summary>Pre-cached: does this property type support delta encoding?</summary>
         private readonly bool[] _propSupportsDelta;
+        /// <summary>
+        /// Object properties that hold a NODE REFERENCE rather than in-place-mutated content.
+        /// These are the only object properties whose dirty bit is trustworthy — see
+        /// <see cref="Protocol.IsNodeReferenceClass"/> — so they are the only ones gated on it.
+        /// </summary>
+        private readonly bool[] _propIsNodeRef;
 
         /// <summary>Pre-cached property types</summary>
         private readonly SerialVariantType[] _propTypes;
@@ -270,6 +276,7 @@ namespace Nebula.Serialization.Serializers
                 _propertyCount = 0;
                 _byteCount = 0;
                 _propSupportsDelta = Array.Empty<bool>();
+                _propIsNodeRef = Array.Empty<bool>();
                 _propTypes = Array.Empty<SerialVariantType>();
                 _propIsObject = Array.Empty<bool>();
                 _propClassIndex = Array.Empty<int>();
@@ -303,6 +310,7 @@ namespace Nebula.Serialization.Serializers
             }
 
             _propSupportsDelta = new bool[_propertyCount];
+            _propIsNodeRef = new bool[_propertyCount];
             _propTypes = new SerialVariantType[_propertyCount];
             _propIsObject = new bool[_propertyCount];
             _propClassIndex = new int[_propertyCount];
@@ -317,6 +325,7 @@ namespace Nebula.Serialization.Serializers
                 var prop = Protocol.UnpackProperty(_cachedSceneFilePath, i);
                 _propTypes[i] = prop.VariantType;
                 _propSupportsDelta[i] = SupportsDelta(prop.VariantType);
+                _propIsNodeRef[i] = prop.IsObjectProperty && Protocol.IsNodeReferenceClass(prop.ClassIndex);
                 _propIsObject[i] = prop.IsObjectProperty;
                 _propClassIndex[i] = prop.ClassIndex;
                 _propIsPerPeer[i] = prop.IsPerPeer;
@@ -807,6 +816,7 @@ namespace Nebula.Serialization.Serializers
 
             _propTypes = propTypes;
             _propSupportsDelta = new bool[_propertyCount];
+            _propIsNodeRef = new bool[_propertyCount];
             _propIsObject = new bool[_propertyCount];
             _propClassIndex = new int[_propertyCount];
             for (int i = 0; i < _propertyCount; i++) _propClassIndex[i] = -1;
@@ -1662,11 +1672,13 @@ namespace Nebula.Serialization.Serializers
             // be written absolute so it is exact on arrival.
             Array.Copy(_propertiesUpdated, _dirtyOnlyMask, byteCount);
 
-            // Include non-default PRIMITIVE properties that haven't been synced yet
+            // Include non-default properties that haven't been synced yet. Node references
+            // join the primitives here: their dirty bit is real (MarkDirtyRef sets it), so a
+            // late joiner needs the same initial-sync coverage a primitive gets.
             foreach (var propIndex in nonDefaultProperties)
             {
-                // Skip object properties
-                if (_propIsObject[propIndex]) continue;
+                // Skip object properties whose dirty bit means nothing (in-place mutation).
+                if (_propIsObject[propIndex] && !_propIsNodeRef[propIndex]) continue;
 
                 var byteIndex = propIndex / BitConstants.BitsInByte;
                 var propSlot = (byte)(1 << (propIndex % BitConstants.BitsInByte));
@@ -1697,16 +1709,17 @@ namespace Nebula.Serialization.Serializers
                 }
             }
 
-            // Include PRIMITIVE properties that were sent but not yet acknowledged (for re-sending)
+            // Include properties that were sent but not yet acknowledged (for re-sending).
+            // Node references ride this too: once they are only sent on change, this is the
+            // ONLY thing that recovers a reference lost in flight.
             for (var i = 0; i < state.PendingDirtyMask.Length && i < _propertiesUpdated.Length; i++)
             {
-                // Only include primitive properties from pending mask
                 var pendingByte = state.PendingDirtyMask[i];
                 for (int j = 0; j < 8; j++)
                 {
                     int propIndex = i * 8 + j;
                     if (propIndex >= _propertyCount) break;
-                    if (_propIsObject[propIndex]) continue; // Skip objects
+                    if (_propIsObject[propIndex] && !_propIsNodeRef[propIndex]) continue;
                     if ((pendingByte & (1 << j)) != 0)
                     {
                         _propertiesUpdated[i] |= (byte)(1 << j);
@@ -1911,6 +1924,13 @@ namespace Nebula.Serialization.Serializers
                             actualMask[i] &= (byte)~(1 << j);
                             _leftoverMask[i] |= (byte)(1 << j);
                         }
+                        else if (Diagnostics.PayloadCensus.Enabled)
+                        {
+                            var censusProp = Protocol.UnpackProperty(_cachedSceneFilePath, propIndex);
+                            Diagnostics.PayloadCensus.Record(
+                                $"{censusProp.NodePath}.{censusProp.Name}",
+                                buffer.WritePosition - propStartPos, useDelta);
+                        }
                     }
                     catch (Exception ex)
                     {
@@ -1934,6 +1954,18 @@ namespace Nebula.Serialization.Serializers
 
                 // Check interest for this property
                 if (!PeerHasInterestInProperty(propIndex, peerInterestLayers)) continue;
+
+                // A node reference is only ever ASSIGNED, so MarkDirtyRef has already told us
+                // whether it changed — unlike an in-place-mutated object, whose dirty bit means
+                // nothing and which therefore has to be asked every tick. Gate it on the same
+                // merged mask the primitives use, so it inherits initial sync for late joiners
+                // and resend-until-acked for loss, and costs nothing while it sits unchanged.
+                if (_propIsNodeRef[propIndex]
+                    && (_propertiesUpdated[propIndex / BitConstants.BitsInByte]
+                        & (1 << (propIndex % BitConstants.BitsInByte))) == 0)
+                {
+                    continue;
+                }
 
                 var classIndex = _propClassIndex[propIndex];
                 if (classIndex < 0) continue;
@@ -1970,6 +2002,14 @@ namespace Nebula.Serialization.Serializers
                         int byteIdx = propIndex / 8;
                         int bitIdx = propIndex % 8;
                         actualMask[byteIdx] |= (byte)(1 << bitIdx);
+
+                        if (Diagnostics.PayloadCensus.Enabled)
+                        {
+                            var censusProp = Protocol.UnpackProperty(_cachedSceneFilePath, propIndex);
+                            Diagnostics.PayloadCensus.Record(
+                                $"{censusProp.NodePath}.{censusProp.Name} (obj)",
+                                buffer.WritePosition - startPos, false);
+                        }
                     }
                     else
                     {
@@ -2068,7 +2108,10 @@ namespace Nebula.Serialization.Serializers
                 {
                     if ((b & (1 << bit)) == 0) continue;
                     int propIdx = byteIdx * 8 + bit;
-                    if (propIdx >= _propertyCount || _propIsObject[propIdx]) continue;
+                    if (propIdx >= _propertyCount) continue;
+                    // Node references are banked like primitives; other object properties own
+                    // their per-peer resend state inside their own serializer.
+                    if (_propIsObject[propIdx] && !_propIsNodeRef[propIdx]) continue;
                     state.PendingDirtyMask[byteIdx] |= (byte)(1 << bit);
                     if (propIdx < 64)
                     {

--- a/addons/Nebula/Core/WorldRunner.cs
+++ b/addons/Nebula/Core/WorldRunner.cs
@@ -493,6 +493,9 @@ namespace Nebula
         internal void AccumulateRenderTime(float delta)
         {
             TimeSinceLastTick += delta;
+
+            // Peak silence this window. Sampled here rather than on arrival because the gap that
+            // matters is the one still OPEN -- a stream that has stopped reports nothing at all.
         }
 
         /// <summary>
@@ -500,20 +503,324 @@ namespace Nebula
         /// </summary>
         internal void OnWorldTickReceived(int tick)
         {
+            // The gap that just ended is what the jitter buffer is sized from, so it is tallied here --
+            // the one place that knows an arrival happened.
+            if (NetRunner.Instance.IsClient) RecordTickGap(TimeSinceLastTick);
+
             // Reset accumulator when we receive a new tick
             TimeSinceLastTick = 0f;
         }
 
+        // ---------------------------------------------------------------- the render clock
+
+        /// <summary>
+        /// Continuous render tick. Advanced once per frame in <see cref="_Process"/>, never derived
+        /// per call -- see <see cref="AdvanceRenderClock"/>.
+        /// </summary>
+        private float _renderClock = float.NaN;
+
+        private float _renderClockError;
+        private int _renderClockSampledTick = int.MinValue;
+
+        /// <summary>How hard the clock is pulled toward the simulated tick, per tick of error.</summary>
+        private const float RenderClockGain = 0.25f;
+
+        /// <summary>Ceiling on that correction as a fraction of normal speed.</summary>
+        private const float RenderClockMaxRateAdjust = 0.05f;
+
+        /// <summary>Error past which the clock is re-seeded instead of corrected: a world change, a
+        /// long hitch, the first frame. Evaluated ONLY when a tick arrives -- see
+        /// <see cref="AdvanceRenderClock"/> for why silence must never trigger it.</summary>
+        private const float RenderClockResyncTicks = 3f;
+
+        /// <summary>How much of each once-per-tick error sample is taken.</summary>
+        private const float RenderClockSampleWeight = 0.25f;
+
+        /// <summary>
+        /// Advances the render clock one frame.
+        ///
+        /// <para>This replaced "last RECEIVED tick plus how long ago it arrived", which is exact and
+        /// stateless while packets arrive on a perfectly regular cadence -- the accumulator reaches one
+        /// tick exactly as the tick counter increments, so the result is continuous with no state at
+        /// all. Under jitter that coincidence breaks, and it breaks in a way that is easy to miss:
+        /// the value never went BACKWARD in measurement, but it advanced UNEVENLY. Measured at 50fps
+        /// against 30Hz ticks, remote entities should move 0.6 ticks per frame and instead alternated
+        /// between 0.4 and 1.0 -- a couple of units of positional wobble at half the frame rate, which
+        /// is a shimmer rather than a jump. Arrival jitter of 19-43ms against a 33.3ms nominal went
+        /// straight onto the screen.</para>
+        ///
+        /// <para>So the clock free-runs on real time and is pulled toward the simulated tick by a
+        /// small capped RATE adjustment. It cannot drift, because a standing error is always being
+        /// corrected, and it cannot judder, because it only ever advances -- slightly fast or slightly
+        /// slow. The error is sampled ONCE PER TICK, at arrival, because that is the only instant whose
+        /// meaning is unambiguous: continuous time is exactly T when tick T lands. Sampled every frame
+        /// against the tick counter instead, the error sawtooths by a full tick every tick however
+        /// well the clock tracks, and steering the rate with that reintroduces the very unevenness
+        /// this removes.</para>
+        /// </summary>
+        internal static (float Tick, float Error, int SampledTick) AdvanceRenderClock(
+            float clock, float error, int sampledTick, int currentTick, int delayTicks, float delta)
+        {
+            int targetTick = currentTick - delayTicks;
+
+            if (float.IsNaN(clock)) return (targetTick, 0f, currentTick);
+
+            // A RE-SEED IS ONLY EVER JUSTIFIED BY AN ARRIVAL, so both it and the error sample live
+            // behind this one gate.
+            //
+            // SILENCE IS ABSENCE OF NEWS, NOT EVIDENCE THAT RENDER TIME IS WRONG. While the stream is
+            // quiet the target stands still, so a free-running clock necessarily outruns it -- and a
+            // symmetric every-frame check read that as a three-tick error and "corrected" it by
+            // snapping render time BACKWARD, replaying motion already drawn. Measured under 200ms
+            // bursts every ~8s: a -3.4 tick step (~115ms of motion) on every single burst, and it
+            // persisted at the deepest buffer the controller can reach, because buffer depth and this
+            // are unrelated faults. The clock was right and the target was merely stale: the server
+            // kept ticking, we just had not heard, and when the stream resumes the target jumps by
+            // exactly the length of the silence and lands back on the clock -- no correction needed,
+            // which is why coasting costs nothing to recover from.
+            //
+            // A genuine pause is still caught, just one instant later: when the stream resumes with
+            // the target STILL far behind the clock, that arrival proves the server did not tick
+            // through the gap, and the re-seed below fires then.
+            //
+            // THE GATE IS THE TICK COUNTER, NOT THE TARGET, and the difference is not pedantic. The
+            // target is `currentTick - delayTicks`, so the ADAPTIVE BUFFER moves it too -- and the one
+            // moment it is most likely to move is the window a dropout was just detected in, which is
+            // exactly when the clock is coasting furthest ahead. Keyed on the target, a delay change
+            // mid-dropout opens this gate with no arrival behind it, and the re-seed fires against a
+            // stale target: observed once as a -8.3 tick step on a 300ms burst that grew the buffer
+            // from 4 to 5. Keyed on the counter, resizing the buffer only moves where the clock is
+            // AIMED, and the next real arrival slews to it.
+            if (currentTick != sampledTick)
+            {
+                if (Math.Abs(targetTick - clock) > RenderClockResyncTicks) return (targetTick, 0f, currentTick);
+
+                sampledTick = currentTick;
+                error = error + (targetTick - clock - error) * RenderClockSampleWeight;
+            }
+
+            var rate = 1f + Math.Clamp(
+                error * RenderClockGain, -RenderClockMaxRateAdjust, RenderClockMaxRateAdjust);
+            return (clock + delta * NetRunner.TPS * rate, error, sampledTick);
+        }
+
         /// <summary>
         /// Get the fractional render tick for interpolation (used by all entities).
+        ///
+        /// <para>A pure read of the clock advanced in <see cref="_Process"/>; every entity in the frame
+        /// therefore gets the same answer no matter when it asks.</para>
+        ///
+        /// <para>THE DELAY IS ALREADY IN THE CLOCK -- it is part of what the clock aims at, not
+        /// subtracted here. That is what lets <see cref="InterpolationDelayTicks"/> change at runtime:
+        /// a one-tick change moves the target by one tick and the rate correction absorbs it over
+        /// about a second, instead of teleporting render time the instant the buffer is resized.</para>
         /// </summary>
         public float GetRenderTick()
         {
-            float tickDuration = 1f / NetRunner.TPS;
-            float fractionalTick = TimeSinceLastTick / tickDuration;
-            // Clamp to avoid extrapolating too far if frame is slow
-            fractionalTick = Math.Min(fractionalTick, 1.5f);
-            return CurrentTick + fractionalTick - InterpolationDelayTicks;
+            if (float.IsNaN(_renderClock))
+            {
+                // Before the first frame has advanced it, fall back to the original derivation so a
+                // caller during startup still gets a sane answer.
+                float fallback = Math.Min(TimeSinceLastTick * NetRunner.TPS, 1.5f);
+                return CurrentTick + fallback - InterpolationDelayTicks;
+            }
+            return _renderClock;
+        }
+
+        // ------------------------------------------------------------- adaptive interpolation delay
+
+        /// <summary>
+        /// Shallowest buffer the controller will settle on, and the value shipped as the default.
+        ///
+        /// <para>NOT the theoretical minimum. One tick technically interpolates -- there is still a
+        /// snapshot on each side -- but it leaves no slack whatsoever: a single packet arriving late
+        /// starves it, the buffer grows back, and the controller hunts between one and two forever on
+        /// any link with jitter at all. Two ticks is the shallowest depth that absorbs one late
+        /// packet, so it is the right floor for a policy whose whole job is avoiding starvation.</para>
+        /// </summary>
+        private const int MinInterpolationDelayTicks = 2;
+
+        /// <summary>
+        /// Largest usable buffer, and a real ceiling rather than a chosen one:
+        /// <c>NetworkController.SNAPSHOT_BUFFER_SIZE</c> is 8 PER ENTITY, so beyond this the delay
+        /// would point past the oldest snapshot the buffer can still hold. At 30 TPS that caps the
+        /// jitter buffer at roughly 200ms. If the controller pins here under test, the buffer size is
+        /// the next thing to look at -- growing it costs memory per entity per property, so it is a
+        /// deliberate separate decision rather than something to raise quietly.
+        /// </summary>
+        private const int MaxInterpolationDelayTicks = 6;
+
+        /// <summary>Windows the target must stay below the current depth before a tick is given back.</summary>
+        private const int CleanWindowsBeforeShrink = 5;
+
+        /// <summary>
+        /// Arrival gaps are tallied in whole ticks; anything at or beyond the last bucket lands in it.
+        /// Sized past <see cref="MaxInterpolationDelayTicks"/> so an outage the buffer could never
+        /// cover is still COUNTED (it has to be, or it could not be outvoted by the ordinary traffic
+        /// around it) without needing a bucket per possible length.
+        /// </summary>
+        private const int GapHistogramBuckets = 16;
+
+        /// <summary>
+        /// Fraction of arrivals the buffer is sized to absorb without a freeze.
+        ///
+        /// <para>THE WHOLE POINT OF THE REWRITE. Sizing for the WORST gap means paying its latency on
+        /// every frame forever, and a rare outage is the one case where that trade is clearly bad: a
+        /// 200ms burst every 8s is 0.4% of arrivals, so covering it costs 100ms of permanent lag to
+        /// improve four seconds in a thousand. Sizing for a high percentile instead covers ordinary
+        /// jitter -- which is continuous, and what a jitter buffer is actually for -- and lets the rare
+        /// outage be the freeze it honestly is.</para>
+        /// </summary>
+        private const float TargetGapCoverage = 0.99f;
+
+        /// <summary>
+        /// Arrivals the percentile is taken over: a true sliding window, ~17s at 30 TPS.
+        ///
+        /// <para>SIZED BY WHAT THE PERCENTILE HAS TO RESOLVE, not by feel. A 99th percentile can only
+        /// step over an event that is genuinely rarer than 1% of samples, so the window has to hold
+        /// enough arrivals for a rare fault to BE rare in it. A burst every 8s is one arrival in 240;
+        /// measured against a decaying tally worth only ~56 effective samples, that single gap was 1.8%
+        /// of the distribution and dragged the target to the ceiling on every burst -- the percentile
+        /// was right and the sample count was too small for it to mean anything.</para>
+        /// </summary>
+        private const int GapWindowSamples = 512;
+
+        /// <summary>
+        /// Most the buffer may move in one window.
+        ///
+        /// <para>Kept strictly under <see cref="RenderClockResyncTicks"/>, and that is the entire
+        /// reason it exists: the delay is part of what the render clock aims at, so resizing the buffer
+        /// by more than the clock can absorb re-seeds it at the next arrival -- a visible jump
+        /// BACKWARD, which is exactly what the clock work removed. Observed as a -4.5 tick step when a
+        /// four-tick growth landed in one window.</para>
+        /// </summary>
+        private const int MaxDelayStepTicks = 2;
+
+        private ulong _delayWindowStartMsec;
+
+        /// <summary>How many arrivals in the window were separated by n whole ticks. Maintained
+        /// incrementally against <see cref="_gapSamples"/>, so the percentile is exact and costs
+        /// nothing to read.</summary>
+        private readonly int[] _gapHistogram = new int[GapHistogramBuckets];
+
+        /// <summary>The window itself: one bucket index per arrival, oldest overwritten first.
+        /// A byte because <see cref="GapHistogramBuckets"/> is 16.</summary>
+        private readonly byte[] _gapSamples = new byte[GapWindowSamples];
+        private int _gapSampleIndex;
+        private int _gapSampleCount;
+
+        /// <summary>Consecutive windows whose target sat below the current depth.</summary>
+        private int _windowsBelowTarget;
+
+        /// <summary>
+        /// Tallies one arrival gap. Called from <see cref="OnWorldTickReceived"/>, which is the only
+        /// place that knows an arrival happened -- and the level at which a dropout is distinguishable
+        /// from an idle entity at all. A per-entity view cannot tell them apart: both look like running
+        /// past the newest snapshot. An idle entity is quiet while every OTHER entity keeps arriving;
+        /// a dropout is the whole stream stopping, which is precisely what this measures.
+        /// </summary>
+        private void RecordTickGap(float gapSeconds)
+        {
+            int gapTicks = (int)(gapSeconds * NetRunner.TPS);
+            if (gapTicks < 0) gapTicks = 0;
+            if (gapTicks >= GapHistogramBuckets) gapTicks = GapHistogramBuckets - 1;
+
+            // Evict the sample this slot is about to overwrite, so the histogram always describes
+            // exactly the arrivals still in the window.
+            if (_gapSampleCount == GapWindowSamples) _gapHistogram[_gapSamples[_gapSampleIndex]]--;
+            else _gapSampleCount++;
+
+            _gapSamples[_gapSampleIndex] = (byte)gapTicks;
+            _gapHistogram[gapTicks]++;
+            _gapSampleIndex = (_gapSampleIndex + 1) % GapWindowSamples;
+        }
+
+        /// <summary>
+        /// The shallowest buffer that would have absorbed <paramref name="coverage"/> of the arrivals
+        /// tallied in <paramref name="histogram"/>, clamped to the usable range.
+        ///
+        /// <para>THE FIX FOR A BUFFER THAT HUNTS. The previous policy grew on ANY starvation and shrank
+        /// after a fixed clean run, which cannot settle against a repeating fault: measured against a
+        /// 200ms burst every 8s, it sawtoothed between 3 and 6 ticks forever -- 100ms of lag appearing
+        /// and disappearing -- while never once being deep enough, because nine of eleven bursts
+        /// exceeded even the ceiling. It was paying latency for coverage it could not reach.</para>
+        ///
+        /// <para>A percentile settles by construction. Ordinary jitter is continuous, so it dominates
+        /// the distribution and fixes the answer; a rare outage is a handful of samples that the
+        /// percentile steps over, so the buffer stops chasing what it cannot catch. When the link
+        /// genuinely degrades -- when big gaps stop being rare -- they cross the percentile on their
+        /// own and the buffer grows, which is the adaptation actually worth having.</para>
+        ///
+        /// <para>Pure so the policy is testable without a network, the same way
+        /// <see cref="AdvanceRenderClock"/> is.</para>
+        /// </summary>
+        internal static int DelayForCoverage(ReadOnlySpan<int> histogram, float coverage, int min, int max)
+        {
+            int total = 0;
+            for (int i = 0; i < histogram.Length; i++) total += histogram[i];
+
+            // No arrivals measured yet: the shipped default is the honest answer, not a guess.
+            if (total == 0) return min;
+
+            // Ceiling, so a coverage of 1.0 means every sample rather than all-but-rounding.
+            int needed = (int)Math.Ceiling(total * coverage);
+
+            int running = 0;
+            for (int gapTicks = 0; gapTicks < histogram.Length; gapTicks++)
+            {
+                running += histogram[gapTicks];
+
+                // A gap of n ticks is absorbed by a buffer of n ticks -- see the starvation rule in
+                // NetworkController.GetInterpolationSnapshots -- so the bucket index IS the depth.
+                if (running >= needed) return Math.Clamp(gapTicks, min, max);
+            }
+
+            return max;
+        }
+
+        /// <summary>
+        /// Moves the buffer toward <paramref name="target"/>: straight up, one tick at a time down.
+        ///
+        /// <para>The asymmetry survives the rewrite because its reasoning does. Under-buffering is
+        /// visible the moment it happens, so there is no case for approaching it slowly;
+        /// over-buffering only costs latency nobody can see directly, so there is no case for racing to
+        /// reclaim it, and a slow release keeps a link that is merely between faults from being
+        /// re-measured as healthy.</para>
+        /// </summary>
+        internal static int NextInterpolationDelay(int current, int target, int windowsBelowTarget)
+        {
+            if (target > current)
+                return Math.Min(Math.Min(target, current + MaxDelayStepTicks), MaxInterpolationDelayTicks);
+
+            if (target < current && windowsBelowTarget >= CleanWindowsBeforeShrink)
+                return Math.Max(current - 1, MinInterpolationDelayTicks);
+
+            return current;
+        }
+
+        /// <summary>
+        /// Resizes the jitter buffer once a second from what interpolation actually experienced.
+        /// Client-only: the server neither interpolates nor renders.
+        /// </summary>
+        private void UpdateInterpolationDelay()
+        {
+            var now = Time.GetTicksMsec();
+            if (_delayWindowStartMsec == 0) { _delayWindowStartMsec = now; return; }
+            if (now - _delayWindowStartMsec < 1000) return;
+            _delayWindowStartMsec = now;
+
+            int target = DelayForCoverage(
+                _gapHistogram, TargetGapCoverage, MinInterpolationDelayTicks, MaxInterpolationDelayTicks);
+
+            _windowsBelowTarget = target < InterpolationDelayTicks ? _windowsBelowTarget + 1 : 0;
+
+            int next = NextInterpolationDelay(InterpolationDelayTicks, target, _windowsBelowTarget);
+            if (next == InterpolationDelayTicks) return;
+
+            // Any move restarts the release run, so a buffer that steps down does not immediately
+            // qualify to step down again on the following window.
+            _windowsBelowTarget = 0;
+            InterpolationDelayTicks = next;
         }
 
         #endregion
@@ -832,6 +1139,29 @@ namespace Nebula
         }
 
         /// <summary>
+        /// Round-trip time as the APPLICATION experiences it: what the transport measured, plus any
+        /// delay the synthetic impairment is holding packets for.
+        ///
+        /// <para>WITHOUT THIS THE IMPAIRMENT SIMULATES A LINK THAT CANNOT EXIST. ENet measures RTT
+        /// inside the native transport, and <see cref="Diagnostics.NetworkImpairment"/> holds packets
+        /// AFTER ENet has delivered them -- so on loopback the peer still reports ~0ms however severe
+        /// the configured latency is. The lead is derived from that reading, so an impaired client
+        /// aimed for the loopback minimum of two ticks while its view of the server ran 80ms (2.4
+        /// ticks) behind: it stamped every input for a tick the server had ALREADY simulated, and the
+        /// server fell back to the previous tick's input (see GetServerBufferedInput) essentially
+        /// forever. Held keys survive that unharmed -- the repeated input is the same input -- but
+        /// every TRANSITION lands a tick late on the server, and a mistimed turn is a permanent
+        /// heading disagreement, because one tick of turning is a smaller change than the forward
+        /// direction's prediction tolerance and is therefore never reconciled.</para>
+        ///
+        /// <para>Only the configured latency is added, not the jitter: LEAD_JITTER_MARGIN_TICKS
+        /// already exists to cover variance, and paying for the worst jitter on every tick is the
+        /// same bad trade the interpolation buffer avoids.</para>
+        /// </summary>
+        internal static uint EffectiveRoundTripMs(uint measuredRttMs, int simulatedLatencyMs)
+            => measuredRttMs + (uint)Math.Max(0, simulatedLatencyMs);
+
+        /// <summary>
         /// Slew decision for one eligible frame: 1 is steady state; 0 sheds one tick of
         /// excess lead; 2 builds one tick of missing lead. Correction is rate-limited to
         /// one tick per SLEW_INTERVAL eligible frames so a 25-tick debt drains in a few
@@ -868,7 +1198,9 @@ namespace Nebula
                 // client can shed it. Warn on first engage, then every ~10s while pinned.
                 if ((_predictionThrottleLogCounter++ % 300) == 0)
                 {
-                    uint rtt = NetRunner.Instance.ServerPeer.IsSet ? NetRunner.Instance.ServerPeer.RoundTripTime : 0;
+                    uint rtt = EffectiveRoundTripMs(
+                        NetRunner.Instance.ServerPeer.IsSet ? NetRunner.Instance.ServerPeer.RoundTripTime : 0,
+                        NetRunner.Impairment.LatencyMs);
                     Log(Debugger.DebugLevel.WARN,
                         $"[Prediction] Lead capped: predicted {_clientPredictedTick} is {_clientPredictedTick - CurrentTick} ahead of confirmed {CurrentTick} " +
                         $"(rtt {rtt}ms, target lead {ComputeTargetLeadTicks(rtt, NetRunner.TPS)}) — confirmed timeline is falling behind faster than the slew can shed lead");
@@ -1466,6 +1798,8 @@ namespace Nebula
                 // Timed separately from the scan around it: this is game code, and telling it apart
                 // from Nebula's own per-node bookkeeping is the whole point of the breakdown.
                 var gameplayTs = Diagnostics.TickProfiler.Now();
+                var censusTs = Diagnostics.PayloadCensus.Enabled
+                    ? System.Diagnostics.Stopwatch.GetTimestamp() : 0L;
                 netController._NetworkProcess(CurrentTick);
                 foreach (var networkChild in netController.StaticNetworkChildren)
                 {
@@ -1473,6 +1807,14 @@ namespace Nebula
                     if (networkChild.RawNode == null) continue;
                     if (networkChild.RawNode.ProcessMode == ProcessModeEnum.Disabled) continue;
                     networkChild._NetworkProcess(CurrentTick);
+                }
+                if (censusTs != 0L)
+                {
+                    // Charged to the ROOT scene including its static children, which is
+                    // the unit a reader can actually go and open.
+                    Diagnostics.PayloadCensus.RecordGameplay(
+                        netController.RawNode?.SceneFilePath,
+                        System.Diagnostics.Stopwatch.GetTimestamp() - censusTs);
                 }
                 _profiler?.Record(Diagnostics.TickProfiler.Phase.Gameplay, gameplayTs);
             }
@@ -1832,6 +2174,17 @@ namespace Nebula
             if (NetRunner.Instance.IsClient)
             {
                 AccumulateRenderTime((float)delta);
+                UpdateInterpolationDelay();
+
+                // The delay is part of the TARGET, so resizing the buffer is slewed by the rate
+                // correction rather than jumping render time. See GetRenderTick.
+                var advanced = AdvanceRenderClock(
+                    _renderClock, _renderClockError, _renderClockSampledTick,
+                    CurrentTick, InterpolationDelayTicks, (float)delta);
+                _renderClock = advanced.Tick;
+                _renderClockError = advanced.Error;
+                _renderClockSampledTick = advanced.SampledTick;
+
             }
         }
 
@@ -1846,12 +2199,19 @@ namespace Nebula
             /// <summary>Valid byte count -- rented arrays are oversized, only [0, Length) is packet data.</summary>
             public readonly int Length;
 
-            public InboundPacket(NetPeer peer, byte channel, byte[] payload, int length)
+            /// <summary>
+            /// Wall clock at which this may be applied. Zero for the normal path -- only synthetic
+            /// impairment ever sets it, so an unimpaired build compares against zero and moves on.
+            /// </summary>
+            public readonly ulong ReleaseAtMsec;
+
+            public InboundPacket(NetPeer peer, byte channel, byte[] payload, int length, ulong releaseAtMsec = 0)
             {
                 Peer = peer;
                 Channel = channel;
                 Payload = payload;
                 Length = length;
+                ReleaseAtMsec = releaseAtMsec;
             }
         }
 
@@ -1883,7 +2243,8 @@ namespace Nebula
         /// returns it to the pool on drop, after apply, or at world teardown. Callers must not
         /// touch the array after this returns.
         /// </summary>
-        internal void EnqueueInboundPacket(NetPeer peer, byte channel, byte[] payload, int length)
+        internal void EnqueueInboundPacket(
+            NetPeer peer, byte channel, byte[] payload, int length, ulong releaseAtMsec = 0)
         {
             lock (_inboundLock)
             {
@@ -1900,7 +2261,7 @@ namespace Nebula
                     return;
                 }
 
-                _inboundPackets[_inboundTail] = new InboundPacket(peer, channel, payload, length);
+                _inboundPackets[_inboundTail] = new InboundPacket(peer, channel, payload, length, releaseAtMsec);
                 _inboundTail = (_inboundTail + 1) % InboundQueueCapacity;
                 _inboundCount++;
             }
@@ -1921,6 +2282,8 @@ namespace Nebula
                 pending = _inboundCount;
             }
 
+            ulong nowMsec = Time.GetTicksMsec();
+
             while (pending-- > 0)
             {
                 InboundPacket packet;
@@ -1928,6 +2291,12 @@ namespace Nebula
                 {
                     if (_inboundCount == 0) return;
                     packet = _inboundPackets[_inboundHead];
+
+                    // Held back by synthetic impairment. Stop rather than skip: this is a queue, and
+                    // releasing later packets around a held one would reorder every channel including
+                    // the reliable ones, which is not what a delayed link does.
+                    if (packet.ReleaseAtMsec > nowMsec) return;
+
                     // Release the payload reference so a quiet world doesn't pin up to
                     // InboundQueueCapacity packets until the slot is reused.
                     _inboundPackets[_inboundHead] = default;
@@ -2074,6 +2443,13 @@ namespace Nebula
                         CollectPeerRtt(out int metricsPeers, out double rttMean, out uint rttMax);
                         var metricsJson = _metrics.Emit(WorldId, CurrentTick, metricsPeers, rttMean, rttMax, metricsWindow);
 
+                        // Same window, so the census shares the metrics line's peers/duration.
+                        if (Diagnostics.PayloadCensus.Enabled)
+                        {
+                            Diagnostics.PayloadCensus.Emit(
+                                metricsPeers, metricsWindow, _metrics.TicksInLastWindow);
+                        }
+
                         // Also ship it to any attached debugger for the Performance tab.
                         // ~400 bytes once a second - negligible next to the tick frames.
                         // Priority + reliable: the main queue carries hundreds of frames
@@ -2121,9 +2497,11 @@ namespace Nebula
                         // Adaptive lead slew: steer the predicted timeline toward an
                         // RTT-derived lead instead of free-running (see the slew block
                         // above RunClientPredictionTick for why).
-                        uint rttMs = NetRunner.Instance.ServerPeer.IsSet
-                            ? NetRunner.Instance.ServerPeer.RoundTripTime
-                            : 0;
+                        uint rttMs = EffectiveRoundTripMs(
+                            NetRunner.Instance.ServerPeer.IsSet
+                                ? NetRunner.Instance.ServerPeer.RoundTripTime
+                                : 0,
+                            NetRunner.Impairment.LatencyMs);
                         int targetLead = ComputeTargetLeadTicks(rttMs, NetRunner.TPS);
                         int lead = _clientPredictedTick - CurrentTick;
                         int ticksToRun = PredictionTicksThisFrame(lead, targetLead, _eligibleFrameIndex);
@@ -2266,6 +2644,7 @@ namespace Nebula
         internal void ResetForWorldChange()
         {
             if (NetRunner.Instance.IsServer) return;
+
 
             // Let game-side singletons drop cached references to nodes we're about to free
             // (e.g. WorldPlayers.CurrentPlayer) before the nodes are disposed.
@@ -3081,7 +3460,7 @@ namespace Nebula
 
                 _profiler?.Record(Diagnostics.TickProfiler.Phase.ExportResync, exportPhaseTs);
 
-                if (_metrics != null)
+                    if (_metrics != null)
                 {
                     _metrics.RecordTickBudget(ledger.Used, ledger.Budget);
                     _metrics.RecordDeferredSections(spawnSectionsDeferred, propsSectionsDeferred);

--- a/addons/Nebula/Testing/Integration/ImpairedSoakTests.cs
+++ b/addons/Nebula/Testing/Integration/ImpairedSoakTests.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Nebula.Testing.Integration;
+
+/// <summary>
+/// Runs a real server and two real clients, one of them on a deliberately bad link, and asserts the
+/// session stays healthy.
+///
+/// <para>WHY THIS IS AN INTEGRATION TEST AND NOT A UNIT TEST. The pieces are unit-tested already —
+/// the impairment scheduler, the render clock, the delay policy. What none of those can show is the
+/// thing that actually went wrong historically: every one of those components measured fine in
+/// isolation while remote entities visibly stuttered, because the defect lived in how they combined
+/// under real arrival timing. This is the smallest harness that reproduces that combination.</para>
+///
+/// <para>It is also the first user of <see cref="IntegrationTestBase"/>, which has been present and
+/// unexercised. Both <c>ServerConfig</c> and <c>ClientConfig</c> already carry an <c>ExtraArgs</c>
+/// dictionary, so impairment needed no harness change at all.</para>
+/// </summary>
+public class ImpairedSoakTests : IntegrationTestBase
+{
+    /// <summary>Long enough for the adaptive buffer to react and settle: it evaluates once a second
+    /// and needs five consecutive clean windows before giving a tick back.</summary>
+    private static readonly TimeSpan SoakDuration = TimeSpan.FromSeconds(20);
+
+    private const string WorldScene = "res://scenes/structures/Backslat.tscn";
+
+    /// <summary>
+    /// A healthy client and a badly impaired one in the same session.
+    ///
+    /// <para>The asymmetry is the point. A run where everyone is equally degraded hides the case that
+    /// matters — one bad peer observed by a good one — which is exactly the shape of the remote-ship
+    /// stutter that prompted this work.</para>
+    /// </summary>
+    [Fact]
+    public Task ASessionSurvivesOneBadlyImpairedClient() => NebulaTest(async () =>
+    {
+        var server = StartServer(new ServerConfig
+        {
+            InitialWorldScene = WorldScene,
+            // One JSON line per interval on stdout; the assertions below read it.
+            ExtraArgs = { ["metrics"] = "1" },
+        });
+        await server.WaitForOutput("Server ready", TimeSpan.FromSeconds(60));
+
+        var healthy = StartClient();
+
+        var impaired = StartClient(new ClientConfig
+        {
+            ExtraArgs =
+            {
+                ["simLatencyMs"] = "80",
+                ["simJitterMs"] = "30",
+                ["simLossPct"] = "2",
+                // Seeded, so a failure here can actually be re-run.
+                ["simSeed"] = "20260826",
+            },
+        });
+
+        await Task.Delay(SoakDuration);
+
+        // 1. Nobody fell over. An impaired link must degrade smoothness, never liveness.
+        Assert.False(server.HasExited, "server exited during the soak");
+        Assert.False(healthy.HasExited, "the healthy client exited during the soak");
+        Assert.False(impaired.HasExited, "the impaired client exited during the soak");
+
+        // 2. The server kept ticking throughout, rather than stalling behind a struggling peer.
+        var ticks = MetricValues(server.AllOutput, "tickCount");
+        Assert.True(ticks.Count >= 2, $"expected repeated metrics lines, saw {ticks.Count}");
+        Assert.True(ticks.Last() > ticks.First(), "server tick count did not advance during the soak");
+
+        // 3. Neither client logged an error. The impairment exercises loss-recovery paths (spawn
+        //    resend, delta baseline fallback); those are supposed to be exercised, not to complain.
+        AssertNoErrors(healthy.AllOutput, "healthy client");
+        AssertNoErrors(impaired.AllOutput, "impaired client");
+    });
+
+    /// <summary>
+    /// The no-impairment control.
+    ///
+    /// <para>Worth its own test rather than being assumed: the impairment layer sits on the inbound
+    /// path of every build, and the thing most worth knowing is that an unconfigured session is
+    /// untouched by it.</para>
+    /// </summary>
+    [Fact]
+    public Task AnUnimpairedSessionIsUnaffected() => NebulaTest(async () =>
+    {
+        var server = StartServer(new ServerConfig
+        {
+            InitialWorldScene = WorldScene,
+            ExtraArgs = { ["metrics"] = "1" },
+        });
+        await server.WaitForOutput("Server ready", TimeSpan.FromSeconds(60));
+
+        var client = StartClient();
+        await Task.Delay(TimeSpan.FromSeconds(10));
+
+        Assert.False(server.HasExited, "server exited during the control run");
+        Assert.False(client.HasExited, "client exited during the control run");
+        AssertNoErrors(client.AllOutput, "client");
+    });
+
+    /// <summary>
+    /// Pulls a numeric field out of the <c>NEBULA_METRICS </c> stdout lines. Deliberately a shallow
+    /// scrape rather than a JSON dependency — the line format is stable and the alternative is adding
+    /// a parser to the test project for four numbers.
+    /// </summary>
+    private static List<double> MetricValues(string output, string field)
+    {
+        var values = new List<double>();
+        foreach (var line in output.Split('\n'))
+        {
+            int start = line.IndexOf($"\"{field}\":", StringComparison.Ordinal);
+            if (start < 0) continue;
+
+            start += field.Length + 3;
+            int end = start;
+            while (end < line.Length && (char.IsDigit(line[end]) || line[end] == '.' || line[end] == '-')) end++;
+
+            if (double.TryParse(line[start..end], NumberStyles.Float, CultureInfo.InvariantCulture, out double parsed))
+                values.Add(parsed);
+        }
+        return values;
+    }
+
+    private static void AssertNoErrors(string output, string label)
+    {
+        var offenders = output
+            .Split('\n')
+            .Where(line => line.Contains("(ERROR)", StringComparison.Ordinal))
+            .Take(5)
+            .ToArray();
+
+        Assert.True(offenders.Length == 0,
+            $"{label} logged errors:\n{string.Join("\n", offenders)}");
+    }
+}

--- a/addons/Nebula/Testing/Integration/ImpairedSoakTests.cs.uid
+++ b/addons/Nebula/Testing/Integration/ImpairedSoakTests.cs.uid
@@ -1,0 +1,1 @@
+uid://dttsfg4y6crre

--- a/addons/Nebula/Testing/Unit/InterpolationDelayTests.cs
+++ b/addons/Nebula/Testing/Unit/InterpolationDelayTests.cs
@@ -1,0 +1,243 @@
+using Nebula.Testing.Unit;
+using Xunit;
+
+namespace Nebula.Tests
+{
+    /// <summary>
+    /// The adaptive jitter-buffer policy: how deep a buffer remote entities are interpolated through.
+    ///
+    /// <para>Too shallow and the render clock outruns the data — <c>GetInterpolationSnapshots</c> takes
+    /// its hold-last branch and the entity freezes until more arrives. Too deep and everything is
+    /// needlessly late, on every single frame, forever. The policy is pure so it can be tested without
+    /// a network, the same way the render clock is.</para>
+    ///
+    /// <para>Sizing is by PERCENTILE of the observed arrival-gap distribution rather than by reacting
+    /// to individual starvations, and these tests are mostly about why. The reactive version could not
+    /// settle against a repeating fault: measured against a 200ms burst every 8s it sawtoothed between
+    /// 3 and 6 ticks indefinitely, never deep enough to help and never cheap enough to stop paying
+    /// for.</para>
+    /// </summary>
+    [NebulaUnitTest]
+    public class InterpolationDelayTests
+    {
+        private const int Min = 2;
+        private const int Max = 6;
+        private const int CleanWindowsBeforeShrink = 5;
+        private const float Coverage = 0.99f;
+
+        private static int Next(int current, int target, int windowsBelowTarget)
+            => WorldRunner.NextInterpolationDelay(current, target, windowsBelowTarget);
+
+        private static int Target(int[] histogram)
+            => WorldRunner.DelayForCoverage(histogram, Coverage, Min, Max);
+
+        /// <summary>Builds a gap histogram: <c>(gapTicks, count)</c> pairs into buckets.</summary>
+        private static int[] Gaps(params (int GapTicks, int Count)[] samples)
+        {
+            var histogram = new int[16];
+            foreach (var (gapTicks, count) in samples) histogram[gapTicks] += count;
+            return histogram;
+        }
+
+        // ─── Sizing from the distribution ────────────────────────────────────
+
+        /// <summary>
+        /// THE CASE THE REWRITE EXISTS FOR. A 200ms burst every 8s is ~0.4% of arrivals. Covering it
+        /// would cost 100ms of permanent lag on every frame to improve four seconds in a thousand, so
+        /// a 99th percentile must step straight over it and leave the buffer where ordinary traffic
+        /// puts it.
+        /// </summary>
+        [NebulaUnitTest]
+        public void ARareOutageDoesNotSizeTheBuffer()
+        {
+            // ~10s of a healthy 30 TPS link, plus one 8-tick hole per burst.
+            var histogram = Gaps((1, 297), (8, 3));
+
+            Assert.Equal(Min, Target(histogram));
+        }
+
+        /// <summary>
+        /// ...but the same gap SIZE sizes the buffer once it stops being rare. This is the adaptation
+        /// worth having, and the pair with the test above is the whole policy: the buffer reacts to how
+        /// OFTEN a gap happens, not to how big the worst one was.
+        /// </summary>
+        [NebulaUnitTest]
+        public void ACommonGapDoesSizeTheBuffer()
+        {
+            // The same 8-tick gap, now a tenth of all arrivals.
+            var histogram = Gaps((1, 270), (8, 30));
+
+            Assert.Equal(Max, Target(histogram));
+        }
+
+        /// <summary>Ordinary jitter — the continuous thing a jitter buffer is actually for — is
+        /// covered rather than stepped over.</summary>
+        [NebulaUnitTest]
+        public void OrdinaryJitterIsCovered()
+        {
+            // A link that routinely runs a tick or two late, and rarely three.
+            var histogram = Gaps((1, 200), (2, 80), (3, 19), (4, 1));
+
+            Assert.Equal(3, Target(histogram));
+        }
+
+        /// <summary>
+        /// The ceiling is not a taste choice: <c>NetworkController.SNAPSHOT_BUFFER_SIZE</c> is 8 per
+        /// entity, so a deeper delay would point past the oldest snapshot still held. A link whose
+        /// gaps exceed it pins here rather than reporting a depth that cannot be honoured.
+        /// </summary>
+        [NebulaUnitTest]
+        public void ItPinsAtTheBufferCeilingRatherThanRunningPastIt()
+        {
+            Assert.Equal(Max, Target(Gaps((12, 300))));
+        }
+
+        /// <summary>The floor is the shipped default, and an unmeasured link reports it rather than
+        /// guessing.</summary>
+        [NebulaUnitTest]
+        public void AnUnmeasuredLinkReportsTheDefault()
+        {
+            Assert.Equal(Min, Target(new int[16]));
+            Assert.Equal(Min, Target(Gaps((1, 300))));
+        }
+
+        /// <summary>
+        /// A gap of n ticks is absorbed by a buffer of n ticks, so the bucket index IS the depth. Worth
+        /// pinning because an off-by-one here is invisible — it just leaves every link one tick
+        /// under-buffered.
+        /// </summary>
+        [NebulaUnitTest]
+        public void TheDepthMatchesTheGapItMustAbsorb()
+        {
+            // Every arrival exactly 4 ticks apart: 4 ticks of buffer covers it, 3 would not.
+            Assert.Equal(4, Target(Gaps((4, 300))));
+        }
+
+        // ─── Moving toward the target ────────────────────────────────────────
+
+        /// <summary>Under-buffering is visible the moment it happens, so it is approached at the
+        /// fastest rate that stays continuous.</summary>
+        [NebulaUnitTest]
+        public void ItGrowsTowardTheTargetImmediately()
+        {
+            Assert.Equal(3, Next(current: 2, target: 3, windowsBelowTarget: 0));
+            Assert.Equal(4, Next(current: 2, target: 4, windowsBelowTarget: 0));
+        }
+
+        /// <summary>
+        /// A STEP THE RENDER CLOCK CANNOT FOLLOW IS A JUMP BACKWARD. The delay is part of what the
+        /// clock aims at, so a resize larger than RenderClockResyncTicks re-seeds the clock at the next
+        /// arrival and replays motion already drawn — the exact artifact the clock work removed.
+        /// Measured as a -4.5 tick step when a four-tick growth landed in one window.
+        /// </summary>
+        [NebulaUnitTest]
+        public void ItNeverStepsFurtherThanTheRenderClockCanAbsorb()
+        {
+            // Whatever the target, one window may not move the aim past the clock's re-seed threshold.
+            for (int current = Min; current <= Max; current++)
+            {
+                int next = Next(current, target: 99, windowsBelowTarget: 0);
+                Assert.True(next - current < 3,
+                    $"grew {current} -> {next}, which re-seeds the render clock instead of slewing");
+            }
+        }
+
+        /// <summary>
+        /// Giving buffer back takes a sustained run below target. The asymmetry is the point:
+        /// over-buffering only costs latency nobody can see directly, and a slow release keeps a link
+        /// that is merely BETWEEN faults from being re-measured as healthy.
+        /// </summary>
+        [NebulaUnitTest]
+        public void ShrinkingRequiresASustainedRunBelowTarget()
+        {
+            for (int window = 0; window < CleanWindowsBeforeShrink; window++)
+            {
+                Assert.Equal(4, Next(current: 4, target: 2, windowsBelowTarget: window));
+            }
+
+            Assert.Equal(3, Next(current: 4, target: 2, windowsBelowTarget: CleanWindowsBeforeShrink));
+        }
+
+        /// <summary>It gives back one tick at a time, never dropping straight to the target.</summary>
+        [NebulaUnitTest]
+        public void ItShrinksOneTickAtATime()
+        {
+            Assert.Equal(5, Next(current: 6, target: Min, windowsBelowTarget: 100));
+        }
+
+        [NebulaUnitTest]
+        public void ItHoldsWhenItIsAlreadyAtTheTarget()
+        {
+            Assert.Equal(4, Next(current: 4, target: 4, windowsBelowTarget: 100));
+        }
+
+        [NebulaUnitTest]
+        public void ItNeverLeavesTheUsableRange()
+        {
+            Assert.Equal(Min, Next(current: Min, target: Min, windowsBelowTarget: 100));
+            Assert.Equal(Max, Next(current: Max, target: Max, windowsBelowTarget: 0));
+        }
+
+        // ─── Settling ────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// THE REGRESSION THIS REPLACES, driven end to end. A repeating burst against a steady link
+        /// must reach a depth and STAY there — the old policy sawtoothed 3↔6 forever on exactly this
+        /// input, because it grew on any starvation and shrank on a fixed timer.
+        /// </summary>
+        [NebulaUnitTest]
+        public void ARepeatingBurstSettlesInsteadOfHunting()
+        {
+            var histogram = Gaps((1, 297), (8, 3)); // steady link, one rare burst
+            int delay = Min;
+            int below = 0;
+
+            int? settledAt = null;
+            for (int window = 0; window < 60; window++)
+            {
+                int target = Target(histogram);
+                below = target < delay ? below + 1 : 0;
+
+                int next = Next(delay, target, below);
+                if (next != delay) { below = 0; settledAt = null; } else settledAt ??= window;
+                delay = next;
+            }
+
+            Assert.Equal(Min, delay);
+            Assert.NotNull(settledAt);
+        }
+
+        /// <summary>A link that genuinely degrades and then recovers walks up and back down once,
+        /// rather than oscillating on the way.</summary>
+        [NebulaUnitTest]
+        public void ItWalksUpOnceAndBackDownOnce()
+        {
+            int delay = Min;
+            int below = 0;
+            int changes = 0;
+
+            // Degraded: 4-tick gaps are the norm.
+            for (int window = 0; window < 20; window++)
+            {
+                int target = Target(Gaps((4, 300)));
+                below = target < delay ? below + 1 : 0;
+                int next = Next(delay, target, below);
+                if (next != delay) { changes++; below = 0; }
+                delay = next;
+            }
+            Assert.Equal(4, delay);
+            Assert.Equal(1, changes); // one step of two ticks, not four separate ones
+
+            // Recovered.
+            for (int window = 0; window < 40; window++)
+            {
+                int target = Target(Gaps((1, 300)));
+                below = target < delay ? below + 1 : 0;
+                int next = Next(delay, target, below);
+                if (next != delay) below = 0;
+                delay = next;
+            }
+            Assert.Equal(Min, delay);
+        }
+    }
+}

--- a/addons/Nebula/Testing/Unit/InterpolationDelayTests.cs.uid
+++ b/addons/Nebula/Testing/Unit/InterpolationDelayTests.cs.uid
@@ -1,0 +1,1 @@
+uid://c3ymgkht42do6

--- a/addons/Nebula/Testing/Unit/NetworkImpairmentTests.cs
+++ b/addons/Nebula/Testing/Unit/NetworkImpairmentTests.cs
@@ -1,0 +1,321 @@
+using Nebula.Diagnostics;
+using Nebula.Testing.Unit;
+using Xunit;
+
+namespace Nebula.Tests
+{
+    /// <summary>
+    /// The synthetic impairment scheduler. Pure and clock-injected, so all of this runs with no
+    /// sockets, no processes and no wall-clock waiting.
+    /// </summary>
+    [NebulaUnitTest]
+    public class NetworkImpairmentTests
+    {
+        private const byte TickChannel = (byte)NetRunner.ENetChannelId.Tick;
+        private const byte FunctionChannel = (byte)NetRunner.ENetChannelId.Function;
+        private const byte InputChannel = (byte)NetRunner.ENetChannelId.Input;
+
+        [NebulaUnitTest]
+        public void AnUnconfiguredImpairmentIsInertAndFree()
+        {
+            var impairment = NetworkImpairment.ForTest(0, 0, 0, seed: 1);
+
+            Assert.False(impairment.IsActive);
+            Assert.True(impairment.TryScheduleInbound(TickChannel, 1000, out var releaseAt));
+            Assert.Equal(1000ul, releaseAt);
+        }
+
+        /// <summary>With no jitter, delay is a constant offset -- so packets stay in the order they
+        /// arrived and simply land later.</summary>
+        [NebulaUnitTest]
+        public void PureLatencyPreservesOrder()
+        {
+            var impairment = NetworkImpairment.ForTest(latencyMs: 80, jitterMs: 0, lossPct: 0, seed: 1);
+
+            ulong previous = 0;
+            for (ulong now = 0; now < 1000; now += 33)
+            {
+                Assert.True(impairment.TryScheduleInbound(TickChannel, now, out var releaseAt));
+                Assert.Equal(now + 80, releaseAt);
+                Assert.True(releaseAt >= previous);
+                previous = releaseAt;
+            }
+        }
+
+        /// <summary>
+        /// Reordering is not a separate knob -- it is what jitter DOES. This asserts the mechanism
+        /// exists rather than that any particular packet overtakes another.
+        /// </summary>
+        [NebulaUnitTest]
+        public void JitterProducesOutOfOrderRelease()
+        {
+            var impairment = NetworkImpairment.ForTest(latencyMs: 80, jitterMs: 40, lossPct: 0, seed: 7);
+
+            bool sawOvertake = false;
+            ulong previous = 0;
+            for (ulong now = 0; now < 3000; now += 33)
+            {
+                Assert.True(impairment.TryScheduleInbound(TickChannel, now, out var releaseAt));
+
+                // Never earlier than the moment it arrived: impairment may only hold a packet back.
+                Assert.True(releaseAt >= now);
+
+                if (releaseAt < previous) sawOvertake = true;
+                previous = releaseAt;
+            }
+
+            Assert.True(sawOvertake, "jitter of +/-40ms against a 33ms cadence should reorder");
+        }
+
+        /// <summary>
+        /// THE RULE THAT IS CORRECTNESS, NOT TASTE. Reliable channels have already been delivered by
+        /// ENet; dropping one here loses it permanently and breaks the protocol rather than simulating
+        /// a network. The unreliable ones -- Tick and Input -- are not retransmitted by ENet either,
+        /// so both really can vanish on a live link.
+        /// </summary>
+        [NebulaUnitTest]
+        public void OnlyUnreliableChannelsAreDropped()
+        {
+            var impairment = NetworkImpairment.ForTest(latencyMs: 0, jitterMs: 0, lossPct: 100, seed: 3);
+
+            Assert.True(NetworkImpairment.IsDroppable(TickChannel));
+            Assert.True(NetworkImpairment.IsDroppable(InputChannel));
+            Assert.False(NetworkImpairment.IsDroppable(FunctionChannel));
+
+            for (ulong now = 0; now < 500; now += 33)
+            {
+                Assert.True(impairment.TryScheduleInbound(FunctionChannel, now, out _));
+                Assert.True(impairment.TrySendOutbound(FunctionChannel, now));
+
+                // ...while the droppable ones at 100% always are, in both directions.
+                Assert.False(impairment.TryScheduleInbound(TickChannel, now, out _));
+                Assert.False(impairment.TrySendOutbound(InputChannel, now));
+            }
+        }
+
+        /// <summary>
+        /// AN OUTAGE HAS TO TAKE OUT BOTH DIRECTIONS. Impairment is per process so one bad client can
+        /// sit beside a healthy one, which leaves the server unimpaired -- so ingress filtering alone
+        /// let a client sail through a "100% loss" burst still delivering flawless input. That is not
+        /// an outage, and it hid the server's hold-last-input fallback from ever being exercised.
+        /// </summary>
+        [NebulaUnitTest]
+        public void ABurstStopsInputAsWellAsTicks()
+        {
+            var impairment = NetworkImpairment.ForTest(
+                latencyMs: 0, jitterMs: 0, lossPct: 0, seed: 21,
+                burstLossPct: 100, burstEverySec: 1f, burstMs: 300);
+
+            int inputRun = 0;
+            int longestInputRun = 0;
+
+            for (ulong now = 0; now < 30_000; now += 33)
+            {
+                if (impairment.TrySendOutbound(InputChannel, now))
+                {
+                    inputRun = 0;
+                }
+                else
+                {
+                    inputRun++;
+                    if (inputRun > longestInputRun) longestInputRun = inputRun;
+                }
+            }
+
+            // Input packets carry INPUT_REDUNDANCY_COUNT (8) ticks of history, so an outage only
+            // actually starves the server once the run of lost packets approaches that window --
+            // which is exactly what a 300ms burst at 33ms spacing must produce.
+            Assert.True(longestInputRun >= 5,
+                $"longest run of dropped input was {longestInputRun}; a burst must interrupt input");
+        }
+
+        /// <summary>An unconfigured impairment must not touch the send path at all.</summary>
+        [NebulaUnitTest]
+        public void AnInertImpairmentSendsEverything()
+        {
+            var impairment = NetworkImpairment.ForTest(0, 0, 0, seed: 1);
+
+            for (ulong now = 0; now < 1000; now += 33)
+            {
+                Assert.True(impairment.TrySendOutbound(InputChannel, now));
+                Assert.True(impairment.TrySendOutbound(TickChannel, now));
+            }
+        }
+
+        [NebulaUnitTest]
+        public void LossConvergesOnTheConfiguredRate()
+        {
+            var impairment = NetworkImpairment.ForTest(latencyMs: 0, jitterMs: 0, lossPct: 25, seed: 11);
+
+            const int samples = 20_000;
+            int dropped = 0;
+            for (int i = 0; i < samples; i++)
+            {
+                if (!impairment.TryScheduleInbound(TickChannel, (ulong)i, out _)) dropped++;
+            }
+
+            double rate = 100.0 * dropped / samples;
+            Assert.True(System.Math.Abs(rate - 25.0) < 2.0, $"observed {rate:F1}% loss, expected ~25%");
+        }
+
+        // ─── Bursty loss ─────────────────────────────────────────────────────
+        //
+        // The reason this exists at all: independent per-packet loss is the FRIENDLY case. Real links
+        // lose runs of consecutive packets, and a run is what actually empties an interpolation
+        // buffer. 2% uniform loss barely dents it; 100% for 300ms is a hole.
+
+        /// <summary>
+        /// A burst must actually produce a RUN of consecutive drops, not scattered ones. This is the
+        /// whole difference from steady loss, so it is asserted directly rather than statistically.
+        /// </summary>
+        [NebulaUnitTest]
+        public void ABurstDropsConsecutivePackets()
+        {
+            var impairment = NetworkImpairment.ForTest(
+                latencyMs: 0, jitterMs: 0, lossPct: 0, seed: 5,
+                burstLossPct: 100, burstEverySec: 1f, burstMs: 300);
+
+            int longestRun = 0;
+            int run = 0;
+
+            // 30 seconds at a 33ms tick cadence.
+            for (ulong now = 0; now < 30_000; now += 33)
+            {
+                if (impairment.TryScheduleInbound(TickChannel, now, out _))
+                {
+                    run = 0;
+                }
+                else
+                {
+                    run++;
+                    if (run > longestRun) longestRun = run;
+                }
+            }
+
+            // A 300ms burst at 33ms spacing is ~9 packets. Anything above a handful proves the drops
+            // are contiguous rather than independent.
+            Assert.True(longestRun >= 5, $"longest consecutive drop run was {longestRun}, expected a burst");
+        }
+
+        /// <summary>Between bursts the link must be clean, or this is just steady loss with extra
+        /// steps.</summary>
+        [NebulaUnitTest]
+        public void TheLinkIsCleanBetweenBursts()
+        {
+            var impairment = NetworkImpairment.ForTest(
+                latencyMs: 0, jitterMs: 0, lossPct: 0, seed: 9,
+                burstLossPct: 100, burstEverySec: 5f, burstMs: 200);
+
+            int delivered = 0;
+            int dropped = 0;
+            for (ulong now = 0; now < 60_000; now += 33)
+            {
+                if (impairment.TryScheduleInbound(TickChannel, now, out _)) delivered++;
+                else dropped++;
+            }
+
+            // ~200ms of every ~5s is lost, so the overwhelming majority must get through.
+            Assert.True(delivered > dropped * 5,
+                $"delivered {delivered} vs dropped {dropped}; bursts should be occasional, not constant");
+            Assert.True(dropped > 0, "no burst ever fired");
+        }
+
+        /// <summary>Bursts must not fire on the very first packet: a session should not begin
+        /// mid-fault, which would make every startup measurement a burst measurement.</summary>
+        [NebulaUnitTest]
+        public void ASessionDoesNotBeginInsideABurst()
+        {
+            var impairment = NetworkImpairment.ForTest(
+                latencyMs: 0, jitterMs: 0, lossPct: 0, seed: 13,
+                burstLossPct: 100, burstEverySec: 5f, burstMs: 200);
+
+            Assert.True(impairment.TryScheduleInbound(TickChannel, 0, out _));
+            Assert.False(impairment.InBurst);
+        }
+
+        /// <summary>Even at 100% burst loss, a reliable channel is never dropped -- the same rule as
+        /// steady loss, and for the same reason. In BOTH directions: egress is where a reliable drop
+        /// would be easiest to introduce by accident, since nothing has been delivered yet.</summary>
+        [NebulaUnitTest]
+        public void BurstsStillNeverDropReliableChannels()
+        {
+            var impairment = NetworkImpairment.ForTest(
+                latencyMs: 0, jitterMs: 0, lossPct: 0, seed: 17,
+                burstLossPct: 100, burstEverySec: 1f, burstMs: 500);
+
+            for (ulong now = 0; now < 20_000; now += 33)
+            {
+                Assert.True(impairment.TryScheduleInbound(FunctionChannel, now, out _));
+                Assert.True(impairment.TrySendOutbound(FunctionChannel, now));
+            }
+        }
+
+        /// <summary>Bursts are off unless both a loss level and a duration are configured, so the
+        /// knobs cannot half-arm each other.</summary>
+        [NebulaUnitTest]
+        public void BurstsAreOffUnlessFullyConfigured()
+        {
+            var noDuration = NetworkImpairment.ForTest(0, 0, 0, seed: 1, burstLossPct: 100, burstMs: 0);
+            Assert.False(noDuration.IsActive);
+
+            var noLoss = NetworkImpairment.ForTest(0, 0, 0, seed: 1, burstLossPct: 0, burstMs: 500);
+            Assert.False(noLoss.IsActive);
+
+            var armed = NetworkImpairment.ForTest(0, 0, 0, seed: 1, burstLossPct: 100, burstMs: 500);
+            Assert.True(armed.IsActive);
+        }
+
+        // ─── Fidelity ────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// THE IMPAIRMENT MUST SIMULATE A LINK THAT COULD EXIST. ENet measures RTT inside the native
+        /// transport and this layer holds packets after delivery, so the peer keeps reporting loopback
+        /// latency however severe the configuration is. Anything sizing itself from RTT -- the
+        /// prediction lead above all -- then aims for a link nobody is on: measured as an impaired
+        /// client targeting a two-tick lead while its view of the server ran 2.4 ticks behind, so every
+        /// input it sent was stamped for a tick the server had already simulated.
+        /// </summary>
+        [NebulaUnitTest]
+        public void ConfiguredLatencyIsVisibleToRttConsumers()
+        {
+            var impaired = NetworkImpairment.ForTest(latencyMs: 80, jitterMs: 30, lossPct: 0, seed: 1);
+            var inert = NetworkImpairment.ForTest(0, 0, 0, seed: 1);
+
+            // An unconfigured impairment changes nothing.
+            Assert.Equal(20u, WorldRunner.EffectiveRoundTripMs(20, inert.LatencyMs));
+
+            // The transport's own reading is kept, not replaced: a real link's RTT and a synthetic
+            // hold are both really in the path.
+            Assert.Equal(80u, WorldRunner.EffectiveRoundTripMs(0, impaired.LatencyMs));
+            Assert.Equal(100u, WorldRunner.EffectiveRoundTripMs(20, impaired.LatencyMs));
+
+            // ...and that has to be enough to move the lead, or reporting it changes nothing. 80ms is
+            // 2.4 ticks at 30 TPS, which is exactly the shortfall that starved the server of input.
+            int loopback = WorldRunner.ComputeTargetLeadTicks(
+                WorldRunner.EffectiveRoundTripMs(0, inert.LatencyMs), NetRunner.TPS);
+            int simulated = WorldRunner.ComputeTargetLeadTicks(
+                WorldRunner.EffectiveRoundTripMs(0, impaired.LatencyMs), NetRunner.TPS);
+
+            Assert.True(simulated >= loopback + 3,
+                $"an 80ms hold moved the target lead only {simulated - loopback} ticks ({loopback} -> {simulated})");
+        }
+
+        /// <summary>A failing impairment run is worthless if it cannot be repeated, so the seed has to
+        /// fully determine the sequence.</summary>
+        [NebulaUnitTest]
+        public void AFixedSeedReproducesExactly()
+        {
+            var first = NetworkImpairment.ForTest(60, 30, 15, seed: 4242);
+            var second = NetworkImpairment.ForTest(60, 30, 15, seed: 4242);
+
+            for (ulong now = 0; now < 2000; now += 33)
+            {
+                bool keptA = first.TryScheduleInbound(TickChannel, now, out var releaseA);
+                bool keptB = second.TryScheduleInbound(TickChannel, now, out var releaseB);
+
+                Assert.Equal(keptA, keptB);
+                Assert.Equal(releaseA, releaseB);
+            }
+        }
+    }
+}

--- a/addons/Nebula/Testing/Unit/NetworkImpairmentTests.cs.uid
+++ b/addons/Nebula/Testing/Unit/NetworkImpairmentTests.cs.uid
@@ -1,0 +1,1 @@
+uid://bh3cxwovi03i1

--- a/addons/Nebula/Testing/Unit/RenderClockTests.cs
+++ b/addons/Nebula/Testing/Unit/RenderClockTests.cs
@@ -1,0 +1,245 @@
+using System;
+using Nebula.Testing.Unit;
+using Xunit;
+
+namespace Nebula.Tests
+{
+    /// <summary>
+    /// The clock every REMOTE entity is interpolated on (<see cref="WorldRunner.GetRenderTick"/>).
+    ///
+    /// <para>It used to be derived fresh each call as "last received tick, plus how long ago it
+    /// arrived". That is exact and stateless on a perfectly regular packet cadence -- the accumulator
+    /// reaches one tick exactly as the tick counter increments -- but it couples render time to
+    /// ARRIVAL, so jitter lands on the screen. The failure it produced was not a jump: measured at
+    /// 50fps against 30Hz ticks, remote entities advanced between 0.4 and 1.0 ticks per frame instead
+    /// of a constant 0.6, which reads as a shimmer.</para>
+    ///
+    /// <para>Each test below is one property that separates the working clock from a version that has
+    /// already shipped broken.</para>
+    /// </summary>
+    [NebulaUnitTest]
+    public class RenderClockTests
+    {
+        private const float Frame = 1f / 60f;
+        private const int Tps = 30;
+
+        private static (float Tick, float Error, int Sampled) Fresh(float tick)
+            => (tick, 0f, int.MinValue);
+
+        /// <summary>
+        /// Drives the clock with a tick counter advancing on REAL time, optionally with arrival
+        /// jitter, and returns every position it passed through.
+        /// </summary>
+        private static (float Tick, System.Collections.Generic.List<float> Steps) Run(
+            (float Tick, float Error, int Sampled) clock,
+            int frames,
+            float startTick = 0f,
+            Func<int, float> jitterMs = null)
+        {
+            var steps = new System.Collections.Generic.List<float>();
+            float elapsedMs = startTick * (1000f / Tps);
+            float prev = clock.Tick;
+
+            for (int i = 0; i < frames; i++)
+            {
+                elapsedMs += Frame * 1000f;
+
+                // The tick counter only ever increments on ARRIVAL, so jitter moves the moment it
+                // steps -- which is the whole input the clock has to tolerate.
+                float shifted = elapsedMs + (jitterMs?.Invoke(i) ?? 0f);
+                int targetTick = (int)(shifted / (1000f / Tps));
+
+                var next = WorldRunner.AdvanceRenderClock(
+                    clock.Tick, clock.Error, clock.Sampled, targetTick, 0, Frame);
+                clock = (next.Tick, next.Error, next.SampledTick);
+
+                steps.Add(clock.Tick - prev);
+                prev = clock.Tick;
+            }
+
+            return (clock.Tick, steps);
+        }
+
+        /// <summary>
+        /// THE BUG THIS REPLACED. Arrival jitter must not reach the screen. With packets landing up to
+        /// half a tick early or late, the clock still has to advance by an even amount every frame --
+        /// the old derivation swung between 0.4 and 1.0 ticks under exactly this input.
+        /// </summary>
+        [NebulaUnitTest]
+        public void ArrivalJitterDoesNotMakeMotionUneven()
+        {
+            // Alternating +/-8ms against a 33.3ms cadence, which is milder than the 19-43ms measured.
+            var (_, steps) = Run(Fresh(0f), frames: 300, jitterMs: i => (i % 2 == 0) ? 8f : -8f);
+
+            float expected = Frame * Tps;
+            for (int i = 120; i < steps.Count; i++)
+            {
+                Assert.True(Math.Abs(steps[i] - expected) < expected * 0.05f,
+                    $"frame {i}: advanced {steps[i]:F4}t, expected ~{expected:F4}t");
+            }
+        }
+
+        /// <summary>Time may only move forward. A clock that steps back replays motion already drawn,
+        /// which is what the old derivation did when a packet arrived late.</summary>
+        [NebulaUnitTest]
+        public void TheClockNeverMovesBackwardOrStalls()
+        {
+            var (_, steps) = Run(Fresh(0f), frames: 300, jitterMs: i => (i % 3 == 0) ? 12f : -6f);
+
+            foreach (var step in steps)
+            {
+                Assert.True(step > 0f, $"clock advanced by {step}, which is not forward");
+            }
+        }
+
+        /// <summary>
+        /// A standing offset has to be eaten. A correction rate equal to the arrival rate -- which is
+        /// what the orbital version of this originally had -- can never close a gap, and leaves every
+        /// entity rendering permanently behind.
+        /// </summary>
+        [NebulaUnitTest]
+        public void AStandingErrorIsCorrectedAway()
+        {
+            // Two ticks behind, inside the resync threshold so this exercises the correction and not
+            // the re-seed.
+            var (final, _) = Run(Fresh(-2f), frames: 900);
+
+            float aim = (int)(900 * Frame * Tps);
+            Assert.True(Math.Abs(aim - final) < 1f,
+                $"clock settled {aim - final:F2} ticks from its aim; the gap should have closed");
+        }
+
+        /// <summary>A discontinuity -- world change, long hitch, first frame -- is re-seeded outright,
+        /// because converging over seconds would render the world visibly wrong for all of them.</summary>
+        [NebulaUnitTest]
+        public void ALargeJumpResyncsImmediately()
+        {
+            var next = WorldRunner.AdvanceRenderClock(0f, 0f, int.MinValue, 500, 0, Frame);
+
+            Assert.Equal(500f, next.Tick);
+            Assert.Equal(0f, next.Error);
+        }
+
+        /// <summary>An uninitialised clock adopts its target rather than sweeping up to it from zero.</summary>
+        [NebulaUnitTest]
+        public void AFreshClockStartsAtItsTarget()
+        {
+            var next = WorldRunner.AdvanceRenderClock(float.NaN, 0f, int.MinValue, 42, 0, Frame);
+
+            Assert.Equal(42f, next.Tick);
+        }
+
+        // ─── Dropouts ────────────────────────────────────────────────────────
+        //
+        // A burst of loss stops the tick stream outright. The target then stands still while the
+        // clock free-runs, which is NOT an error even though it looks exactly like one.
+
+        /// <summary>
+        /// Coasts the clock through a silent stretch, returning where it ended up.
+        /// </summary>
+        private static (float Tick, float Error, int Sampled) Coast(
+            (float Tick, float Error, int Sampled) clock, int frames, int frozenTarget)
+        {
+            for (int i = 0; i < frames; i++)
+            {
+                var next = WorldRunner.AdvanceRenderClock(
+                    clock.Tick, clock.Error, clock.Sampled, frozenTarget, 0, Frame);
+                clock = (next.Tick, next.Error, next.SampledTick);
+            }
+            return clock;
+        }
+
+        /// <summary>
+        /// THE DROPOUT REWIND. Silence is absence of news, not evidence that render time is wrong --
+        /// but a free-running clock outruns a frozen target, and a symmetric re-seed reads that as
+        /// error and snaps render time BACKWARD, replaying motion already drawn. Measured under 200ms
+        /// bursts as a -3.4 tick step (~115ms) on every burst, and it survived at the deepest buffer
+        /// the controller can reach, because no amount of buffer depth addresses it.
+        /// </summary>
+        [NebulaUnitTest]
+        public void SilenceDoesNotRewindTheClock()
+        {
+            // 200ms of nothing at 60fps: six ticks of silence against a three-tick resync threshold,
+            // so the old symmetric check tripped roughly halfway through.
+            var clock = (Tick: 100f, Error: 0f, Sampled: 100);
+            float previous = clock.Tick;
+
+            for (int frame = 0; frame < 12; frame++)
+            {
+                var next = WorldRunner.AdvanceRenderClock(
+                    clock.Tick, clock.Error, clock.Sampled, 100, 0, Frame);
+                clock = (next.Tick, next.Error, next.SampledTick);
+
+                Assert.True(clock.Tick > previous,
+                    $"frame {frame}: clock moved {previous:F3} -> {clock.Tick:F3}, which is not forward");
+                previous = clock.Tick;
+            }
+        }
+
+        /// <summary>
+        /// WHY COASTING COSTS NOTHING TO RECOVER FROM. The server kept ticking through the silence, so
+        /// when the stream resumes the target jumps by exactly the length of the gap and lands back on
+        /// the clock. The arrival confirms the clock rather than moving it -- the recovery frame is an
+        /// ordinary step, not a correction.
+        /// </summary>
+        [NebulaUnitTest]
+        public void ADropoutRecoversWithoutACorrection()
+        {
+            var clock = Coast((Tick: 100f, Error: 0f, Sampled: 100), frames: 12, frozenTarget: 100);
+
+            // Six ticks of real time passed, so the resuming stream reports six ticks of progress.
+            var resumed = WorldRunner.AdvanceRenderClock(
+                clock.Tick, clock.Error, clock.Sampled, 106, 0, Frame);
+
+            float step = resumed.Tick - clock.Tick;
+            float ordinary = Frame * Tps;
+            Assert.True(Math.Abs(step - ordinary) < ordinary * 0.05f,
+                $"recovery frame advanced {step:F3}t; an ordinary step is {ordinary:F3}t");
+        }
+
+        /// <summary>
+        /// RESIZING THE BUFFER IS NOT AN ARRIVAL. The target is `currentTick - delayTicks`, so the
+        /// adaptive buffer moves it -- and it moves it precisely in the window a dropout was just
+        /// detected in, which is when the clock is coasting furthest ahead. A gate keyed on the target
+        /// therefore opens mid-dropout with nothing behind it and re-seeds against a stale target:
+        /// observed as a -8.3 tick step on a 300ms burst that grew the buffer from 4 to 5.
+        /// </summary>
+        [NebulaUnitTest]
+        public void GrowingTheBufferMidDropoutDoesNotRewindTheClock()
+        {
+            // Silent throughout: the tick counter never moves, so nothing here is an arrival.
+            const int FrozenTick = 100;
+            var clock = Coast((Tick: 100f, Error: 0f, Sampled: FrozenTick), frames: 12, frozenTarget: FrozenTick);
+
+            float before = clock.Tick;
+
+            // The dropout is detected and the controller grows the buffer by a tick.
+            var next = WorldRunner.AdvanceRenderClock(
+                clock.Tick, clock.Error, clock.Sampled, FrozenTick, 1, Frame);
+
+            Assert.True(next.Tick > before,
+                $"resizing the buffer moved the clock {before:F3} -> {next.Tick:F3} instead of advancing it");
+        }
+
+        /// <summary>
+        /// A GENUINE PAUSE IS STILL CAUGHT, one instant later. If the stream resumes with the target
+        /// still far behind, that arrival is the proof the server did not tick through the gap -- and
+        /// re-seeding is then correct, because the clock really is rendering a future that never
+        /// happened.
+        /// </summary>
+        [NebulaUnitTest]
+        public void AGenuinePauseResyncsWhenTheStreamResumes()
+        {
+            // A full second of silence: the clock coasts ~30 ticks ahead.
+            var clock = Coast((Tick: 100f, Error: 0f, Sampled: 100), frames: 60, frozenTarget: 100);
+            Assert.True(clock.Tick > 125f, $"clock should have coasted well ahead, reached {clock.Tick:F1}");
+
+            // The server picks up where it left off rather than having advanced.
+            var resumed = WorldRunner.AdvanceRenderClock(
+                clock.Tick, clock.Error, clock.Sampled, 101, 0, Frame);
+
+            Assert.Equal(101f, resumed.Tick);
+            Assert.Equal(0f, resumed.Error);
+        }
+    }
+}

--- a/addons/Nebula/Testing/Unit/RenderClockTests.cs.uid
+++ b/addons/Nebula/Testing/Unit/RenderClockTests.cs.uid
@@ -1,0 +1,1 @@
+uid://q2gvakyhsipg

--- a/addons/Nebula/Tools/Main.cs
+++ b/addons/Nebula/Tools/Main.cs
@@ -437,13 +437,29 @@ public partial class Main : EditorPlugin
         {
             int clientDebugPort = ReserveLoopbackPort();
             debugPorts.Add(clientDebugPort);
-            clientArgsList.Add(new[]
+
+            var clientArgs = new System.Collections.Generic.List<string>
             {
                 "--path", projectPath,
                 "--remote-debug", debugUri,
                 $"--debugPort={clientDebugPort}",
                 $"--clientId={i}",
-            });
+            };
+
+            // Impairment rides as per-instance args because that is the only level at which it can
+            // differ between clients -- a project setting would degrade all of them identically, and
+            // the case worth testing is one bad peer watched by a healthy one.
+            if (config.HasImpairment && (!config.ImpairFirstClientOnly || i == 0))
+            {
+                clientArgs.Add($"--simLatencyMs={config.SimLatencyMs}");
+                clientArgs.Add($"--simJitterMs={config.SimJitterMs}");
+                clientArgs.Add($"--simLossPct={config.SimLossPct}");
+                clientArgs.Add($"--simBurstLossPct={config.SimBurstLossPct}");
+                clientArgs.Add($"--simBurstEverySec={config.SimBurstEverySec}");
+                clientArgs.Add($"--simBurstMs={config.SimBurstMs}");
+            }
+
+            clientArgsList.Add(clientArgs.ToArray());
         }
 
         GetOrchestrator(createIfMissing: true).Call("launch",

--- a/addons/Nebula/Tools/MainScreen/NebulaConfigDialog.cs
+++ b/addons/Nebula/Tools/MainScreen/NebulaConfigDialog.cs
@@ -37,6 +37,13 @@ public partial class NebulaConfigDialog : AcceptDialog
     private SpinBox botCountSpin;
     private OptionButton botBehaviorPicker;
     private CheckBox botsHeadlessCheck;
+    private SpinBox simLatencySpin;
+    private SpinBox simJitterSpin;
+    private SpinBox simLossSpin;
+    private CheckBox impairFirstOnlyCheck;
+    private SpinBox simBurstLossSpin;
+    private SpinBox simBurstEverySpin;
+    private SpinBox simBurstMsSpin;
     /// <summary>
     /// Behavior type names in <see cref="botBehaviorPicker"/> order, index 0 being "(none)".
     /// Kept alongside the control because OptionButton only carries the display text.
@@ -176,6 +183,13 @@ public partial class NebulaConfigDialog : AcceptDialog
             clientCountSpin.Value = config.ClientCount;
             botCountSpin.Value = config.BotCount;
             botsHeadlessCheck.ButtonPressed = config.BotsHeadless;
+            simLatencySpin.Value = config.SimLatencyMs;
+            simJitterSpin.Value = config.SimJitterMs;
+            simLossSpin.Value = config.SimLossPct;
+            simBurstLossSpin.Value = config.SimBurstLossPct;
+            simBurstEverySpin.Value = config.SimBurstEverySec;
+            simBurstMsSpin.Value = config.SimBurstMs;
+            impairFirstOnlyCheck.ButtonPressed = config.ImpairFirstClientOnly;
             SelectBotBehavior(config.BotBehavior);
         }
         else
@@ -185,6 +199,17 @@ public partial class NebulaConfigDialog : AcceptDialog
             botCountSpin.Value = 0;
             botsHeadlessCheck.ButtonPressed = true;
             botBehaviorPicker.Selected = 0;
+
+            // Reset these too. The form's controls are reused across opens, so anything not
+            // explicitly cleared here is inherited from whatever was last EDITED -- which for
+            // impairment means a new configuration silently arrives pre-degraded.
+            simLatencySpin.Value = 0;
+            simJitterSpin.Value = 0;
+            simLossSpin.Value = 0;
+            simBurstLossSpin.Value = 0;
+            simBurstEverySpin.Value = 10;
+            simBurstMsSpin.Value = 0;
+            impairFirstOnlyCheck.ButtonPressed = true;
         }
 
         formDialog.PopupCentered(new Vector2I(420, 0));
@@ -290,6 +315,96 @@ public partial class NebulaConfigDialog : AcceptDialog
         };
         grid.AddChild(botsHeadlessCheck);
 
+        // ── Synthetic network impairment ─────────────────────────────────
+        // Everything about interpolation was developed on localhost, where jitter is small and loss
+        // is zero. These make a bad link something you can produce on purpose.
+        grid.AddChild(new Label { Text = "Sim latency (ms)" });
+        simLatencySpin = new SpinBox
+        {
+            MinValue = 0,
+            MaxValue = 1000,
+            Value = 0,
+            Rounded = true,
+            CustomMinimumSize = new Vector2(120, 0),
+            TooltipText = "One-way delay added to inbound packets. 0 disables impairment entirely.",
+        };
+        grid.AddChild(simLatencySpin);
+
+        grid.AddChild(new Label { Text = "Sim jitter (+/- ms)" });
+        simJitterSpin = new SpinBox
+        {
+            MinValue = 0,
+            MaxValue = 500,
+            Value = 0,
+            Rounded = true,
+            CustomMinimumSize = new Vector2(120, 0),
+            TooltipText = "Random spread around the latency. This is what drives the adaptive "
+                + "interpolation buffer, and what reorders packets.",
+        };
+        grid.AddChild(simJitterSpin);
+
+        grid.AddChild(new Label { Text = "Sim loss (%)" });
+        simLossSpin = new SpinBox
+        {
+            MinValue = 0,
+            MaxValue = 100,
+            Value = 0,
+            Rounded = true,
+            CustomMinimumSize = new Vector2(120, 0),
+            TooltipText = "Percentage of snapshot packets discarded. Reliable channels are never "
+                + "dropped -- ENet has already delivered those, so dropping one loses it for good.",
+        };
+        grid.AddChild(simLossSpin);
+
+        grid.AddChild(new Label { Text = "Burst loss (%)" });
+        simBurstLossSpin = new SpinBox
+        {
+            MinValue = 0,
+            MaxValue = 100,
+            Value = 0,
+            Rounded = true,
+            CustomMinimumSize = new Vector2(120, 0),
+            TooltipText = "Loss during a burst. Real links drop RUNS of packets, not scattered ones, "
+                + "and a run is what actually empties the interpolation buffer. 100 = full dropout. "
+                + "Needs a burst length to do anything.",
+        };
+        grid.AddChild(simBurstLossSpin);
+
+        grid.AddChild(new Label { Text = "Burst every (s)" });
+        simBurstEverySpin = new SpinBox
+        {
+            MinValue = 1,
+            MaxValue = 120,
+            Value = 10,
+            Rounded = true,
+            CustomMinimumSize = new Vector2(120, 0),
+            TooltipText = "Average seconds between bursts. Actual spacing is random around this, "
+                + "because real faults do not arrive on a metronome.",
+        };
+        grid.AddChild(simBurstEverySpin);
+
+        grid.AddChild(new Label { Text = "Burst length (ms)" });
+        simBurstMsSpin = new SpinBox
+        {
+            MinValue = 0,
+            MaxValue = 5000,
+            Value = 0,
+            Rounded = true,
+            CustomMinimumSize = new Vector2(120, 0),
+            TooltipText = "How long each burst lasts. 0 disables bursts. Anything longer than the "
+                + "interpolation buffer (~66ms by default) will starve it, which is the point.",
+        };
+        grid.AddChild(simBurstMsSpin);
+
+        grid.AddChild(new Label { Text = "Impair first client only" });
+        impairFirstOnlyCheck = new CheckBox
+        {
+            ButtonPressed = true,
+            TooltipText = "Degrade only client 0, leaving the rest healthy. This is usually what you "
+                + "want: an impaired peer is only interesting when a healthy one is watching it.",
+        };
+        grid.AddChild(impairFirstOnlyCheck);
+
         formDialog.Connect(ConfirmationDialog.SignalName.Confirmed, new Callable(this, MethodName.OnFormConfirmed));
         AddChild(formDialog);
     }
@@ -316,6 +431,13 @@ public partial class NebulaConfigDialog : AcceptDialog
             BotCount = botCount,
             BotBehavior = botBehavior,
             BotsHeadless = botsHeadlessCheck.ButtonPressed,
+            SimLatencyMs = (int)simLatencySpin.Value,
+            SimJitterMs = (int)simJitterSpin.Value,
+            SimLossPct = (int)simLossSpin.Value,
+            SimBurstLossPct = (int)simBurstLossSpin.Value,
+            SimBurstEverySec = (int)simBurstEverySpin.Value,
+            SimBurstMs = (int)simBurstMsSpin.Value,
+            ImpairFirstClientOnly = impairFirstOnlyCheck.ButtonPressed,
         };
 
         if (editingIndex >= 0 && editingIndex < configurations.Count)

--- a/addons/Nebula/Tools/MainScreen/NebulaPlayConfigStore.cs
+++ b/addons/Nebula/Tools/MainScreen/NebulaPlayConfigStore.cs
@@ -36,6 +36,32 @@ public sealed class NebulaPlayConfiguration
     /// </summary>
     public bool BotsHeadless = true;
 
+    /// <summary>
+    /// Synthetic network impairment applied to the launched clients (see
+    /// <see cref="Nebula.Diagnostics.NetworkImpairment"/>). Passed as per-instance command-line args,
+    /// which is the only way to vary it: a project setting would impair every spawned client
+    /// identically.
+    /// </summary>
+    public int SimLatencyMs = 0;
+    public int SimJitterMs = 0;
+    public int SimLossPct = 0;
+
+    /// <summary>
+    /// Bursty loss: a run of consecutive drops rather than scattered ones. This is the case that
+    /// actually empties an interpolation buffer -- uniform loss almost never leaves a hole.
+    /// <see cref="SimBurstLossPct"/> of 100 is a full dropout.
+    /// </summary>
+    public int SimBurstLossPct = 0;
+    public int SimBurstEverySec = 10;
+    public int SimBurstMs = 0;
+
+    /// <summary>
+    /// Impair only the FIRST client instead of all of them. This is the configuration that matters:
+    /// an impaired peer is only interesting when a healthy one is watching it, and a session where
+    /// everyone is equally degraded hides exactly the asymmetries worth seeing.
+    /// </summary>
+    public bool ImpairFirstClientOnly = true;
+
     public NebulaPlayConfiguration Clone() => new()
     {
         Name = Name,
@@ -43,7 +69,19 @@ public sealed class NebulaPlayConfiguration
         BotCount = BotCount,
         BotBehavior = BotBehavior,
         BotsHeadless = BotsHeadless,
+        SimLatencyMs = SimLatencyMs,
+        SimJitterMs = SimJitterMs,
+        SimLossPct = SimLossPct,
+        SimBurstLossPct = SimBurstLossPct,
+        SimBurstEverySec = SimBurstEverySec,
+        SimBurstMs = SimBurstMs,
+        ImpairFirstClientOnly = ImpairFirstClientOnly,
     };
+
+    /// <summary>Whether this configuration impairs anything at all.</summary>
+    public bool HasImpairment =>
+        SimLatencyMs > 0 || SimJitterMs > 0 || SimLossPct > 0
+        || (SimBurstLossPct > 0 && SimBurstMs > 0);
 
     /// <summary>
     /// The configuration is just its instance counts, so name it after them. Bots have to appear
@@ -102,6 +140,14 @@ public static class NebulaPlayConfigStore
                     BotCount = botCount,
                     BotBehavior = file.GetValue(section, "bot_behavior", "").AsString(),
                     BotsHeadless = file.GetValue(section, "bots_headless", true).AsBool(),
+                    // Absent in older files, which simply means "no impairment".
+                    SimLatencyMs = file.GetValue(section, "sim_latency_ms", 0).AsInt32(),
+                    SimJitterMs = file.GetValue(section, "sim_jitter_ms", 0).AsInt32(),
+                    SimLossPct = file.GetValue(section, "sim_loss_pct", 0).AsInt32(),
+                    SimBurstLossPct = file.GetValue(section, "sim_burst_loss_pct", 0).AsInt32(),
+                    SimBurstEverySec = file.GetValue(section, "sim_burst_every_sec", 10).AsInt32(),
+                    SimBurstMs = file.GetValue(section, "sim_burst_ms", 0).AsInt32(),
+                    ImpairFirstClientOnly = file.GetValue(section, "impair_first_client_only", true).AsBool(),
                 });
             }
         }
@@ -137,6 +183,13 @@ public static class NebulaPlayConfigStore
             file.SetValue(section, "bot_count", config.BotCount);
             file.SetValue(section, "bot_behavior", config.BotBehavior);
             file.SetValue(section, "bots_headless", config.BotsHeadless);
+            file.SetValue(section, "sim_latency_ms", config.SimLatencyMs);
+            file.SetValue(section, "sim_jitter_ms", config.SimJitterMs);
+            file.SetValue(section, "sim_loss_pct", config.SimLossPct);
+            file.SetValue(section, "sim_burst_loss_pct", config.SimBurstLossPct);
+            file.SetValue(section, "sim_burst_every_sec", config.SimBurstEverySec);
+            file.SetValue(section, "sim_burst_ms", config.SimBurstMs);
+            file.SetValue(section, "impair_first_client_only", config.ImpairFirstClientOnly);
         }
         if (selected.Length > 0)
             file.SetValue(META_SECTION, SELECTED_KEY, selected);

--- a/addons/Nebula/Tools/ProjectSettingsController.cs
+++ b/addons/Nebula/Tools/ProjectSettingsController.cs
@@ -194,6 +194,46 @@ public partial class ProjectSettingsController : Node
             {"hint_string", "0,100,1"},
         });
 
+        // Debug: synthetic network impairment applied to INBOUND packets. These are the editor
+        // defaults; the per-instance switches are the --simLatencyMs / --simJitterMs / --simLossPct
+        // command-line args (see Diagnostics/NetworkImpairment.cs), because a project setting is
+        // process-global and would impair every client the Play tab spawns identically. The point of
+        // the feature is one bad client beside a healthy one.
+        Register("Nebula/config/debug/sim_latency_ms", 0, new(){
+            {"type", (int)Variant.Type.Int},
+            {"hint", (int)PropertyHint.Range},
+            {"hint_string", "0,1000,1"},
+        });
+        Register("Nebula/config/debug/sim_jitter_ms", 0, new(){
+            {"type", (int)Variant.Type.Int},
+            {"hint", (int)PropertyHint.Range},
+            {"hint_string", "0,500,1"},
+        });
+        Register("Nebula/config/debug/sim_loss_pct", 0, new(){
+            {"type", (int)Variant.Type.Int},
+            {"hint", (int)PropertyHint.Range},
+            {"hint_string", "0,100,1"},
+        });
+
+        // Debug: BURSTY loss. Independent per-packet loss is the friendly case -- real links drop
+        // RUNS of consecutive packets (handover, congestion, interference), and a run is what actually
+        // empties an interpolation buffer. Set burst_loss_pct to 100 for a full dropout.
+        Register("Nebula/config/debug/sim_burst_loss_pct", 0, new(){
+            {"type", (int)Variant.Type.Int},
+            {"hint", (int)PropertyHint.Range},
+            {"hint_string", "0,100,1"},
+        });
+        Register("Nebula/config/debug/sim_burst_every_sec", 10, new(){
+            {"type", (int)Variant.Type.Int},
+            {"hint", (int)PropertyHint.Range},
+            {"hint_string", "1,120,1"},
+        });
+        Register("Nebula/config/debug/sim_burst_ms", 0, new(){
+            {"type", (int)Variant.Type.Int},
+            {"hint", (int)PropertyHint.Range},
+            {"hint_string", "0,5000,10"},
+        });
+
         // ── Pack ─────────────────────────────────────────────────────────
         // NebulaPack: delta-compress tick payloads against a baseline the peer has acknowledged.
         // Server-side and per-packet - every packet says whether it is a delta or raw - so clients


### PR DESCRIPTION
- Replace the derived render tick with a free-running clock pulled toward the simulated tick by a small capped rate adjustment, sampled once per tick arrival.
- Size the interpolation buffer from tick arrival gaps instead of per-entity snapshot underruns, with a 2-tick floor and a runtime-adjustable delay.
- Clamp the Hermite extrapolation window to 1.5 ticks and floor (not cap) the owned-entity carry-over.
- Add NetworkImpairment: per-process synthetic latency, jitter, uniform and burst loss on inbound and outbound packets, configurable via command line, env vars, and project settings, plus Play tab fields to impair only the first client.
- Add PayloadCensus (NEBULA_CENSUS) for per-property byte accounting of the tick payload, and emit ServerMetrics to stdout for headless soaks.
- Share node reference serialization across NetNode/2D/3D, gate it on an ACKed spawn, and send node references on change instead of every tick.
- Add render clock, interpolation delay, impairment, and impaired soak tests.